### PR TITLE
Add View Repository menu item in dependency view

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
         "command": "swift.openInWorkspace",
         "title": "Add to Workspace",
         "category": "Swift"
+      },
+      {
+        "command": "swift.openExternal",
+        "title": "View Repository",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -154,6 +159,10 @@
         {
           "command": "swift.resetPackage",
           "when": "swift.hasPackage"
+        },
+        {
+          "command": "swift.openExternal",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -189,6 +198,10 @@
         {
           "command": "swift.openInWorkspace",
           "when": "view == packageDependencies && viewItem == local"
+        },
+        {
+          "command": "swift.openExternal",
+          "when": "view == packageDependencies && viewItem == remote"
         }
       ]
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -343,7 +343,6 @@ async function uneditFolderDependency(
 /**
  * Open local package in workspace
  * @param packageNode PackageNode attached to dependency tree item
- * @param ctx workspace context
  */
 async function openInWorkspace(packageNode: PackageNode) {
     const index = vscode.workspace.workspaceFolders?.length ?? 0;
@@ -351,6 +350,19 @@ async function openInWorkspace(packageNode: PackageNode) {
         uri: vscode.Uri.file(packageNode.path),
         name: packageNode.name,
     });
+}
+
+/**
+ *
+ * @param packageNode PackageNode attached to dependency tree item
+ */
+function openInExternalEditor(packageNode: PackageNode) {
+    try {
+        const uri = vscode.Uri.parse(packageNode.path, true);
+        vscode.env.openExternal(uri);
+    } catch {
+        // ignore error
+    }
 }
 
 /**
@@ -388,6 +400,11 @@ export function register(ctx: WorkspaceContext) {
         vscode.commands.registerCommand("swift.openInWorkspace", item => {
             if (item instanceof PackageNode) {
                 openInWorkspace(item);
+            }
+        }),
+        vscode.commands.registerCommand("swift.openExternal", item => {
+            if (item instanceof PackageNode) {
+                openInExternalEditor(item);
             }
         })
     );


### PR DESCRIPTION
Adds a new entry 'View Repository' to the right click menu in the dependency view that opens the git repository in your webbrowser.