### PR TITLE
Fixes for task completion

### DIFF
--- a/src/TaskManager.ts
+++ b/src/TaskManager.ts
@@ -57,12 +57,12 @@ export class TaskManager implements vscode.Disposable {
         task: vscode.Task,
         token?: vscode.CancellationToken
     ): Promise<number | undefined> {
+        // set id on definition to catch this task when completing
+        task.definition.id = this.taskId;
+        this.taskId += 1;
         return new Promise<number | undefined>(resolve => {
             const disposable = this.onDidEndTaskProcess(event => {
-                if (
-                    event.execution.task.definition === task.definition ||
-                    event.execution.task.scope === task.scope
-                ) {
+                if (event.execution.task.definition.id === task.definition.id) {
                     disposable.dispose();
                     resolve(event.exitCode);
                 }
@@ -89,6 +89,7 @@ export class TaskManager implements vscode.Disposable {
     private observers: Set<TaskObserver> = new Set();
     private onDidEndTaskProcessDisposible: vscode.Disposable;
     private onDidEndTaskDisposible: vscode.Disposable;
+    private taskId = 0;
 }
 
 /** Workspace Folder observer function */

--- a/src/TaskQueue.ts
+++ b/src/TaskQueue.ts
@@ -36,7 +36,10 @@ class QueuedOperation implements SwiftOperation {
         if (args1.length !== args2.length) {
             return false;
         }
-        return args1.every((value, index) => value === args2[index]);
+        return (
+            args1.every((value, index) => value === args2[index]) &&
+            operation.task.scope === this.task.scope
+        );
     }
 }
 


### PR DESCRIPTION
Task definitions needs to be unique. If two task have same definition but different scopes task execution code gets confused. So these changes ensure the full path cwd is set in the definition