### PR TITLE
Experimental: Remove hard CodeLLDB dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,6 +328,12 @@
             "description": "The path of the SDK to compile against (`--sdk` parameter). The default SDK is determined by the environment on macOS and Windows.",
             "order": 3
           },
+          "swift.skipCodeLLDBCheck": {
+            "type": "boolean",
+            "default": false,
+            "description": "Skip check for CodeLLDB being installed.",
+            "order": 4
+          },
           "swift.diagnostics": {
             "type": "boolean",
             "default": false,

--- a/package.json
+++ b/package.json
@@ -567,9 +567,6 @@
       ]
     }
   },
-  "extensionDependencies": [
-    "vadimcn.vscode-lldb"
-  ],
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node16",

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -23,7 +23,7 @@ import {
     swiftLibraryPathKey,
     getErrorDescription,
 } from "./utilities/utilities";
-import { getLLDBLibPath } from "./debugger/lldb";
+import { checkLLDBInstalled, getLLDBLibPath } from "./debugger/lldb";
 import { LanguageClientManager } from "./sourcekit-lsp/LanguageClientManager";
 import { TemporaryFolder } from "./utilities/tempFolder";
 import { SwiftToolchain } from "./toolchain/toolchain";
@@ -348,6 +348,22 @@ export class WorkspaceContext implements vscode.Disposable {
     observeFolders(fn: WorkspaceFoldersObserver): vscode.Disposable {
         this.observers.add(fn);
         return { dispose: () => this.observers.delete(fn) };
+    }
+
+    async setupLLDB() {
+        await checkLLDBInstalled().then(
+            async result => {
+                if (result) {
+                    this.setLLDBVersion();
+                }
+            },
+            error => {
+                const errorMessage = `Error: ${getErrorDescription(error)}`;
+                vscode.window.showErrorMessage(
+                    `Failed to setup CodeLLDB for debugging of Swift code. Debugging may produce unexpected results. ${errorMessage}`
+                );
+            }
+        );
     }
 
     /** find LLDB version and setup path in CodeLLDB */

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -350,8 +350,8 @@ export class WorkspaceContext implements vscode.Disposable {
         return { dispose: () => this.observers.delete(fn) };
     }
 
-    async setupLLDB(extContext: vscode.ExtensionContext) {
-        await checkLLDBInstalled(extContext.globalState).then(
+    async setupLLDB() {
+        await checkLLDBInstalled().then(
             async result => {
                 if (result) {
                     this.setLLDBVersion();

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -350,8 +350,8 @@ export class WorkspaceContext implements vscode.Disposable {
         return { dispose: () => this.observers.delete(fn) };
     }
 
-    async setupLLDB() {
-        await checkLLDBInstalled().then(
+    async setupLLDB(extContext: vscode.ExtensionContext) {
+        await checkLLDBInstalled(extContext.globalState).then(
             async result => {
                 if (result) {
                     this.setLLDBVersion();

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -141,6 +141,10 @@ const configuration = {
             .get<boolean>("backgroundCompilation", false);
     },
     /** output additional diagnostics */
+    get skipCodeLLDBCheck(): boolean {
+        return vscode.workspace.getConfiguration("swift").get<boolean>("skipCodeLLDBCheck", false);
+    },
+    /** output additional diagnostics */
     get diagnostics(): boolean {
         return vscode.workspace.getConfiguration("swift").get<boolean>("diagnostics", false);
     },

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -15,11 +15,59 @@
 // Based on code taken from CodeLLDB https://github.com/vadimcn/vscode-lldb/
 // LICENSED with MIT License
 
+import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs/promises";
 import { execFile } from "../utilities/utilities";
 import { Result } from "../utilities/result";
 import { SwiftToolchain } from "../toolchain/toolchain";
+
+/**
+ * Check if CodeLLDB extension is installed and offer to install it if it is not.
+ * @returns Whether extension was installed
+ */
+export async function checkLLDBInstalled(): Promise<boolean> {
+    const lldbExtension = vscode.extensions.getExtension("vadimcn.vscode-lldb");
+    // if extension is in list return true
+    if (lldbExtension) {
+        return true;
+    }
+
+    // otherwise display menu asking if user wants to install it
+    return new Promise<boolean>((resolve, reject) => {
+        vscode.window
+            .showWarningMessage(
+                "The Swift extension requires the CodeLLDB extension to enable debugging. Do you want to install it?",
+                "Yes",
+                "No"
+            )
+            .then(async result => {
+                switch (result) {
+                    case "Yes":
+                        try {
+                            await installCodeLLDB();
+                            return resolve(true);
+                        } catch (error) {
+                            return reject(error);
+                        }
+                        break;
+                    case "No":
+                        break;
+                }
+                return resolve(false);
+            });
+    });
+}
+
+/**
+ * Install CodeLLDB extension
+ */
+async function installCodeLLDB() {
+    await vscode.commands.executeCommand(
+        "workbench.extensions.installExtension",
+        "vadimcn.vscode-lldb"
+    );
+}
 
 /**
  * Get LLDB library for given LLDB executable

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -21,21 +21,20 @@ import * as fs from "fs/promises";
 import { execFile } from "../utilities/utilities";
 import { Result } from "../utilities/result";
 import { SwiftToolchain } from "../toolchain/toolchain";
+import configuration from "../configuration";
 
 /**
  * Check if CodeLLDB extension is installed and offer to install it if it is not.
  * @returns Whether extension was installed
  */
-export async function checkLLDBInstalled(workspaceState: vscode.Memento): Promise<boolean> {
+export async function checkLLDBInstalled(): Promise<boolean> {
     const lldbExtension = vscode.extensions.getExtension("vadimcn.vscode-lldb");
     // if extension is in list return true
     if (lldbExtension) {
-        // reset skip check flag
-        workspaceState.update("skip-check-lldb", false);
         return true;
     }
     // if workspace is set to ignore LLDB check then return
-    if (workspaceState.get("skip-check-lldb") === true) {
+    if (configuration.skipCodeLLDBCheck === true) {
         return false;
     }
     // otherwise display menu asking if user wants to install it
@@ -47,22 +46,17 @@ export async function checkLLDBInstalled(workspaceState: vscode.Memento): Promis
                     modal: true,
                     detail: "The Swift extension requires it to enable debugging.",
                 },
-                "Yes",
-                "Never"
+                "Install"
             )
             .then(async result => {
                 switch (result) {
-                    case "Yes":
+                    case "Install":
                         try {
                             await installCodeLLDB();
                             return resolve(true);
                         } catch (error) {
                             return reject(error);
                         }
-                        break;
-                    case "Never":
-                        workspaceState.update("skip-check-lldb", true);
-                        break;
                     case undefined:
                         break;
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         context.subscriptions.push(workspaceContext);
 
         // setup swift version of LLDB. Don't await on this as it can run in the background
-        workspaceContext.setupLLDB();
+        workspaceContext.setupLLDB(context);
 
         // listen for workspace folder changes and active text editor changes
         workspaceContext.setupEventListeners();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         context.subscriptions.push(workspaceContext);
 
         // setup swift version of LLDB. Don't await on this as it can run in the background
-        workspaceContext.setLLDBVersion();
+        workspaceContext.setupLLDB();
 
         // listen for workspace folder changes and active text editor changes
         workspaceContext.setupEventListeners();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         context.subscriptions.push(workspaceContext);
 
         // setup swift version of LLDB. Don't await on this as it can run in the background
-        workspaceContext.setupLLDB(context);
+        workspaceContext.setupLLDB();
 
         // listen for workspace folder changes and active text editor changes
         workspaceContext.setupEventListeners();

--- a/test/runTest.ts
+++ b/test/runTest.ts
@@ -12,13 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as cp from "child_process";
 import * as path from "path";
-import {
-    runTests,
-    downloadAndUnzipVSCode,
-    resolveCliPathFromVSCodeExecutablePath,
-} from "@vscode/test-electron";
+import { runTests } from "@vscode/test-electron";
 
 async function main() {
     try {
@@ -29,22 +24,6 @@ async function main() {
         // The path to test runner
         // Passed to --extensionTestsPath
         const extensionTestsPath = path.resolve(__dirname, "./suite/index");
-
-        const vscodeExecutablePath = await downloadAndUnzipVSCode();
-        const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
-
-        // Use cp.spawn / cp.exec for custom setup
-        console.log(`${cliPath} --install-extension vadimcn.vscode-lldb`);
-        const { stdout, stderr } = cp.spawnSync(
-            cliPath,
-            ["--install-extension", "vadimcn.vscode-lldb"],
-            {
-                encoding: "utf-8",
-                stdio: "inherit",
-            }
-        );
-        console.log(stdout);
-        console.log(stderr);
 
         // Download VS Code, unzip it and run the integration test
         await runTests({


### PR DESCRIPTION
Add a dialog that is displayed if the CodeLLDB dependency is not available. You can install the dependency from this dialog, set it to never appear again or just ignore it. This actually works out quite nicely.

Problems occur if you have the dependency installed but disabled. It cannot recognise this. Also if you go into a devcontainer without CodeLLDB but have it installed locally you cannot install it into the devcontainer. You need the user to go do it manually. Not too much of a problem if I could recognise you were in a container.