### PR TITLE
Add client-side support for macro expansions

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,11 @@
         "category": "Swift"
       },
       {
+        "command": "swift.expandMacro",
+        "title": "Expand Macro",
+        "category": "Swift"
+      },
+      {
         "command": "swift.showTestCoverageReport",
         "title": "Show Test Coverage Report",
         "category": "Swift"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,7 +27,7 @@ import { DarwinCompatibleTarget, SwiftToolchain } from "./toolchain/toolchain";
 import { debugSnippet, runSnippet } from "./SwiftSnippets";
 import { debugLaunchConfig, getLaunchConfiguration } from "./debugger/launch";
 import { execFile } from "./utilities/utilities";
-import { macroExpansionRequest } from "./sourcekit-lsp/lspExtensions";
+import { MacroExpansionParams, macroExpansionRequest } from "./sourcekit-lsp/lspExtensions";
 
 /**
  * References:
@@ -481,14 +481,14 @@ function insertFunctionComment(workspaceContext: WorkspaceContext) {
 function expandMacro(workspaceContext: WorkspaceContext) {
     const activeEditor = vscode.window.activeTextEditor;
     const document = activeEditor?.document;
-    const position = activeEditor?.selection.active;
-    if (!document || !position) {
+    const selection = activeEditor?.selection;
+    if (!document || !selection) {
         return;
     }
     return workspaceContext.languageClientManager.useLanguageClient(async (client, token) => {
-        const params = {
+        const params: MacroExpansionParams = {
             textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
-            position: client.code2ProtocolConverter.asPosition(position),
+            range: client.code2ProtocolConverter.asRange(selection),
         };
         const result = await client.sendRequest(macroExpansionRequest, params, token);
         const sourceText = result?.sourceText;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -503,7 +503,7 @@ function expandMacro(workspaceContext: WorkspaceContext) {
             });
             workspaceContext.subscriptions.push(provider);
             const location = new vscode.Location(
-                vscode.Uri.from({ scheme }),
+                vscode.Uri.from({ scheme, path: "Macro Expansion.swift" }),
                 new vscode.Position(0, 0)
             );
             await vscode.commands.executeCommand(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -495,7 +495,7 @@ function expandMacro(workspaceContext: WorkspaceContext) {
             // Present the macro expansion using a custom in-memory URI scheme
             // TODO: This will currently reregister the provider for this scheme
             // every time a new macro expansion is requested. It looks like the
-            // old expansions will be kept open correctly, but perhaps there's
+            // old expansions will be closed correctly, but perhaps there's
             // a more elegant solution to this?
             const scheme = "swift-macro-expansion";
             const provider = vscode.workspace.registerTextDocumentContentProvider(scheme, {

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -68,9 +68,9 @@ export interface MacroExpansionParams {
     textDocument: langclient.TextDocumentIdentifier;
 
     /**
-     * The position within the code at which the macro is used.
+     * The range within the code at which the macro is used.
      */
-    position: langclient.Position;
+    range: langclient.Range;
 }
 
 export interface MacroExpansion {

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -87,6 +87,6 @@ export interface MacroExpansion {
 
 export const macroExpansionRequest = new langclient.RequestType<
     MacroExpansionParams,
-    MacroExpansion | null,
+    MacroExpansion[],
     unknown
 >("sourcekit-lsp/macroExpansion");

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -75,6 +75,11 @@ export interface MacroExpansionParams {
 
 export interface MacroExpansion {
     /**
+     * The position in the source file where the expansion would be inserted.
+     */
+    position: langclient.Position;
+
+    /**
      * The source text of the expansion.
      */
     sourceText: string;

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -60,3 +60,28 @@ export const legacyInlayHintsRequest = new langclient.RequestType<
     LegacyInlayHint[],
     unknown
 >("sourcekit-lsp/inlayHints");
+
+export interface MacroExpansionParams {
+    /**
+     * The text document.
+     */
+    textDocument: langclient.TextDocumentIdentifier;
+
+    /**
+     * The position within the code at which the macro is used.
+     */
+    position: langclient.Position;
+}
+
+export interface MacroExpansion {
+    /**
+     * The source text of the expansion.
+     */
+    sourceText: string;
+}
+
+export const macroExpansionRequest = new langclient.RequestType<
+    MacroExpansionParams,
+    MacroExpansion | null,
+    unknown
+>("sourcekit-lsp/macroExpansion");


### PR DESCRIPTION
This implements basic client-side support for the `sourcekit-lsp/macroExpansion` request introduced in

- https://github.com/apple/sourcekit-lsp/pull/892

The expansion is presented using an in-memory text document in a peeked editor:

<img width="532" alt="image" src="https://github.com/swift-server/vscode-swift/assets/30873659/629609c9-b451-459e-99e1-d29c2286e8e4">

### To do

- [x] Declare the request (`sourcekit-lsp/macroExpansion`)
- [x] Add a VSCode command for performing the request (`swift.expandMacro`)
- [x] Find a better presentation style than dumping the expansion into an info message popup