### PR TITLE
Add Swift: Capture VSCode Swift Diagnostic Logs command

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
       },
       {
         "command": "swift.captureDiagnostics",
-        "title": "Capture VSCode Swift Diagnostic Logs",
+        "title": "Capture VS Code Swift Diagnostic Logs",
         "category": "Swift"
       },
       {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
       },
       {
         "command": "swift.captureDiagnostics",
-        "title": "Capture VS Code Swift Diagnostic Logs",
+        "title": "Capture VS Code Swift Diagnostic Bundle",
         "category": "Swift"
       },
       {

--- a/package.json
+++ b/package.json
@@ -171,6 +171,11 @@
         "category": "Swift"
       },
       {
+        "command": "swift.captureDiagnostics",
+        "title": "Capture VSCode Swift Diagnostic Logs",
+        "category": "Swift"
+      },
+      {
         "command": "swift.clearDiagnosticsCollection",
         "title": "Clear Diagnostics Collection",
         "category": "Swift"

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -555,11 +555,6 @@ export class TestRunner {
     ) {
         return new Promise<void>((resolve, reject) => {
             const args = testBuildConfig.args ?? [];
-            this.folderContext?.workspaceContext.outputChannel.logDiagnostic(
-                `Exec: ${testBuildConfig.program} ${args.join(" ")}`,
-                this.folderContext.name
-            );
-
             let kindLabel: string;
             switch (testKind) {
                 case TestKind.coverage:

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -31,6 +31,7 @@ import { execFile } from "./utilities/utilities";
 import { SwiftExecOperation, TaskOperation } from "./tasks/TaskQueue";
 import { SwiftProjectTemplate } from "./toolchain/toolchain";
 import { showToolchainSelectionQuickPick, showToolchainError } from "./ui/ToolchainSelection";
+import { captureDiagnostics } from "./commands/captureDiagnostics";
 
 /**
  * References:
@@ -848,5 +849,6 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         vscode.commands.registerCommand("swift.clearDiagnosticsCollection", () =>
             ctx.diagnostics.clear()
         ),
+        vscode.commands.registerCommand("swift.captureDiagnostics", () => captureDiagnostics(ctx)),
     ];
 }

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -166,9 +166,9 @@ async function sourcekitDiagnose(ctx: WorkspaceContext, dir: string) {
             location: vscode.ProgressLocation.Notification,
         },
         async progress => {
-            progress.report({ message: "Generating Diagnostic Bundle..." });
+            progress.report({ message: "Diagnosing SourceKit-LSP..." });
             const writableStream = progressUpdatingWritable(percent =>
-                progress.report({ message: `Generating Diagnostic Bundle: ${percent}%` })
+                progress.report({ message: `Diagnosing SourceKit-LSP: ${percent}%` })
             );
 
             await execFileStreamOutput(

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -26,17 +26,20 @@ export async function captureDiagnostics(ctx: WorkspaceContext) {
         `vscode-diagnostics-${formatDateString(new Date())}`
     );
 
-    const versionOutputChannel = new SwiftOutputChannel();
-    ctx.toolchain.logDiagnostics(versionOutputChannel);
+    const environmentOutputChannel = new SwiftOutputChannel();
+    ctx.toolchain.logDiagnostics(environmentOutputChannel);
+    environmentOutputChannel.log(
+        JSON.stringify(vscode.workspace.getConfiguration("swift"), null, 2)
+    );
 
     const logs = ctx.outputChannel.logs.join("\n");
-    const versionLogs = versionOutputChannel.logs.join("\n");
+    const environmentLogs = environmentOutputChannel.logs.join("\n");
     const diagnosticLogs = buildDiagnostics();
 
     try {
         await fs.mkdir(diagnosticsDir);
         await fs.writeFile(path.join(diagnosticsDir, "logs.txt"), logs);
-        await fs.writeFile(path.join(diagnosticsDir, "version.txt"), versionLogs);
+        await fs.writeFile(path.join(diagnosticsDir, "environment.txt"), environmentLogs);
         await fs.writeFile(path.join(diagnosticsDir, "diagnostics.txt"), diagnosticLogs);
 
         ctx.outputChannel.log(`Saved diagnostics to ${diagnosticsDir}`);
@@ -113,11 +116,9 @@ function severityToString(severity: vscode.DiagnosticSeverity): string {
     }
 }
 
-function padZero(num: number, length: number = 2): string {
-    return num.toString().padStart(length, "0");
-}
-
 function formatDateString(date: Date): string {
+    const padZero = (num: number, length: number = 2) => num.toString().padStart(length, "0");
+
     const year = date.getFullYear();
     const month = padZero(date.getMonth() + 1);
     const day = padZero(date.getDate());

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -1,12 +1,12 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the VSCode Swift open source project
+// This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Copyright (c) 2021-2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
-// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -39,7 +39,7 @@ export async function captureDiagnostics(ctx: WorkspaceContext) {
 
         await fs.mkdir(diagnosticsDir);
         await writeLogFile(diagnosticsDir, "extension-logs.txt", extensionLogs(ctx));
-        await writeLogFile(diagnosticsDir, "environment-logs.txt", environmentLogs(ctx));
+        await writeLogFile(diagnosticsDir, "settings.txt", settingsLogs(ctx));
         await writeLogFile(diagnosticsDir, "diagnostics.txt", diagnosticLogs());
 
         if (captureMode === "Full") {
@@ -130,8 +130,9 @@ function extensionLogs(ctx: WorkspaceContext): string {
     return ctx.outputChannel.logs.join("\n");
 }
 
-function environmentLogs(ctx: WorkspaceContext): string {
-    return ctx.toolchain.diagnostics;
+function settingsLogs(ctx: WorkspaceContext): string {
+    const settings = JSON.stringify(vscode.workspace.getConfiguration("swift"), null, 2);
+    return `${ctx.toolchain.diagnostics}\nSettings:\n${settings}`;
 }
 
 function diagnosticLogs(): string {

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -43,9 +43,10 @@ export async function captureDiagnostics(
         await fs.mkdir(diagnosticsDir);
         await writeLogFile(diagnosticsDir, "extension-logs.txt", extensionLogs(ctx));
         await writeLogFile(diagnosticsDir, "settings.txt", settingsLogs(ctx));
-        await writeLogFile(diagnosticsDir, "source-code-diagnostics.txt", diagnosticLogs());
 
         if (captureMode === "Full") {
+            await writeLogFile(diagnosticsDir, "source-code-diagnostics.txt", diagnosticLogs());
+
             // The `sourcekit-lsp diagnose` command is only available in 6.0 and higher.
             if (ctx.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))) {
                 await sourcekitDiagnose(ctx, diagnosticsDir);

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -43,7 +43,7 @@ export async function captureDiagnostics(
         await fs.mkdir(diagnosticsDir);
         await writeLogFile(diagnosticsDir, "extension-logs.txt", extensionLogs(ctx));
         await writeLogFile(diagnosticsDir, "settings.txt", settingsLogs(ctx));
-        await writeLogFile(diagnosticsDir, "diagnostics.txt", diagnosticLogs());
+        await writeLogFile(diagnosticsDir, "source-code-diagnostics.txt", diagnosticLogs());
 
         if (captureMode === "Full") {
             // The `sourcekit-lsp diagnose` command is only available in 6.0 and higher.
@@ -90,7 +90,7 @@ async function captureDiagnosticsMode(
         const minimalButton = "Capture Minimal Diagnostics";
         const buttons = allowMinimalCapture ? [fullButton, minimalButton] : [fullButton];
         const fullCaptureResult = await vscode.window.showInformationMessage(
-            `A Diagnostic Bundle collects information that helps the developers of the VS Code Swift extension diagnose and fix issues.
+            `A Diagnostic Bundle collects information that helps the developers of the Swift for VS Code extension diagnose and fix issues.
 
 This information contains:
 - Extension logs
@@ -100,7 +100,9 @@ This information contains:
 - If possible, a minimized project that caused SourceKit to crash
 - If possible, a minimized project that caused the Swift compiler to crash
 
-Please attach this bundle to GitHub issues.`,
+All information is collected locally and you can inspect the diagnose bundle before sharing it with developers of the Swift for VS Code extension.
+
+Please file an issue with a description of the problem you are seeing at https://github.com/swiftlang/vscode-swift, and attach this diagnose bundle.`,
             {
                 modal: true,
                 detail: allowMinimalCapture

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VSCode Swift open source project
+//
+// Copyright (c) 2021-2024 the VSCode Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VSCode Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as vscode from "vscode";
+import { tmpdir } from "os";
+import { exec } from "child_process";
+import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
+import { WorkspaceContext } from "../WorkspaceContext";
+
+export async function captureDiagnostics(ctx: WorkspaceContext) {
+    const diagnosticsDir = path.join(
+        tmpdir(),
+        `vscode-diagnostics-${formatDateString(new Date())}`
+    );
+
+    const versionOutputChannel = new SwiftOutputChannel();
+    ctx.toolchain.logDiagnostics(versionOutputChannel);
+
+    const logs = ctx.outputChannel.logs.join("\n");
+    const versionLogs = versionOutputChannel.logs.join("\n");
+    const diagnosticLogs = buildDiagnostics();
+
+    try {
+        await fs.mkdir(diagnosticsDir);
+        await fs.writeFile(path.join(diagnosticsDir, "logs.txt"), logs);
+        await fs.writeFile(path.join(diagnosticsDir, "version.txt"), versionLogs);
+        await fs.writeFile(path.join(diagnosticsDir, "diagnostics.txt"), diagnosticLogs);
+
+        ctx.outputChannel.log(`Saved diagnostics to ${diagnosticsDir}`);
+
+        const showInFinderButton = "Show In Finder";
+        const copyPath = "Copy Path to Clipboard";
+        const infoDialogButtons = [
+            ...(process.platform === "darwin" ? [showInFinderButton] : []),
+            copyPath,
+        ];
+        const result = await vscode.window.showInformationMessage(
+            `Saved diagnostic logs to ${diagnosticsDir}`,
+            ...infoDialogButtons
+        );
+        if (result === copyPath) {
+            vscode.env.clipboard.writeText(diagnosticsDir);
+        } else if (result === showInFinderButton) {
+            exec(`open ${diagnosticsDir}`, error => {
+                if (error) {
+                    vscode.window.showErrorMessage(`Failed to open Finder: ${error.message}`);
+                    return;
+                }
+            });
+        }
+    } catch (error) {
+        vscode.window.showErrorMessage(`Unable to captrure diagnostics logs: ${error}`);
+    }
+}
+
+function buildDiagnostics(): string {
+    const diagnosticToString = (diagnostic: vscode.Diagnostic) => {
+        return `${severityToString(diagnostic.severity)} - ${diagnostic.message} [Ln ${diagnostic.range.start.line}, Col ${diagnostic.range.start.character}]`;
+    };
+
+    return vscode.languages
+        .getDiagnostics()
+        .map(
+            ([uri, diagnostics]) => `${uri}\n\t${diagnostics.map(diagnosticToString).join("\n\t")}`
+        )
+        .join("\n");
+}
+
+function severityToString(severity: vscode.DiagnosticSeverity): string {
+    switch (severity) {
+        case vscode.DiagnosticSeverity.Error:
+            return "Error";
+        case vscode.DiagnosticSeverity.Warning:
+            return "Warning";
+        case vscode.DiagnosticSeverity.Information:
+            return "Information";
+        case vscode.DiagnosticSeverity.Hint:
+            return "Hint";
+    }
+}
+
+function padZero(num: number, length: number = 2): string {
+    return num.toString().padStart(length, "0");
+}
+
+function formatDateString(date: Date): string {
+    const year = date.getFullYear();
+    const month = padZero(date.getMonth() + 1);
+    const day = padZero(date.getDate());
+    const hours = padZero(date.getHours());
+    const minutes = padZero(date.getMinutes());
+    const seconds = padZero(date.getSeconds());
+    const timezoneOffset = -date.getTimezoneOffset();
+    const timezoneSign = timezoneOffset >= 0 ? "+" : "-";
+    const timezoneHours = padZero(Math.floor(Math.abs(timezoneOffset) / 60));
+    const timezoneMinutes = padZero(Math.abs(timezoneOffset) % 60);
+    return `${year}-${month}-${day}T${hours}-${minutes}-${seconds}${timezoneSign}${timezoneHours}-${timezoneMinutes}`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export interface Api {
 export async function activate(context: vscode.ExtensionContext): Promise<Api | undefined> {
     try {
         console.debug("Activating Swift for Visual Studio Code...");
-        const outputChannel = new SwiftOutputChannel();
+        const outputChannel = new SwiftOutputChannel("Swift");
 
         checkAndWarnAboutWindowsSymlinks(outputChannel);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api | 
 
         const toolchain: SwiftToolchain | undefined = await SwiftToolchain.create()
             .then(toolchain => {
-                outputChannel.log(toolchain.swiftVersionString);
                 toolchain.logDiagnostics(outputChannel);
                 contextKeys.createNewProjectAvailable = toolchain.swiftVersion.isGreaterThanOrEqual(
                     new Version(5, 8, 0)

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -486,7 +486,7 @@ export class LanguageClientManager {
             documentSelector: LanguageClientManager.documentSelector,
             revealOutputChannelOn: langclient.RevealOutputChannelOn.Never,
             workspaceFolder: workspaceFolder,
-            outputChannel: new SwiftOutputChannel("SourceKit Language Server"),
+            outputChannel: new SwiftOutputChannel("SourceKit Language Server", false),
             middleware: {
                 provideDocumentSymbols: async (document, token, next) => {
                     const result = await next(document, token);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -541,12 +541,17 @@ export class LanguageClientManager {
                     );
                 },
                 handleWorkDoneProgress: (() => {
-                    let hasPrompted = false;
+                    let lastPrompted = new Date(0).getTime();
                     return async (token, params, next) => {
                         const result = await next(token, params);
-                        if (!hasPrompted && token.toString().startsWith("sourcekitd-crashed")) {
-                            // Only prompt once in case sourcekit is in a crash loop
-                            hasPrompted = true;
+                        const now = new Date().getTime();
+                        const oneHour = 60 * 60 * 1000;
+                        if (
+                            now - lastPrompted > oneHour &&
+                            token.toString().startsWith("sourcekitd-crashed")
+                        ) {
+                            // Only prompt once an hour in case sourcekit is in a crash loop
+                            lastPrompted = now;
                             promptForDiagnostics(this.workspaceContext);
                         }
                         return result;

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -403,25 +403,31 @@ export class SwiftToolchain {
         return path.join(base, "Library/Frameworks");
     }
 
-    logDiagnostics(channel: SwiftOutputChannel) {
-        channel.logDiagnostic(this.swiftVersionString);
-        channel.logDiagnostic(`Swift Path: ${this.swiftFolderPath}`);
-        channel.logDiagnostic(`Toolchain Path: ${this.toolchainPath}`);
+    get diagnostics(): string {
+        let str = "";
+        str += this.swiftVersionString;
+        str += `\nSwift Path: ${this.swiftFolderPath}`;
+        str += `\nToolchain Path: ${this.toolchainPath}`;
         if (this.runtimePath) {
-            channel.logDiagnostic(`Runtime Library Path: ${this.runtimePath}`);
+            str += `\nRuntime Library Path: ${this.runtimePath}`;
         }
         if (this.defaultTarget) {
-            channel.logDiagnostic(`Default Target: ${this.defaultTarget}`);
+            str += `\nDefault Target: ${this.defaultTarget}`;
         }
         if (this.defaultSDK) {
-            channel.logDiagnostic(`Default SDK: ${this.defaultSDK}`);
+            str += `\nDefault SDK: ${this.defaultSDK}`;
         }
         if (this.customSDK) {
-            channel.logDiagnostic(`Custom SDK: ${this.customSDK}`);
+            str += `\nCustom SDK: ${this.customSDK}`;
         }
         if (this.xcTestPath) {
-            channel.logDiagnostic(`XCTest Path: ${this.xcTestPath}`);
+            str += `\nXCTest Path: ${this.xcTestPath}`;
         }
+        return str;
+    }
+
+    logDiagnostics(channel: SwiftOutputChannel) {
+        channel.logDiagnostic(this.diagnostics);
     }
 
     private static async getSwiftFolderPath(): Promise<string> {

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -404,6 +404,7 @@ export class SwiftToolchain {
     }
 
     logDiagnostics(channel: SwiftOutputChannel) {
+        channel.logDiagnostic(this.swiftVersionString);
         channel.logDiagnostic(`Swift Path: ${this.swiftFolderPath}`);
         channel.logDiagnostic(`Toolchain Path: ${this.toolchainPath}`);
         if (this.runtimePath) {

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -18,6 +18,7 @@ import configuration from "../configuration";
 export class SwiftOutputChannel implements vscode.OutputChannel {
     private channel: vscode.OutputChannel;
     private logStore = new RollingLog(1024 * 1024 * 5);
+    private logToConsole: boolean;
 
     public name: string;
 
@@ -25,8 +26,9 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
      * Creates a vscode.OutputChannel that allows for later retrival of logs.
      * @param name
      */
-    constructor(name: string) {
+    constructor(name: string, logToConsole: boolean = true) {
         this.name = name;
+        this.logToConsole = process.env["CI"] !== "1" && logToConsole;
         this.channel = vscode.window.createOutputChannel(name);
     }
 
@@ -34,7 +36,7 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
         this.channel.append(value);
         this.logStore.append(value);
 
-        if (process.env["CI"] !== "1") {
+        if (this.logToConsole) {
             console.log(value);
         }
     }
@@ -43,7 +45,7 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
         this.channel.appendLine(value);
         this.logStore.appendLine(value);
 
-        if (process.env["CI"] !== "1") {
+        if (this.logToConsole) {
             console.log(value);
         }
     }

--- a/test/suite/DiagnosticsManager.test.ts
+++ b/test/suite/DiagnosticsManager.test.ts
@@ -82,7 +82,10 @@ suite("DiagnosticsManager Test Suite", async function () {
 
     suiteSetup(async () => {
         toolchain = await SwiftToolchain.create();
-        workspaceContext = await WorkspaceContext.create(new SwiftOutputChannel(), toolchain);
+        workspaceContext = await WorkspaceContext.create(
+            new SwiftOutputChannel("Swift"),
+            toolchain
+        );
         workspaceFolder = testAssetWorkspaceFolder("diagnostics");
         folderContext = await workspaceContext.addPackageFolder(
             workspaceFolder.uri,

--- a/test/suite/ui/SwiftOutputChannel.test.ts
+++ b/test/suite/ui/SwiftOutputChannel.test.ts
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as assert from "assert";
+import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
+
+suite("SwiftOutputChannel", function () {
+    let channel: SwiftOutputChannel;
+    setup(() => {
+        channel = new SwiftOutputChannel("SwiftOutputChannel Tests", false, 3);
+    });
+
+    teardown(() => {
+        channel.dispose();
+    });
+
+    test("Appends logs", () => {
+        channel.append("a");
+        channel.append("b");
+        channel.append("c");
+        assert.deepEqual(channel.logs, ["abc"]);
+    });
+
+    test("Appends lines", () => {
+        channel.appendLine("a");
+        channel.appendLine("b");
+        channel.appendLine("c");
+        assert.deepEqual(channel.logs, ["a", "b", "c"]);
+    });
+
+    test("Appends lines and rolls over", () => {
+        channel.appendLine("a");
+        channel.appendLine("b");
+        channel.appendLine("c");
+        channel.appendLine("d");
+        assert.deepEqual(channel.logs, ["b", "c", "d"]);
+    });
+
+    test("Appends and rolls over", () => {
+        channel.appendLine("a");
+        channel.appendLine("b");
+        channel.appendLine("c");
+        channel.append("d");
+        channel.appendLine("e");
+        assert.deepEqual(channel.logs, ["b", "cd", "e"]);
+    });
+
+    test("Replaces", () => {
+        channel.appendLine("a");
+        channel.appendLine("b");
+        channel.appendLine("c");
+        channel.appendLine("d");
+        channel.replace("e");
+        assert.deepEqual(channel.logs, ["e"]);
+    });
+});


### PR DESCRIPTION
Adds a new command that users can use to help generate bug reports for the extension itself. The Capture VSCode Swift Diagnostic Logs command will create a new folder in a temporary directory that contains:

- Swift version and path information
- Extension logs
- Any diagnostics in the Problems pane

Users can copy the folder path or, if they're on macOS, open it in Finder. From there they can zip and attach these files to a GitHub issue. We'll want to update the New Issue Template with instructions on how to capture and attach these logs.

Fixes #842