### PR TITLE
Remove stale swiftc diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,12 +276,6 @@
             ],
             "order": 9
           },
-          "swift.removeStaleSwiftcDiagnostics": {
-            "type": "boolean",
-            "default": true,
-            "markdownDescription": "Whether to clear old build diagnostics from `swiftc` when `SourceKit` indicates it has been fixed in the editor.",
-            "order": 10
-          },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
             "type": "array",
@@ -292,13 +286,13 @@
               ".git",
               ".github"
             ],
-            "order": 11
+            "order": 10
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 12
+            "order": 11
           },
           "swift.actionAfterBuildError": {
             "type": "string",
@@ -313,25 +307,25 @@
               "Focus on Build Task Terminal"
             ],
             "markdownDescription": "Action after a Build task generates errors.",
-            "order": 13
+            "order": 12
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "order": 14
+            "order": 13
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 15
+            "order": 14
           },
           "swift.showCreateSwiftProjectInWelcomePage": {
             "type": "boolean",
             "default": true,
             "description": "Controls whether or not the create new swift project button appears in the welcome page.",
-            "order": 16
+            "order": 15
           },
           "swift.openAfterCreateNewProject": {
             "type": "string",
@@ -349,7 +343,7 @@
             ],
             "default": "prompt",
             "description": "Controls whether to open a swift project automatically after creating it.",
-            "order": 17
+            "order": 16
           },
           "swift.showBuildStatus": {
             "type": "string",
@@ -367,14 +361,14 @@
               "Show the Swift build status in the \"Progress Message\" status bar item provided by VS Code.",
               "Show the Swift build status as a progress notification."
             ],
-            "order": 18
+            "order": 17
           },
           "swift.warnAboutSymlinkCreation": {
             "type": "boolean",
             "default": true,
             "description": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
             "scope": "application",
-            "order": 19
+            "order": 18
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -169,6 +169,11 @@
         "command": "swift.attachDebugger",
         "title": "Attach to Process...",
         "category": "Swift"
+      },
+      {
+        "command": "swift.clearDiagnosticsCollection",
+        "title": "Clear Diagnostics Collection",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -271,6 +276,12 @@
             ],
             "order": 9
           },
+          "swift.removeStaleSwiftcDiagnostics": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Whether to clear old build diagnostics from `swiftc` when `SourceKit` indicates it has been fixed in the editor.",
+            "order": 10
+          },
           "swift.excludePathsFromPackageDependencies": {
             "description": "A list of paths to exclude from the Package Dependencies view.",
             "type": "array",
@@ -281,13 +292,13 @@
               ".git",
               ".github"
             ],
-            "order": 10
+            "order": 11
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 11
+            "order": 12
           },
           "swift.actionAfterBuildError": {
             "type": "string",
@@ -302,25 +313,25 @@
               "Focus on Build Task Terminal"
             ],
             "markdownDescription": "Action after a Build task generates errors.",
-            "order": 12
+            "order": 13
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "order": 13
+            "order": 14
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 14
+            "order": 15
           },
           "swift.showCreateSwiftProjectInWelcomePage": {
             "type": "boolean",
             "default": true,
             "description": "Controls whether or not the create new swift project button appears in the welcome page.",
-            "order": 15
+            "order": 16
           },
           "swift.openAfterCreateNewProject": {
             "type": "string",
@@ -338,7 +349,7 @@
             ],
             "default": "prompt",
             "description": "Controls whether to open a swift project automatically after creating it.",
-            "order": 16
+            "order": 17
           },
           "swift.showBuildStatus": {
             "type": "string",
@@ -356,14 +367,14 @@
               "Show the Swift build status in the \"Progress Message\" status bar item provided by VS Code.",
               "Show the Swift build status as a progress notification."
             ],
-            "order": 17
+            "order": 18
           },
           "swift.warnAboutSymlinkCreation": {
             "type": "boolean",
             "default": true,
             "description": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
             "scope": "application",
-            "order": 18
+            "order": 19
           }
         }
       },

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -120,7 +120,7 @@ export class DiagnosticsManager implements vscode.Disposable {
             this.isSource(d, sources)
         );
         // Clean up any "fixed" swiftc diagnostics
-        if (configuration.removeStaleSwiftcDiagnostics && isFromSourceKit) {
+        if (isFromSourceKit) {
             this.removeDiagnostics(
                 removedDiagnostics,
                 d1 => !!newDiagnostics.find(d2 => isEqual(d1, d2))

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -25,6 +25,9 @@ interface ParsedDiagnostic {
 
 type DiagnosticsMap = Map<string, vscode.Diagnostic[]>;
 
+const isEqual = (d1: vscode.Diagnostic, d2: vscode.Diagnostic) =>
+    d1.range.start.isEqual(d2.range.start) && d1.message === d2.message;
+
 /**
  * Handles the collection and deduplication of diagnostics from
  * various {@link vscode.Diagnostic.source | Diagnostic sources}.
@@ -40,18 +43,23 @@ export class DiagnosticsManager implements vscode.Disposable {
 
     private diagnosticCollection: vscode.DiagnosticCollection =
         vscode.languages.createDiagnosticCollection("swift");
+    private allDiagnostics: Map<string, vscode.Diagnostic[]> = new Map();
 
     constructor(context: WorkspaceContext) {
         this.onDidChangeConfigurationDisposible = vscode.workspace.onDidChangeConfiguration(e => {
             if (e.affectsConfiguration("swift.diagnosticsCollection")) {
-                if (!this.includeSwiftcDiagnostics()) {
-                    // Clean up "swiftc" diagnostics
-                    this.removeSwiftcDiagnostics();
-                }
-                if (!this.includeSourceKitDiagnostics()) {
-                    // Clean up SourceKit diagnostics
-                    this.removeSourceKitDiagnostics();
-                }
+                // if (!this.includeSwiftcDiagnostics()) {
+                //     // Clean up "swiftc" diagnostics
+                //     this.removeSwiftcDiagnostics();
+                // }
+                // if (!this.includeSourceKitDiagnostics()) {
+                //     // Clean up SourceKit diagnostics
+                //     this.removeSourceKitDiagnostics();
+                // }
+                this.diagnosticCollection.clear();
+                this.allDiagnostics.forEach((_, uri) =>
+                    this.updateDiagnosticsCollection(vscode.Uri.file(uri))
+                );
             }
         });
         this.onDidStartTaskDisposible = vscode.tasks.onDidStartTask(event => {
@@ -92,101 +100,153 @@ export class DiagnosticsManager implements vscode.Disposable {
      * @param uri {@link vscode.Uri Uri} of the file these diagonstics apply to
      * @param sources The source of the diagnostics which will apply for cleaning
      * up diagnostics that have been removed. See {@link swiftc} and {@link sourcekit}
-     * @param diagnostics Array of {@link vscode.Diagnostic}. This can be empty to remove old diagnostics for the specified `sources`.
+     * @param newDiagnostics Array of {@link vscode.Diagnostic}. This can be empty to remove old diagnostics for the specified `sources`.
      */
-    handleDiagnostics(uri: vscode.Uri, sources: string[], diagnostics: vscode.Diagnostic[]): void {
+    handleDiagnostics(
+        uri: vscode.Uri,
+        sources: string[],
+        newDiagnostics: vscode.Diagnostic[]
+    ): void {
+        const isFromSourceKit = !!DiagnosticsManager.sourcekit.find(s => sources.includes(s));
         // Is a descrepency between SourceKit-LSP and older versions
         // of Swift as to whether the first letter is capitalized or not,
         // so we'll always display messages capitalized to user and this
         // also will allow comparing messages when merging
-        diagnostics.forEach(this.capitalizeMessage);
-        const newDiagnostics = this.diagnosticCollection.get(uri)?.slice() || [];
+        newDiagnostics.forEach(this.capitalizeMessage);
+        // const mergedDiagnostics = this.diagnosticCollection.get(uri)?.slice() || [];
+        const allDiagnostics = this.allDiagnostics.get(uri.fsPath)?.slice() || [];
         // Remove the old set of diagnostics from this source
-        this.removeDiagnostics(newDiagnostics, sources);
+        const removedDiagnostics = this.removeDiagnostics(allDiagnostics, d =>
+            this.isSource(d, sources)
+        );
+        // Clean up any "fixed" swiftc diagnostics
+        if (configuration.removeStaleSwiftcDiagnostics && isFromSourceKit) {
+            this.removeDiagnostics(
+                removedDiagnostics,
+                d1 => !!newDiagnostics.find(d2 => isEqual(d1, d2))
+            );
+            this.removeDiagnostics(
+                allDiagnostics,
+                d1 => this.isSwiftc(d1) && !!removedDiagnostics.find(d2 => isEqual(d1, d2))
+            );
+        }
+        // Append the new diagnostics we just received
+        allDiagnostics.push(...newDiagnostics);
+        this.allDiagnostics.set(uri.fsPath, allDiagnostics);
+        // Update the collection
+        this.updateDiagnosticsCollection(uri);
+    }
+
+    private updateDiagnosticsCollection(uri: vscode.Uri): void {
+        const diagnostics = this.allDiagnostics.get(uri.fsPath) ?? [];
+        const swiftcDiagnostics = this.getDiagnostics(diagnostics, DiagnosticsManager.swiftc);
+        const sourceKitDiagnostics = this.getDiagnostics(diagnostics, DiagnosticsManager.sourcekit);
+        const mergedDiagnostics: vscode.Diagnostic[] = [];
         switch (configuration.diagnosticsCollection) {
             case "keepSourceKit":
-                this.mergeDiagnostics(newDiagnostics, diagnostics, DiagnosticsManager.sourcekit);
+                mergedDiagnostics.push(...swiftcDiagnostics);
+                this.mergeDiagnostics(
+                    mergedDiagnostics,
+                    sourceKitDiagnostics,
+                    DiagnosticsManager.sourcekit
+                );
                 break;
             case "keepSwiftc":
-                this.mergeDiagnostics(newDiagnostics, diagnostics, DiagnosticsManager.swiftc);
+                mergedDiagnostics.push(...sourceKitDiagnostics);
+                this.mergeDiagnostics(
+                    mergedDiagnostics,
+                    swiftcDiagnostics,
+                    DiagnosticsManager.swiftc
+                );
                 break;
             case "onlySourceKit":
-                this.removeDiagnostics(newDiagnostics, DiagnosticsManager.swiftc); // Just in case
-                if (DiagnosticsManager.swiftc.find(s => sources.includes(s))) {
-                    break;
-                }
-                newDiagnostics.push(...diagnostics);
+                mergedDiagnostics.push(...sourceKitDiagnostics);
                 break;
             case "onlySwiftc":
-                this.removeDiagnostics(newDiagnostics, DiagnosticsManager.sourcekit); // Just in case
-                if (DiagnosticsManager.sourcekit.find(s => sources.includes(s))) {
-                    break;
-                }
-                newDiagnostics.push(...diagnostics);
+                mergedDiagnostics.push(...swiftcDiagnostics);
                 break;
             case "keepAll":
-                newDiagnostics.push(...diagnostics);
+                mergedDiagnostics.push(...sourceKitDiagnostics);
+                mergedDiagnostics.push(...swiftcDiagnostics);
                 break;
         }
-        this.diagnosticCollection.set(uri, newDiagnostics);
+        this.diagnosticCollection.set(uri, mergedDiagnostics);
     }
 
     private mergeDiagnostics(
-        combinedDiagnostics: vscode.Diagnostic[],
-        incomingDiagnostics: vscode.Diagnostic[],
+        mergedDiagnostics: vscode.Diagnostic[],
+        // removedDiagnostics: vscode.Diagnostic[],
+        newDiagnostics: vscode.Diagnostic[],
         precedence: string[]
     ): void {
-        for (const diagnostic of incomingDiagnostics) {
+        for (const diagnostic of newDiagnostics) {
             // See if a duplicate diagnostic exists
-            const currentDiagnostic = combinedDiagnostics.find(
-                d =>
-                    d.range.start.isEqual(diagnostic.range.start) &&
-                    d.message === diagnostic.message
-            );
+            const currentDiagnostic = mergedDiagnostics.find(d => isEqual(d, diagnostic));
             if (currentDiagnostic) {
-                combinedDiagnostics.splice(combinedDiagnostics.indexOf(currentDiagnostic), 1);
+                mergedDiagnostics.splice(mergedDiagnostics.indexOf(currentDiagnostic), 1);
             }
 
             // Perform de-duplication
             if (precedence.includes(diagnostic.source || "")) {
-                combinedDiagnostics.push(diagnostic);
+                mergedDiagnostics.push(diagnostic);
                 continue;
             }
             if (!currentDiagnostic || !precedence.includes(currentDiagnostic.source || "")) {
-                combinedDiagnostics.push(diagnostic);
+                mergedDiagnostics.push(diagnostic);
                 continue;
             }
-            combinedDiagnostics.push(currentDiagnostic);
+            mergedDiagnostics.push(currentDiagnostic);
         }
     }
 
     private removeSwiftcDiagnostics() {
         this.diagnosticCollection.forEach((uri, diagnostics) => {
             const newDiagnostics = diagnostics.slice();
-            this.removeDiagnostics(newDiagnostics, DiagnosticsManager.swiftc);
+            this.removeDiagnostics(newDiagnostics, d => this.isSwiftc(d));
             if (diagnostics.length !== newDiagnostics.length) {
                 this.diagnosticCollection.set(uri, newDiagnostics);
             }
         });
     }
 
-    private removeSourceKitDiagnostics() {
-        this.diagnosticCollection.forEach((uri, diagnostics) => {
-            const newDiagnostics = diagnostics.slice();
-            this.removeDiagnostics(newDiagnostics, DiagnosticsManager.sourcekit);
-            if (diagnostics.length !== newDiagnostics.length) {
-                this.diagnosticCollection.set(uri, newDiagnostics);
-            }
-        });
+    private isSource(diagnostic: vscode.Diagnostic, sources: string[]): boolean {
+        return sources.includes(diagnostic.source || "");
     }
 
-    private removeDiagnostics(diagnostics: vscode.Diagnostic[], sources: string[]): void {
+    private isSwiftc(diagnostic: vscode.Diagnostic): boolean {
+        return this.isSource(diagnostic, DiagnosticsManager.swiftc);
+    }
+
+    private isSourceKit(diagnostic: vscode.Diagnostic): boolean {
+        return this.isSource(diagnostic, DiagnosticsManager.sourcekit);
+    }
+
+    private removeDiagnostics(
+        diagnostics: vscode.Diagnostic[],
+        matches: (d: vscode.Diagnostic) => boolean
+    ): vscode.Diagnostic[] {
+        const removed: vscode.Diagnostic[] = [];
+        let i = diagnostics.length;
+        while (i--) {
+            if (matches(diagnostics[i])) {
+                removed.push(...diagnostics.splice(i, 1));
+            }
+        }
+        return removed;
+    }
+
+    private getDiagnostics(
+        diagnostics: vscode.Diagnostic[],
+        sources: string[]
+    ): vscode.Diagnostic[] {
+        const filtered: vscode.Diagnostic[] = [];
         let i = diagnostics.length;
         while (i--) {
             if (sources.includes(diagnostics[i].source || "")) {
-                diagnostics.splice(i, 1);
+                filtered.push(diagnostics[i]);
             }
         }
+        return filtered;
     }
 
     /**
@@ -194,6 +254,7 @@ export class DiagnosticsManager implements vscode.Disposable {
      */
     clear(): void {
         this.diagnosticCollection.clear();
+        this.allDiagnostics.clear();
     }
 
     dispose() {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -845,5 +845,8 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             }
         }),
         vscode.commands.registerCommand("swift.attachDebugger", () => attachDebugger(ctx)),
+        vscode.commands.registerCommand("swift.clearDiagnosticsCollection", () =>
+            ctx.diagnostics.clear()
+        ),
     ];
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -211,6 +211,12 @@ const configuration = {
     get diagnosticsStyle(): "default" | "llvm" | "swift" {
         return vscode.workspace.getConfiguration("swift").get("diagnosticsStyle", "llvm");
     },
+    /** where to clear stale diagnostics when merging */
+    get removeStaleSwiftcDiagnostics(): boolean {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<boolean>("removeStaleSwiftcDiagnostics", false);
+    },
     /** where to show the build progress for the running task */
     get showBuildStatus(): ShowBuildStatusOptions {
         return vscode.workspace

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -211,12 +211,6 @@ const configuration = {
     get diagnosticsStyle(): "default" | "llvm" | "swift" {
         return vscode.workspace.getConfiguration("swift").get("diagnosticsStyle", "llvm");
     },
-    /** where to clear stale diagnostics when merging */
-    get removeStaleSwiftcDiagnostics(): boolean {
-        return vscode.workspace
-            .getConfiguration("swift")
-            .get<boolean>("removeStaleSwiftcDiagnostics", false);
-    },
     /** where to show the build progress for the running task */
     get showBuildStatus(): ShowBuildStatusOptions {
         return vscode.workspace


### PR DESCRIPTION
Remove stale swiftc diagnostics

Issue: #750

If the user modifies source and SourceKit diagnostics differ, they may
want to cleanup all the old swiftc ones. This will be turned on by
default. The swiftc must match with a former SourceKit one, and once
SourceKit returns a new list of diagnostics, if that matched diagnostic
is no longer there, assume it is fix and remove the matching swiftc error

Tie this to a setting so the user can turn off.

Keep track of all current diagnostics regardless of source to allow for
this cleanup, and has the added benefit that we can update the list
when the diagnosticsCollection setting changes.