### PR TITLE
Show diff for failed XCTAssertEqual and XCTAssertIdentical calls

### DIFF
--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -46,7 +46,8 @@ export interface ITestRunState {
         index: number,
         message: string | vscode.MarkdownString,
         isKnown: boolean,
-        location?: vscode.Location
+        location?: vscode.Location,
+        diff?: TestIssueDiff
     ): void;
 
     // set test index to have been skipped
@@ -60,4 +61,9 @@ export interface ITestRunState {
 
     // failed suite
     failedSuite(name: string): void;
+}
+
+export interface TestIssueDiff {
+    expected: string;
+    actual: string;
 }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -31,7 +31,7 @@ import { SwiftTestingOutputParser } from "./TestParsers/SwiftTestingOutputParser
 import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
 import { TaskOperation } from "../tasks/TaskQueue";
 import { TestXUnitParser } from "./TestXUnitParser";
-import { ITestRunState } from "./TestParsers/TestRunState";
+import { ITestRunState, TestIssueDiff } from "./TestParsers/TestRunState";
 import { TestRunArguments } from "./TestRunArguments";
 import { TemporaryFolder } from "../utilities/tempFolder";
 import { TestClass, runnableTag, upsertTestItem } from "./TestDiscovery";
@@ -1014,12 +1014,19 @@ export class TestRunnerTestRunState implements ITestRunState {
         index: number,
         message: string | vscode.MarkdownString,
         isKnown: boolean = false,
-        location?: vscode.Location
+        location?: vscode.Location,
+        diff?: TestIssueDiff
     ) {
         if (this.isUnknownTest(index)) {
             return;
         }
+
         const msg = new vscode.TestMessage(message);
+        if (diff) {
+            msg.expectedOutput = diff.expected;
+            msg.actualOutput = diff.actual;
+        }
+
         msg.location = location;
         const issueList = this.issues.get(index) ?? [];
         issueList.push({

--- a/test/suite/testexplorer/MockTestRunState.ts
+++ b/test/suite/testexplorer/MockTestRunState.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import { ITestRunState } from "../../../src/TestExplorer/TestParsers/TestRunState";
+import { ITestRunState, TestIssueDiff } from "../../../src/TestExplorer/TestParsers/TestRunState";
 
 /** TestStatus */
 export enum TestStatus {
@@ -28,7 +28,12 @@ export enum TestStatus {
 interface TestItem {
     name: string;
     status: TestStatus;
-    issues?: { message: string; isKnown: boolean; location?: vscode.Location }[];
+    issues?: {
+        message: string | vscode.MarkdownString;
+        isKnown: boolean;
+        location?: vscode.Location;
+        diff?: TestIssueDiff;
+    }[];
     timing?: { duration: number } | { timestamp: number };
 }
 
@@ -97,13 +102,14 @@ export class TestRunState implements ITestRunState {
 
     recordIssue(
         index: number,
-        message: string,
-        isKnown: boolean = false,
-        location?: vscode.Location
+        message: string | vscode.MarkdownString,
+        isKnown: boolean,
+        location?: vscode.Location,
+        diff?: TestIssueDiff
     ): void {
         this.testItemFinder.tests[index].issues = [
             ...(this.testItemFinder.tests[index].issues ?? []),
-            { message, location, isKnown },
+            { message, location, isKnown, diff },
         ];
         this.testItemFinder.tests[index].status = TestStatus.failed;
     }

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -58,7 +58,7 @@ suite("SwiftTestingOutputParser Suite", () => {
                 instant: { absolute: 0, since1970: 0 },
                 messages: messages ?? [],
                 ...{ testID, sourceLocation },
-                ...(messages ? { issue: { sourceLocation } } : {}),
+                ...(messages ? { issue: { sourceLocation, isKnown: false } } : {}),
                 _testCase: {
                     id: testCaseID ?? testID,
                     displayName: testCaseID ?? testID,
@@ -126,6 +126,7 @@ suite("SwiftTestingOutputParser Suite", () => {
                     new vscode.Position(issueLocation.line - 1, issueLocation?.column ?? 0)
                 ),
                 isKnown: false,
+                diff: undefined,
             },
         ]);
     });

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -58,6 +58,10 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
                         0
                     ),
                     isKnown: false,
+                    diff: {
+                        expected: '"1"',
+                        actual: '"2"',
+                    },
                 },
             ]);
         });
@@ -99,6 +103,7 @@ message`,
                         0
                     ),
                     isKnown: false,
+                    diff: undefined,
                 },
             ]);
         });
@@ -128,6 +133,7 @@ message`,
                         0
                     ),
                     isKnown: false,
+                    diff: undefined,
                 },
                 {
                     message: `failed - Again`,
@@ -137,6 +143,7 @@ message`,
                         0
                     ),
                     isKnown: false,
+                    diff: undefined,
                 },
             ]);
         });
@@ -162,6 +169,7 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                         0
                     ),
                     isKnown: false,
+                    diff: undefined,
                 },
                 {
                     message: `failed - Again`,
@@ -171,6 +179,7 @@ Test Case '-[MyTests.MyTests testFail]' failed (0.571 seconds).
                         0
                     ),
                     isKnown: false,
+                    diff: undefined,
                 },
             ]);
         });
@@ -190,6 +199,61 @@ Test Case '-[MyTests.MyTests`,
             );
             assert.strictEqual(runState.status, TestStatus.passed);
             assert.deepEqual(runState.timing, { duration: 0.006 });
+        });
+
+        suite("Diffs", () => {
+            const testRun = (message: string, expected?: string, actual?: string) => {
+                const testRunState = new TestRunState(["MyTests.MyTests/testFail"], true);
+                const runState = testRunState.tests[0];
+                outputParser.parseResult(
+                    `Test Case '-[MyTests.MyTests testFail]' started.
+/Users/user/Developer/MyTests/MyTests.swift:59: error: -[MyTests.MyTests testFail] : ${message}
+Test Case '-[MyTests.MyTests testFail]' failed (0.106 seconds).
+`,
+                    testRunState
+                );
+
+                assert.strictEqual(runState.status, TestStatus.failed);
+                assert.deepEqual(runState.issues, [
+                    {
+                        message,
+                        location: sourceLocationToVSCodeLocation(
+                            "/Users/user/Developer/MyTests/MyTests.swift",
+                            59,
+                            0
+                        ),
+                        isKnown: false,
+                        diff:
+                            expected && actual
+                                ? {
+                                      expected,
+                                      actual,
+                                  }
+                                : undefined,
+                    },
+                ]);
+            };
+
+            test("XCTAssertEqual", () => {
+                testRun(`XCTAssertEqual failed: ("1") is not equal to ("2")`, '"1"', '"2"');
+            });
+            test("XCTAssertEqualMultiline", () => {
+                testRun(
+                    `XCTAssertEqual failed: ("foo\nbar") is not equal to ("foo\nbaz")`,
+                    '"foo\nbar"',
+                    '"foo\nbaz"'
+                );
+            });
+            test("XCTAssertIdentical", () => {
+                testRun(
+                    `XCTAssertIdentical failed: ("V: 1") is not identical to ("V: 2")`,
+                    '"V: 1"',
+                    '"V: 2"'
+                );
+            });
+            test("XCTAssertIdentical with Identical Strings", () => {
+                testRun(`XCTAssertIdentical failed: ("V: 1") is not identical to ("V: 1")`);
+            });
         });
     });
 
@@ -229,6 +293,10 @@ Test Case 'MyTests.testFail' failed (0.106 seconds).
                         0
                     ),
                     isKnown: false,
+                    diff: {
+                        expected: '"1"',
+                        actual: '"2"',
+                    },
                 },
             ]);
         });


### PR DESCRIPTION
If a test fails with XCTAssertEqual or XCTAssertIdentical, parse the result to provide a diff by setting the expected and actual values on TestMessage.

If the string representation of the class used for XCTAssertIdentical is identical, the diff would be identical, so don't show the diff view in that case.

Fixes #654