### PR TITLE
Always register the swift-lldb debug adapter provider

### DIFF
--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -58,7 +58,7 @@ export class DebugAdapter {
             : workspace.toolchain.getToolchainExecutable(debugAdapter);
         if (!(await this.doesFileExist(lldbDebugAdapterPath))) {
             if (!quiet) {
-                vscode.window.showInformationMessage(
+                vscode.window.showErrorMessage(
                     useCustom
                         ? `Cannot find ${debugAdapter} debug adapter specified in setting Swift.Debugger.Path.`
                         : `Cannot find ${debugAdapter} debug adapter in your Swift toolchain.`

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -30,6 +30,9 @@ export function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vs
                     configuration.debugger.debugAdapterPath.length > 0
                         ? configuration.debugger.debugAdapterPath
                         : workspaceContext.toolchain.getToolchainExecutable(debugAdapter);
+                DebugAdapter.verifyDebugAdapterExists(workspaceContext).then(() => {
+                    /** Ignore */
+                });
                 executable = new vscode.DebugAdapterExecutable(lldbDebugAdapterPath, [], {});
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,10 +213,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api | 
 
         const testExplorerObserver = TestExplorer.observeFolders(workspaceContext);
 
-        if (configuration.debugger.useDebugAdapterFromToolchain) {
-            const lldbDebugAdapter = registerLLDBDebugAdapter(workspaceContext);
-            context.subscriptions.push(lldbDebugAdapter);
-        }
+        // Register swift-lldb debug provider
+        const lldbDebugAdapter = registerLLDBDebugAdapter(workspaceContext);
+        context.subscriptions.push(lldbDebugAdapter);
+
         const loggingDebugAdapter = registerLoggingDebugAdapterTracker();
 
         // setup workspace context with initial workspace folders


### PR DESCRIPTION
Issue: #848

We can always register this and that way the user does not need to reload the window when use change to using lldb-dap. Now they can use the updated debug configurations right away