### PR TITLE
Use proper lldb path on Windows

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -345,10 +345,10 @@ export class SwiftToolchain {
      * is not in macOS toolchain path
      */
     public async getLLDB(): Promise<string> {
-        let lldbPath = path.join(this.swiftFolderPath, "lldb");
-        if (process.platform === "win32") {
-            lldbPath = path.join(this.swiftFolderPath, "lldb.exe");
-        }
+        let lldbPath = path.join(
+            this.swiftFolderPath,
+            process.platform === "win32" ? "lldb.exe" : "lldb"
+        );
         if (!(await pathExists(lldbPath))) {
             if (process.platform !== "darwin") {
                 throw new Error("Failed to find LLDB in swift toolchain");

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -346,6 +346,9 @@ export class SwiftToolchain {
      */
     public async getLLDB(): Promise<string> {
         let lldbPath = path.join(this.swiftFolderPath, "lldb");
+        if (process.platform === "win32") {
+            lldbPath = path.join(this.swiftFolderPath, "lldb.exe");
+        }
         if (!(await pathExists(lldbPath))) {
             if (process.platform !== "darwin") {
                 throw new Error("Failed to find LLDB in swift toolchain");


### PR DESCRIPTION
Issue: #887 

On Windows, the LLDB executable is named `lldb.exe` and wasn't being located correctly.