### PR TITLE
Update tests to only use swift-testing in 6.0

### DIFF
--- a/assets/test/defaultPackage/Package@swift-6.0.swift
+++ b/assets/test/defaultPackage/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -24,7 +24,7 @@ final class MixedXCTestSuite: XCTestCase {
   }
 }
 
-#if swift(>=5.10)
+#if swift(>=6.0)
 import Testing
 
 @Test func topLevelTestPassing() {}

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -62,6 +62,18 @@ suite("Test Explorer Suite", function () {
 
         const testItems = tests.map(test => {
             const testItem = getTestItem(controller, test);
+            if (!testItem) {
+                const testsInController: string[] = [];
+                controller.items.forEach(item => {
+                    testsInController.push(
+                        `${item.id}: ${item.label} ${item.error ? `(error: ${item.error})` : ""}`
+                    );
+                });
+
+                assert.fail(
+                    `Unable to find ${test} in Test Controller. Items in test controller are: ${testsInController.join(", ")}`
+                );
+            }
             assert.ok(testItem);
             return testItem;
         });


### PR DESCRIPTION
Swift testing recently dropped support for Swift 5.10 in https://github.com/apple/swift-testing/pull/467

Our tests were only runing swift-testing tests in 6.0 and up, but the test project was configured to include it as a dependency with 5.10. Bump this up to 6.0.