### PR TITLE
Don't mark tests with children as pass/fail

### DIFF
--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -32,6 +32,11 @@ import Testing
   #expect(1 == 2)
 }
 
+@Test(arguments: [1, 2, 3])
+func parameterizedTest(_ arg: Int) {
+  #expect(arg != 2)
+}
+
 @Suite
 struct MixedSwiftTestingSuite {
   @Test

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -974,6 +974,9 @@ export class TestRunnerTestRunState implements ITestRunState {
             return;
         }
         const test = this.testRun.testItems[index];
+        if (test.children.size > 0) {
+            return;
+        }
         const startTime = this.startTimes.get(index);
 
         let duration: number;

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -124,6 +124,7 @@ suite("Test Explorer Suite", function () {
                     ["testPassing()", "testFailing()"],
                     "topLevelTestPassing()",
                     "topLevelTestFailing()",
+                    "parameterizedTest(_:)",
                     "MixedSwiftTestingSuite",
                     ["testPassing()", "testFailing()", "testDisabled()"],
                     "testWithKnownIssue()",
@@ -240,6 +241,27 @@ suite("Test Explorer Suite", function () {
                         });
                     });
 
+                    test("Runs parameterized test", async function () {
+                        const testRun = await runTest(
+                            testExplorer.controller,
+                            runProfile,
+                            "PackageTests.parameterizedTest(_:)"
+                        );
+
+                        assertTestResults(testRun, {
+                            passed: [
+                                "PackageTests.parameterizedTest(_:)/PackageTests.swift:35:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [49])])",
+                                "PackageTests.parameterizedTest(_:)/PackageTests.swift:35:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [51])])",
+                            ],
+                            failed: [
+                                {
+                                    issues: ["Expectation failed: (arg → 2) != 2"],
+                                    test: "PackageTests.parameterizedTest(_:)/PackageTests.swift:35:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [50])])",
+                                },
+                            ],
+                        });
+                    });
+
                     test("Runs Suite", async function () {
                         const testRun = await runTest(
                             testExplorer.controller,
@@ -248,10 +270,7 @@ suite("Test Explorer Suite", function () {
                         );
 
                         assertTestResults(testRun, {
-                            passed: [
-                                "PackageTests.MixedSwiftTestingSuite/testPassing()",
-                                "PackageTests.MixedSwiftTestingSuite",
-                            ],
+                            passed: ["PackageTests.MixedSwiftTestingSuite/testPassing()"],
                             skipped: ["PackageTests.MixedSwiftTestingSuite/testDisabled()"],
                             failed: [
                                 {
@@ -273,7 +292,6 @@ suite("Test Explorer Suite", function () {
                         assertTestResults(testRun, {
                             passed: [
                                 "PackageTests.MixedSwiftTestingSuite/testPassing()",
-                                "PackageTests.MixedSwiftTestingSuite",
                                 "PackageTests.MixedXCTestSuite/testPassing",
                             ],
                             skipped: ["PackageTests.MixedSwiftTestingSuite/testDisabled()"],

--- a/test/suite/testexplorer/utilities.ts
+++ b/test/suite/testexplorer/utilities.ts
@@ -72,6 +72,9 @@ export function assertTestControllerHierarchy(
 
 /**
  * Asserts on the result of a test run.
+ *
+ * The order of tests is not verified because swift-testing
+ * tests run in parallel and can complete in any order.
  */
 export function assertTestResults(
     testRun: TestRunProxy,
@@ -88,22 +91,24 @@ export function assertTestResults(
 ) {
     assert.deepEqual(
         {
-            passed: testRun.runState.passed.map(({ id }) => id),
-            failed: testRun.runState.failed.map(({ test, message }) => ({
-                test: test.id,
-                issues: Array.isArray(message)
-                    ? message.map(({ message }) => message)
-                    : [(message as vscode.TestMessage).message],
-            })),
-            skipped: testRun.runState.skipped.map(({ id }) => id),
-            errored: testRun.runState.errored.map(({ id }) => id),
+            passed: testRun.runState.passed.map(({ id }) => id).sort(),
+            failed: testRun.runState.failed
+                .map(({ test, message }) => ({
+                    test: test.id,
+                    issues: Array.isArray(message)
+                        ? message.map(({ message }) => message)
+                        : [(message as vscode.TestMessage).message],
+                }))
+                .sort(),
+            skipped: testRun.runState.skipped.map(({ id }) => id).sort(),
+            errored: testRun.runState.errored.map(({ id }) => id).sort(),
             unknown: testRun.runState.unknown,
         },
         {
-            passed: state.passed ?? [],
-            failed: state.failed ?? [],
-            skipped: state.skipped ?? [],
-            errored: state.errored ?? [],
+            passed: (state.passed ?? []).sort(),
+            failed: (state.failed ?? []).sort(),
+            skipped: (state.skipped ?? []).sort(),
+            errored: (state.errored ?? []).sort(),
             unknown: 0,
         }
     );


### PR DESCRIPTION
The Test Explorer automatically shows a pass/fail state based on the state of a TestItem's children. The Test Results in the bottom right were showing suites as passing even if a child test failed. We should simply omit suites from being marked as pass/fail.

Also adds a test for swift-testing parameterized tests.