### PR TITLE
Give debugging sessions unique names

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -725,6 +725,13 @@ export class TestRunner {
 
                     swiftTestBuildConfig.testType = TestLibrary.swiftTesting;
                     swiftTestBuildConfig.preLaunchTask = null;
+
+                    // If we're testing in both frameworks we're going to start more than one debugging
+                    // session. If both build configurations have the same name LLDB will replace the
+                    // output of the first one in the Debug Console with the output of the second one.
+                    // If they each have a unique name the Debug Console gets a nice dropdown the user
+                    // can switch between to see the output for both sessions.
+                    swiftTestBuildConfig.name = `Swift Testing: ${swiftTestBuildConfig.name}`;
                     buildConfigs.push(swiftTestBuildConfig);
                 }
             }
@@ -750,6 +757,7 @@ export class TestRunner {
 
                     xcTestBuildConfig.testType = TestLibrary.xctest;
                     xcTestBuildConfig.preLaunchTask = null;
+                    xcTestBuildConfig.name = `XCTest: ${xcTestBuildConfig.name}`;
                     buildConfigs.push(xcTestBuildConfig);
                 }
             }


### PR DESCRIPTION
If we're testing in both frameworks we're going to start more than one debugging session. If both build configurations have the same name LLDB will replace the output of the first one in the Debug Console with the output of the second one. This means the user loses the debug output from the first session.

If they each have a unique name the Debug Console gets a nice dropdown the user can switch between to see the output for both sessions.

This approach has the caveat where VS Code doesn't seem to have an API to remove an old session with a different name from the dropdown.

Specifically, if we do a debugging run of all tests in a XCTest+Swift Testing project this creates two sessions with, for instance, the names "XCTest" and "Swift Testing". However if then we run a single XCTest the "XCTest" debug session is updated but the old "Swift Testing" session sticks around in the dropdown with the output from the last run.

Issue: #902