### PR TITLE
Add UI Settings Group

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,23 +276,11 @@
             ],
             "order": 9
           },
-          "swift.excludePathsFromPackageDependencies": {
-            "description": "A list of paths to exclude from the Package Dependencies view.",
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "default": [
-              ".git",
-              ".github"
-            ],
-            "order": 10
-          },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved.",
-            "order": 11
+            "order": 10
           },
           "swift.actionAfterBuildError": {
             "type": "string",
@@ -307,43 +295,42 @@
               "Focus on Build Task Terminal"
             ],
             "markdownDescription": "Action after a Build task generates errors.",
-            "order": 12
+            "order": 11
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "Path to the build directory passed to all swift package manager commands.",
-            "order": 13
+            "order": 12
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 14
+            "order": 13
           },
-          "swift.showCreateSwiftProjectInWelcomePage": {
+          "swift.warnAboutSymlinkCreation": {
             "type": "boolean",
             "default": true,
-            "description": "Controls whether or not the create new swift project button appears in the welcome page.",
-            "order": 15
-          },
-          "swift.openAfterCreateNewProject": {
-            "type": "string",
-            "enum": [
-              "always",
-              "alwaysNewWindow",
-              "whenNoFolderOpen",
-              "prompt"
-            ],
-            "enumDescriptions": [
-              "Always open in current window.",
-              "Always open in a new window.",
-              "Only open in current window when no folder is opened.",
-              "Always prompt for action."
-            ],
-            "default": "prompt",
-            "description": "Controls whether to open a swift project automatically after creating it.",
-            "order": 16
+            "description": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
+            "scope": "application",
+            "order": 14
+          }
+        }
+      },
+      {
+        "title": "User Interface",
+        "properties": {
+          "swift.excludePathsFromPackageDependencies": {
+            "description": "A list of paths to exclude from the Package Dependencies view.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              ".git",
+              ".github"
+            ]
           },
           "swift.showBuildStatus": {
             "type": "string",
@@ -360,15 +347,29 @@
               "Show the Swift build status in a status bar item provided by the Swift extension.",
               "Show the Swift build status in the \"Progress Message\" status bar item provided by VS Code.",
               "Show the Swift build status as a progress notification."
-            ],
-            "order": 17
+            ]
           },
-          "swift.warnAboutSymlinkCreation": {
+          "swift.showCreateSwiftProjectInWelcomePage": {
             "type": "boolean",
             "default": true,
-            "description": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
-            "scope": "application",
-            "order": 18
+            "description": "Controls whether or not the create new swift project button appears in the welcome page."
+          },
+          "swift.openAfterCreateNewProject": {
+            "type": "string",
+            "enum": [
+              "always",
+              "alwaysNewWindow",
+              "whenNoFolderOpen",
+              "prompt"
+            ],
+            "enumDescriptions": [
+              "Always open in current window.",
+              "Always open in a new window.",
+              "Only open in current window when no folder is opened.",
+              "Always prompt for action."
+            ],
+            "default": "prompt",
+            "description": "Controls whether to open a swift project automatically after creating it."
           }
         }
       },


### PR DESCRIPTION
Move the following settings in to their own group. Their ID does not change so there is no need to deprecate them or make code changes.

- `swift.excludePathsFromPackageDependencies`
- `swift.showBuildStatus`
- `swift.showCreateSwiftProjectInWelcomePage`
- `swift.openAfterCreateNewProject`

Issue #901