### PR TITLE
Fix src/*.ts source mapping when debugging extension tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,7 @@
 				"${workspaceFolder}/assets/test"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/test/**/*.js"
+				"${workspaceFolder}/out/**/*.js"
 			],
 			"preLaunchTask": "compile-tests"
 		}


### PR DESCRIPTION
Otherwise need to set a breakpoint in .js file under out