### PR TITLE
Ensure build output is printed on swift-testing compiler error

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -532,6 +532,13 @@ export class TestRunner {
             if (error !== 1) {
                 this.testRun.appendOutput(`\r\nError: ${getErrorDescription(error)}`);
             } else {
+                // swift-testing tests don't have their run started until the .swift-testing binary has
+                // sent all of its `test` events, which enumerate the parameterized test cases. This means that
+                // build output is witheld until the run starts. If there is a compile error, unless we call
+                // `testRunStarted()` to flush the buffer of test result output, the build error will be silently
+                // discarded. If the test run has already started this is a no-op so its safe to call it multiple times.
+                this.testRun.testRunStarted();
+
                 this.swiftTestOutputParser.close();
             }
         } finally {


### PR DESCRIPTION
When performing a swift-testing test run with code that fails to compile the build output was being discarded. This made it hard to see why tests weren't being run.

This was happening because swift-testing tests don't have their run started until the .swift-testing binary has sent all of its `test` events, which enumerate the parameterized test cases. This means that build output is witheld until the run starts.

If there is a compile error, unless we call `testRunStarted()` to flush the buffer of test result output, nothing is printed to the Test Results panel and build output is lost.