### PR TITLE
Don't show XCTest failures under Problems view

### DIFF
--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -17,6 +17,7 @@ import stripAnsi = require("strip-ansi");
 import configuration from "./configuration";
 import { SwiftExecution } from "./tasks/SwiftExecution";
 import { WorkspaceContext } from "./WorkspaceContext";
+import { checkIfBuildComplete } from "./utilities/tasks";
 
 interface ParsedDiagnostic {
     uri: string;
@@ -262,6 +263,10 @@ export class DiagnosticsManager implements vscode.Disposable {
                     // Otherwise want to keep remaining data to pre-pend next write
                     remainingData = lines.pop();
                     for (const line of lines) {
+                        if (checkIfBuildComplete(line)) {
+                            done();
+                            return;
+                        }
                         const result = this.parseDiagnostic(line);
                         if (!result) {
                             continue;

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -17,6 +17,7 @@ import * as vscode from "vscode";
 import configuration, { ShowBuildStatusOptions } from "../configuration";
 import { RunningTask, StatusItem } from "./StatusItem";
 import { SwiftExecution } from "../tasks/SwiftExecution";
+import { checkIfBuildComplete } from "../utilities/tasks";
 
 /**
  * Progress of `swift` build, parsed from the
@@ -111,7 +112,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
         // be concerned with
         const lines = sanitizedData.split(/\r\n|\n|\r/gm).reverse();
         for (const line of lines) {
-            if (this.checkIfBuildComplete(line)) {
+            if (checkIfBuildComplete(line)) {
                 return true;
             }
             const progress = this.findBuildProgress(line);
@@ -124,22 +125,6 @@ export class SwiftBuildStatus implements vscode.Disposable {
                 update(`${name} fetching dependencies`);
                 return false;
             }
-        }
-        return false;
-    }
-
-    private checkIfBuildComplete(line: string): boolean {
-        // Output in this format for "build" and "test" commands
-        const completeRegex = /^Build complete!/gm;
-        let match = completeRegex.exec(line);
-        if (match) {
-            return true;
-        }
-        // Output in this format for "run" commands
-        const productCompleteRegex = /^Build of product '.*' complete!/gm;
-        match = productCompleteRegex.exec(line);
-        if (match) {
-            return true;
         }
         return false;
     }

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -35,3 +35,19 @@ function getScopeWorkspaceFolder(task: vscode.Task): string | undefined {
     }
     return;
 }
+
+export function checkIfBuildComplete(line: string): boolean {
+    // Output in this format for "build" and "test" commands
+    const completeRegex = /^Build complete!/gm;
+    let match = completeRegex.exec(line);
+    if (match) {
+        return true;
+    }
+    // Output in this format for "run" commands
+    const productCompleteRegex = /^Build of product '.*' complete!/gm;
+    match = productCompleteRegex.exec(line);
+    if (match) {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
Stop parsing diagnostics once build is complete

Issue: #925