### PR TITLE
Prompt to update `DEVELOPER_DIR` for macOS toolchain selection

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -198,9 +198,6 @@ const configuration = {
             .getConfiguration("swift")
             .get<{ [key: string]: string }>("swiftEnvironmentVariables", {});
     },
-    set swiftEnvironmentVariables(vars: { [key: string]: string }) {
-        vscode.workspace.getConfiguration("swift").update("swiftEnvironmentVariables", vars);
-    },
     /** include build errors in problems view */
     get diagnosticsCollection(): DiagnosticCollectionOptions {
         return vscode.workspace

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -91,25 +91,26 @@ export async function showToolchainError(): Promise<void> {
     }
 }
 
+/** A {@link vscode.QuickPickItem} that contains the path to an installed Swift toolchain */
 type SwiftToolchainItem = PublicSwiftToolchainItem | XcodeToolchainItem;
 
-/** A {@link vscode.QuickPickItem} that contains the path to an installed swift toolchain */
-interface PublicSwiftToolchainItem extends vscode.QuickPickItem {
+/** Common properties for a {@link vscode.QuickPickItem} that represents a Swift toolchain */
+interface BaseSwiftToolchainItem extends vscode.QuickPickItem {
     type: "toolchain";
-    category: "public" | "swiftly";
     toolchainPath: string;
     swiftFolderPath: string;
     onDidSelect?(): Promise<void>;
 }
 
-/** A {@link vscode.QuickPickItem} that contains the path to an installed Xcode toolchain */
-interface XcodeToolchainItem extends vscode.QuickPickItem {
-    type: "toolchain";
+/** A {@link vscode.QuickPickItem} for a Swift toolchain that has been installed manually */
+interface PublicSwiftToolchainItem extends BaseSwiftToolchainItem {
+    category: "public" | "swiftly";
+}
+
+/** A {@link vscode.QuickPickItem} for a Swift toolchain provided by an installed Xcode application */
+interface XcodeToolchainItem extends BaseSwiftToolchainItem {
     category: "xcode";
     xcodePath: string;
-    toolchainPath: string;
-    swiftFolderPath: string;
-    onDidSelect?(): Promise<void>;
 }
 
 /** A {@link vscode.QuickPickItem} that performs an action for the user */
@@ -431,7 +432,7 @@ async function checkAndRemoveWorkspaceSetting(target: vscode.ConfigurationTarget
     const inspect = vscode.workspace.getConfiguration("swift").inspect<string>("path");
     if (inspect?.workspaceValue) {
         const confirmation = await vscode.window.showWarningMessage(
-            "You already have the Swift path configured in Workspace Settings which takes precedence over User Settings." +
+            "You already have a Swift path configured in Workspace Settings which takes precedence over User Settings." +
                 " Would you like to remove the setting from your workspace and use the User Settings instead?",
             "Remove Workspace Setting"
         );

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -259,9 +259,7 @@ export async function showToolchainSelectionQuickPick(activeToolchain: SwiftTool
     const selected = await vscode.window.showQuickPick<SelectToolchainItem>(
         getQuickPickItems(activeToolchain).then(result => {
             xcodePaths = result
-                .filter(
-                    (i): i is XcodeToolchainItem => i.type === "toolchain" && i.category === "xcode"
-                )
+                .filter((i): i is XcodeToolchainItem => "category" in i && i.category === "xcode")
                 .map(xcode => xcode.xcodePath);
             return result;
         }),
@@ -282,7 +280,7 @@ export async function showToolchainSelectionQuickPick(activeToolchain: SwiftTool
         } else if (xcodePaths.length === 1) {
             developerDir = xcodePaths[0];
         } else if (process.platform === "darwin" && xcodePaths.length > 1) {
-            developerDir = await showXcodeSelectionQuickPick(xcodePaths);
+            developerDir = await showDeveloperDirQuickPick(xcodePaths);
             if (!developerDir) {
                 return;
             }
@@ -302,7 +300,7 @@ export async function showToolchainSelectionQuickPick(activeToolchain: SwiftTool
  * @param xcodePaths An array of paths to available Xcode installations on the system
  * @returns The selected DEVELOPER_DIR or undefined if the user cancelled selection
  */
-async function showXcodeSelectionQuickPick(xcodePaths: string[]): Promise<string | undefined> {
+async function showDeveloperDirQuickPick(xcodePaths: string[]): Promise<string | undefined> {
     const selected = await vscode.window.showQuickPick<vscode.QuickPickItem>(
         SwiftToolchain.getXcodeDeveloperDir(configuration.swiftEnvironmentVariables).then(
             existingDeveloperDir => {
@@ -331,7 +329,7 @@ async function showXcodeSelectionQuickPick(xcodePaths: string[]): Promise<string
         ),
         {
             title: "Select a developer directory",
-            placeHolder: "Pick an Xcode installation that VS Code will use",
+            placeHolder: "Pick an Xcode installation to use as the developer directory",
             canPickMany: false,
         }
     );


### PR DESCRIPTION
This updates the toolchain selection workflow to also set the `DEVELOPER_DIR` environment variable on macOS. This will be done automatically if the user selected an Xcode toolchain. However, they will be prompted to select a developer directory if they select a public Swift toolchain and there is more than one Xcode application installed on their system.

Linux and Windows toolchain selection is unaffected by this change.

Issue: #911 