### PR TITLE
Don't prepend target id to test ids if it exists

### DIFF
--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -148,7 +148,12 @@ export class LSPTestDiscovery {
             .getTargets(TargetType.test)
             .find(target => swiftPackage.getTarget(location.uri.fsPath) === target);
 
-        const id = target !== undefined ? `${target.c99name}.${item.id}` : item.id;
+        // If we're using an older sourcekit-lsp it doesn't prepend the target name
+        // to the test item id.
+        const id =
+            target !== undefined && !item.id.startsWith(`${target.c99name}.`)
+                ? `${target.c99name}.${item.id}`
+                : item.id;
         return item.style === "XCTest" ? id.replace(/\(\)$/, "") : id;
     }
 }


### PR DESCRIPTION
With https://github.com/swiftlang/sourcekit-lsp/pull/1530, `sourcekit-lsp` will start prepending a test target's name to the test id. This helps disambiguate when there are two identically named suites in two different test targets.

To maintain the current behaviour with older sourcekit-lsp versions only prefix the test target if it isn't already there.

- Depends on https://github.com/swiftlang/sourcekit-lsp/pull/1530
- Fixes #936