### PR TITLE
Handle `PeekDocumentsRequest` to show documents from sourcekit-lsp (like, Macro Expansions) in a "peeked" editor 

### DIFF
--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -14,8 +14,47 @@
 
 import * as ls from "vscode-languageserver-protocol";
 import * as langclient from "vscode-languageclient/node";
+import * as vscode from "vscode";
 
 // Definitions for non-standard requests used by sourcekit-lsp
+
+// Peek Documents
+export interface PeekDocumentsParams {
+    /**
+     * The `DocumentUri` of the text document in which to show the "peeked" editor
+     */
+    uri: langclient.DocumentUri;
+
+    /**
+     * The `Position` in the given text document in which to show the "peeked editor"
+     */
+    position: vscode.Position;
+
+    /**
+     * An array `DocumentUri` of the documents to appear inside the "peeked" editor
+     */
+    locations: langclient.DocumentUri[];
+}
+
+/**
+ * Response to indicate the `success` of the `PeekDocumentsRequest`
+ */
+export interface PeekDocumentsResult {
+    success: boolean;
+}
+
+/**
+ * Request from the server to the client to show the given documents in a "peeked" editor.
+ *
+ * This request is handled by the client to show the given documents in a "peeked" editor (i.e. inline with / inside the editor canvas).
+ *
+ * It requires the experimental client capability `"workspace/peekDocuments"` to use.
+ */
+export const PeekDocumentsRequest = new langclient.RequestType<
+    PeekDocumentsParams,
+    PeekDocumentsResult,
+    unknown
+>("workspace/peekDocuments");
 
 // Inlay Hints (pre Swift 5.6)
 export interface LegacyInlayHintsParams {

--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import * as langclient from "vscode-languageclient/node";
+import { PeekDocumentsParams, PeekDocumentsRequest } from "./lspExtensions";
+
+export function activatePeekDocuments(client: langclient.LanguageClient): vscode.Disposable {
+    const peekDocuments = client.onRequest(
+        PeekDocumentsRequest.method,
+        async (params: PeekDocumentsParams) => {
+            const locations = params.locations.map(uri => {
+                const location = new vscode.Location(
+                    vscode.Uri.from({
+                        scheme: "file",
+                        path: new URL(uri).pathname,
+                    }),
+                    new vscode.Position(0, 0)
+                );
+
+                return location;
+            });
+
+            await vscode.commands.executeCommand(
+                "editor.action.peekLocations",
+                vscode.Uri.from({
+                    scheme: "file",
+                    path: new URL(params.uri).pathname,
+                }),
+                new vscode.Position(params.position.line, params.position.character),
+                locations,
+                "peek"
+            );
+
+            return { success: true };
+        }
+    );
+
+    return peekDocuments;
+}


### PR DESCRIPTION
This PR utilises the following PR in sourcekit-lsp: https://github.com/swiftlang/sourcekit-lsp/pull/1479
This takes a custom `PeekDocumentsRequest` and opens a peek window to display each given document. In the current state, this request is being used by `ExpandMacroCommand` in sourcekit-lsp to display Macro Expansions.

To check out this functionality, build the `main` branch of `sourcekit-lsp`. Then, configure your "swift.sourcekit-lsp.serverPath" to the built sourcekit-lsp. (This step will not be necessary once this build of sourcekit-lsp is packaged with Swift itself given that you use the latest Swift Toolchain)

*Since the macro expansions feature is behind an experimental feature flag*, configure your swift extension settings as follows:
```
"swift.sourcekit-lsp.serverArguments": [
  "--experimental-feature", "show-macro-expansions"
],
```
(The above step will not be necessary when showing macro expansions comes to a mature stage in the sourcekit-lsp side and thus will be out of its experimental feature flag)

The "Expand Macro" will be available as a Code Action when the cursor sits on a Macro annotation, and selecting the code action will trigger the `ExpandMacroCommand` -> `PeekDocumentsRequest`, and thus shows the Macro Expansions inside a "peeked" editor.

**Note for extension / plugin developers of other editor ecosystems:**
If you are an extension developer wanting to implement this custom functionality in your own editor, set the experimental client capability `workspace/peekDocuments` to `true`, in order to make `sourcekit-lsp` to send the `PeekDocumentsRequest`. From there, you can handle the request and display the documents in any way as you wish, as long as it is "inline" to the editor (or) "peeks" the documents inside the editor.

Fixes https://github.com/swiftlang/vscode-swift/issues/564

-------

[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 