### PR TITLE
always add Swift path to terminal PATH

### DIFF
--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -55,8 +55,7 @@ export class SwiftEnvironmentVariablesManager implements vscode.Disposable {
             return;
         }
 
-        const pathEnv = process.env["PATH"] ?? "";
-        if (!pathEnv.includes(configuration.path)) {
+        if (configuration.path) {
             environment.prepend("PATH", configuration.path + pathSeparator);
         }
         for (const variable in configuration.swiftEnvironmentVariables) {
@@ -75,7 +74,7 @@ export class SwiftTerminalProfileProvider implements vscode.TerminalProfileProvi
             ...configuration.swiftEnvironmentVariables,
         };
         const pathEnv = process.env["PATH"] ?? "";
-        if (!pathEnv.includes(configuration.path)) {
+        if (configuration.path) {
             env["PATH"] = configuration.path + pathSeparator + pathEnv;
         }
         return new vscode.TerminalProfile({


### PR DESCRIPTION
I originally added logic to avoid adding to `PATH` if the `swift.path` setting already existed. However, this leads to weird behaviour if the path is already there, but is lower in the list. Now the Swift extension will always add `swift.path` to the terminal `PATH` as long as the user has overridden it in settings.

Issue: #914 