### PR TITLE
Apply changes to PATH after terminal creation

### DIFF
--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -77,13 +77,18 @@ export class SwiftTerminalProfileProvider implements vscode.TerminalProfileProvi
         const env: vscode.TerminalOptions["env"] = {
             ...configuration.swiftEnvironmentVariables,
         };
-        const pathEnv = process.env["PATH"] ?? "";
-        if (configuration.path) {
-            env["PATH"] = configuration.path + pathSeparator + pathEnv;
+        if (!configuration.enableTerminalEnvironment) {
+            const disposable = vscode.window.onDidOpenTerminal(terminal => {
+                if (configuration.path) {
+                    terminal.sendText(`export PATH=${configuration.path + pathSeparator}$PATH`);
+                }
+                disposable.dispose();
+            });
         }
         return new vscode.TerminalProfile({
             name: "Swift Terminal",
             iconPath: new vscode.ThemeIcon("swift-icon"),
+            shellArgs: [],
             env,
         });
     }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -56,10 +56,14 @@ export class SwiftEnvironmentVariablesManager implements vscode.Disposable {
         }
 
         if (configuration.path) {
-            environment.prepend("PATH", configuration.path + pathSeparator);
+            environment.prepend("PATH", configuration.path + pathSeparator, {
+                applyAtShellIntegration: true,
+            });
         }
         for (const variable in configuration.swiftEnvironmentVariables) {
-            environment.replace(variable, configuration.swiftEnvironmentVariables[variable]);
+            environment.replace(variable, configuration.swiftEnvironmentVariables[variable], {
+                applyAtShellIntegration: true,
+            });
         }
     }
 }


### PR DESCRIPTION
The shell has the ability to add/change environment variables after startup via configuration files. Use `applyAtShellIntegration` to overcome this for the automatic terminal configuration. Terminal profiles, unfortunately, do not have this option. In this case we have to grab the created terminal and inject our environment variables using a command after the terminal starts up.

Issue: #914 