### PR TITLE
Add missing licence header to peekDocuments.ts

### DIFF
--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 import { PeekDocumentsParams, PeekDocumentsRequest } from "./lspExtensions";


### PR DESCRIPTION
During the swiftlang org transition CI was not running, which failed to catch this missing licence declaration.