### PR TITLE
Add Re-Index Project Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -669,6 +669,10 @@
         {
           "command": "swift.attachDebugger",
           "when": "swift.lldbVSCodeAvailable"
+        },
+        {
+          "command": "swift.reindexProject",
+          "when": "swift.supportsReindexing"
         }
       ],
       "editor/context": [

--- a/package.json
+++ b/package.json
@@ -153,6 +153,11 @@
         "category": "Swift"
       },
       {
+        "command": "swift.reindexProject",
+        "title": "Re-Index Project",
+        "category": "Swift"
+      },
+      {
         "command": "swift.switchPlatform",
         "title": "Select Target Platform...",
         "category": "Swift"

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -49,8 +49,6 @@ interface ILanguageClientManager {
  * these results.
  */
 export class LSPTestDiscovery {
-    private capCache = new Map<string, boolean>();
-
     constructor(private languageClient: ILanguageClientManager) {}
 
     /**

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -229,6 +229,14 @@ export class WorkspaceContext implements vscode.Disposable {
         } else {
             contextKeys.currentTargetType = undefined;
         }
+
+        // LSP can be configured per workspace to support reindexing
+        this.languageClientManager.useLanguageClient(async client => {
+            const experimentalCaps = client.initializeResult?.capabilities.experimental;
+            contextKeys.supportsReindexing =
+                experimentalCaps && experimentalCaps["workspace/triggerReindex"] !== undefined;
+        });
+
         setSnippetContextKey(this);
     }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -32,6 +32,7 @@ import { SwiftExecOperation, TaskOperation } from "./tasks/TaskQueue";
 import { SwiftProjectTemplate } from "./toolchain/toolchain";
 import { showToolchainSelectionQuickPick, showToolchainError } from "./ui/ToolchainSelection";
 import { captureDiagnostics } from "./commands/captureDiagnostics";
+import { reindexProjectRequest } from "./sourcekit-lsp/lspExtensions";
 
 /**
  * References:
@@ -656,6 +657,25 @@ function restartLSPServer(workspaceContext: WorkspaceContext): Promise<void> {
     return workspaceContext.languageClientManager.restart();
 }
 
+/** Request that the SourceKit-LSP server reindexes the workspace */
+function reindexProject(workspaceContext: WorkspaceContext): Promise<unknown> {
+    return workspaceContext.languageClientManager.useLanguageClient(async (client, token) => {
+        try {
+            return await client.sendRequest(reindexProjectRequest, {}, token);
+        } catch (err) {
+            const error = err as { code: number; message: string };
+            // methodNotFound, version of sourcekit-lsp is likely too old.
+            if (error.code === -32601) {
+                vscode.window.showWarningMessage(
+                    "The installed version of SourceKit-LSP does not support background indexing."
+                );
+            } else {
+                vscode.window.showWarningMessage(error.message);
+            }
+        }
+    });
+}
+
 /** Execute task and show UI while running */
 async function executeTaskWithUI(
     task: vscode.Task,
@@ -817,6 +837,9 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),
         vscode.commands.registerCommand("swift.runPluginTask", () => runPluginTask()),
         vscode.commands.registerCommand("swift.restartLSPServer", () => restartLSPServer(ctx)),
+        ...(ctx.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))
+            ? [vscode.commands.registerCommand("swift.reindexProject", () => reindexProject(ctx))]
+            : []),
         vscode.commands.registerCommand("swift.insertFunctionComment", () =>
             insertFunctionComment(ctx)
         ),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -837,9 +837,7 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),
         vscode.commands.registerCommand("swift.runPluginTask", () => runPluginTask()),
         vscode.commands.registerCommand("swift.restartLSPServer", () => restartLSPServer(ctx)),
-        ...(ctx.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))
-            ? [vscode.commands.registerCommand("swift.reindexProject", () => reindexProject(ctx))]
-            : []),
+        vscode.commands.registerCommand("swift.reindexProject", () => reindexProject(ctx)),
         vscode.commands.registerCommand("swift.insertFunctionComment", () =>
             insertFunctionComment(ctx)
         ),

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -80,6 +80,13 @@ const contextKeys = {
     set createNewProjectAvailable(value: boolean) {
         vscode.commands.executeCommand("setContext", "swift.createNewProjectAvailable", value);
     },
+
+    /**
+     * Whether the SourceKit-LSP server supports reindexing the workspace.
+     */
+    set supportsReindexing(value: boolean) {
+        vscode.commands.executeCommand("setContext", "swift.supportsReindexing", value);
+    },
 };
 
 export default contextKeys;

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -174,3 +174,7 @@ export const textDocumentTestsRequest = new langclient.RequestType<
     LSPTestItem[],
     unknown
 >("textDocument/tests");
+
+export const reindexProjectRequest = new langclient.RequestType<null, unknown, unknown>(
+    "workspace/triggerReindex"
+);


### PR DESCRIPTION
Adds a command to trigger a re-indexing of the open project. Should only be needed when background indexing is enabled and it gets out of sync. While that is a bug, this can act as a temporary workaround.

Blocked By: https://github.com/swiftlang/sourcekit-lsp/pull/1561, https://github.com/swiftlang/sourcekit-lsp/pull/1563
Issue: #939