### PR TITLE
Add setting to exclude files/directories from code coverage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,6 +347,19 @@
         }
       },
       {
+        "title": "Code Coverage",
+        "properties": {
+          "swift.excludeFromCodeCoverage": {
+            "description": "A list of paths to exclude from code coverage reports. Paths can be absolute or relative to the workspace root.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          }
+        }
+      },
+      {
         "title": "User Interface",
         "properties": {
           "swift.excludePathsFromPackageDependencies": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -154,7 +154,12 @@ const configuration = {
             },
         };
     },
-
+    /** Files and directories to exclude from the code coverage. */
+    get excludeFromCodeCoverage(): string[] {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<string[]>("excludeFromCodeCoverage", []);
+    },
     /** Files and directories to exclude from the Package Dependencies view. */
     get excludePathsFromPackageDependencies(): string[] {
         return vscode.workspace

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -198,6 +198,8 @@ export class TestCoverage {
     private ignoredFilenamesRegex(): string {
         const basePath = this.folderContext.folder.path;
         const buildFolder = path.join(basePath, ".build");
+        const snippetsFolder = path.join(basePath, "Snippets");
+        const pluginsFolder = path.join(basePath, "Plugins");
         const testTargets = this.folderContext.swiftPackage
             .getTargets(TargetType.test)
             .map(target => path.join(basePath, target.path));
@@ -206,7 +208,7 @@ export class TestCoverage {
             path.isAbsolute(target) ? target : path.join(basePath, target)
         );
 
-        return [buildFolder, ...testTargets, ...excluded].join("|");
+        return [buildFolder, snippetsFolder, pluginsFolder, ...testTargets, ...excluded].join("|");
     }
 
     private async loadLcov(lcovContents: string): Promise<lcov.LcovFile[]> {

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -202,7 +202,11 @@ export class TestCoverage {
             .getTargets(TargetType.test)
             .map(target => path.join(basePath, target.path));
 
-        return [buildFolder, ...testTargets].join("|");
+        const excluded = configuration.excludeFromCodeCoverage.map(target =>
+            path.isAbsolute(target) ? target : path.join(basePath, target)
+        );
+
+        return [buildFolder, ...testTargets, ...excluded].join("|");
     }
 
     private async loadLcov(lcovContents: string): Promise<lcov.LcovFile[]> {


### PR DESCRIPTION
Adds `swift.excludeFromCodeCoverage` which provides a list of absolute or relative paths to exclude from the code coverage reports. Relative paths are specified from the workspace root.

Issue: #963