### PR TITLE
Show warning message when reindexing project

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -661,7 +661,20 @@ function restartLSPServer(workspaceContext: WorkspaceContext): Promise<void> {
 function reindexProject(workspaceContext: WorkspaceContext): Promise<unknown> {
     return workspaceContext.languageClientManager.useLanguageClient(async (client, token) => {
         try {
-            return await client.sendRequest(reindexProjectRequest, {}, token);
+            await client.sendRequest(reindexProjectRequest, {}, token);
+            const result = await vscode.window.showWarningMessage(
+                "Re-indexing a project should never be necessary and indicates a bug in SourceKit-LSP. Please file an issue describing which symbol was out-of-date and how you got into the state.",
+                "Report Issue",
+                "Close"
+            );
+            if (result === "Report Issue") {
+                vscode.commands.executeCommand(
+                    "vscode.open",
+                    vscode.Uri.parse(
+                        "https://github.com/swiftlang/sourcekit-lsp/issues/new?template=BUG_REPORT.yml&title=Symbol%20Indexing%20Issue"
+                    )
+                );
+            }
         } catch (err) {
             const error = err as { code: number; message: string };
             // methodNotFound, version of sourcekit-lsp is likely too old.


### PR DESCRIPTION
Show a warning informing the user that they shouldn't have to reindex the project, and doing so indicates a bug in SourceKit-LSP. Show a button that links out to the SourceKit-LSP issue creation page, prepopulating the issue title as "Symbol Indexing Issue".

Requested by @ahoppen in https://github.com/swiftlang/vscode-swift/pull/964#issuecomment-2231169148