### PR TITLE
Retrieve macro expansions for `PeekDocumentsRequest` through `GetReferenceDocumentRequest` instead of showing temporary files

### DIFF
--- a/src/sourcekit-lsp/getReferenceDocument.ts
+++ b/src/sourcekit-lsp/getReferenceDocument.ts
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as langclient from "vscode-languageclient/node";
+import { GetReferenceDocumentParams, GetReferenceDocumentRequest } from "./lspExtensions";
+
+export function activateGetReferenceDocument(client: langclient.LanguageClient): vscode.Disposable {
+    const getReferenceDocument = vscode.workspace.registerTextDocumentContentProvider(
+        "sourcekit-lsp",
+        {
+            provideTextDocumentContent: async (uri, token) => {
+                const params: GetReferenceDocumentParams = {
+                    uri: uri.toString(true),
+                };
+
+                const result = await client.sendRequest(GetReferenceDocumentRequest, params, token);
+
+                if (result) {
+                    return result.content;
+                } else {
+                    return "Unable to retrieve reference document";
+                }
+            },
+        }
+    );
+
+    return getReferenceDocument;
+}

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -56,6 +56,31 @@ export const PeekDocumentsRequest = new langclient.RequestType<
     unknown
 >("workspace/peekDocuments");
 
+// Get Reference Document
+export interface GetReferenceDocumentParams {
+    /**
+     * The `DocumentUri` of the custom scheme url for which content is required
+     */
+    uri: langclient.DocumentUri;
+}
+
+/**
+ * Response containing `content` of `GetReferenceDocumentRequest`
+ */
+export interface GetReferenceDocumentResult {
+    content: string;
+}
+
+/**
+ * Request from the client to the server asking for contents of a URI having a custom scheme
+ * For example: "sourcekit-lsp:"
+ */
+export const GetReferenceDocumentRequest = new langclient.RequestType<
+    GetReferenceDocumentParams,
+    GetReferenceDocumentResult,
+    unknown
+>("workspace/getReferenceDocument");
+
 // Inlay Hints (pre Swift 5.6)
 export interface LegacyInlayHintsParams {
     /**

--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -21,11 +21,9 @@ export function activatePeekDocuments(client: langclient.LanguageClient): vscode
         PeekDocumentsRequest.method,
         async (params: PeekDocumentsParams) => {
             const locations = params.locations.map(uri => {
+                const url = new URL(uri);
                 const location = new vscode.Location(
-                    vscode.Uri.from({
-                        scheme: "file",
-                        path: new URL(uri).pathname,
-                    }),
+                    vscode.Uri.parse(url.href, true),
                     new vscode.Position(0, 0)
                 );
 


### PR DESCRIPTION
This PR utilises the newly introduced `GetReferenceDocumentRequest` to resolve the contents of macro expansion obtained from `PeekDocumentRequest` through a new scheme.

This change doesn't cause any behavioural changes facing the user.
The `GetReferenceDocumentRequest` implemented in sourcekit-lsp allows it to not create temporary files whenever it makes a `PeekDocumentRequest`.

#### References:
Accompanying PR in sourcekit-lsp repository: https://github.com/swiftlang/sourcekit-lsp/pull/1567

------
[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 