### PR TITLE
Use correct xctest path when debugging on Windows

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -88,17 +88,15 @@ export class TestingDebugConfigurationFactory {
         }
 
         switch (process.platform) {
-            case "win32":
-                return this.buildWindowsConfig();
             case "darwin":
                 return this.buildDarwinConfg();
             default:
-                return this.buildLinuxConfig();
+                return this.buildNonDarwinConfig();
         }
     }
 
     /* eslint-disable no-case-declarations */
-    private buildLinuxConfig(): vscode.DebugConfiguration | null {
+    private buildNonDarwinConfig(): vscode.DebugConfiguration | null {
         if (isDebugging(this.testKind) && this.testLibrary === TestLibrary.xctest) {
             return {
                 ...this.baseConfig,
@@ -107,7 +105,6 @@ export class TestingDebugConfigurationFactory {
                 env: {
                     ...swiftRuntimeEnv(),
                     ...configuration.folder(this.ctx.workspaceFolder).testEnvironmentVariables,
-                    SWIFT_TESTING_ENABLED: "0",
                 },
             };
         } else {
@@ -237,16 +234,6 @@ export class TestingDebugConfigurationFactory {
                                     : this.baseConfig.preLaunchTask,
                         };
                 }
-        }
-    }
-
-    private buildWindowsConfig(): vscode.DebugConfiguration | null {
-        switch (this.testLibrary) {
-            case TestLibrary.swiftTesting:
-                // TODO: This is untested until rdar://128092675 is available in a windows SDK.
-                return this.buildDarwinConfg();
-            case TestLibrary.xctest:
-                return this.buildDarwinConfg();
         }
     }
     /* eslint-enable no-case-declarations */


### PR DESCRIPTION
The windows debug config was delegating to the macOS debugging config, which runs xctests through a prebuilt executable included in the toolchain. On Windows, like Linux, an xctest executable is built during `swift test`/`swift build --build-tests`. This should be used instead.

This patch brings the Windows config in line with what we do on Linux.

Issue: #970