### PR TITLE
Inform LSP of supported code lenses

### DIFF
--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -566,6 +566,12 @@ export class LanguageClientManager {
             errorHandler: new SourceKitLSPErrorHandler(5),
             initializationOptions: {
                 "workspace/peekDocuments": true, // workaround for client capability to handle `PeekDocumentsRequest`
+                "textDocument/codeLens": {
+                    supportedCommands: {
+                        "swift.run": "swift.run",
+                        "swift.debug": "swift.debug",
+                    },
+                },
             },
         };
 


### PR DESCRIPTION
Provide the LSP with a mapping of supported code lenses to commands. SourceKit-LSP will provide code lenses for running and debugging applications with a @main function only when we configure the commands we support.

Blocked by https://github.com/swiftlang/sourcekit-lsp/pull/1556