### PR TITLE
Add XCTest.dll path to Path when testing on Windows

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -808,7 +808,7 @@ export class TestRunner {
                                 this.folderContext.name
                             );
                             LoggingDebugAdapterTracker.setDebugSessionCallback(session, output => {
-                                this.testRun.appendOutput(output);
+                                this.testRun.appendOutput(output.replace(/\n/g, "\r\n"));
                                 if (config.testType === TestLibrary.xctest) {
                                     this.xcTestOutputParser.parseResult(output, runState);
                                 }

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -99,7 +99,7 @@ export class TestingDebugConfigurationFactory {
 
     /* eslint-disable no-case-declarations */
     private buildWindowsConfig(): vscode.DebugConfiguration | null {
-        if (isDebugging(this.testKind) && this.testLibrary === TestLibrary.xctest) {
+        if (isDebugging(this.testKind)) {
             const testEnv = {
                 ...swiftRuntimeEnv(),
                 ...configuration.folder(this.ctx.workspaceFolder).testEnvironmentVariables,
@@ -114,8 +114,8 @@ export class TestingDebugConfigurationFactory {
 
             return {
                 ...this.baseConfig,
-                program: this.xcTestOutputPath,
-                args: this.testList,
+                program: this.testExecutableOutputPath,
+                args: this.debuggingTestExecutableArgs,
                 env: testEnv,
             };
         } else {
@@ -401,6 +401,26 @@ export class TestingDebugConfigurationFactory {
             this.artifactFolderForTestKind,
             `${this.ctx.swiftPackage.name}PackageTests.swift-testing`
         );
+    }
+
+    private get testExecutableOutputPath(): string {
+        switch (this.testLibrary) {
+            case TestLibrary.swiftTesting:
+                return this.swiftTestingOutputPath;
+            case TestLibrary.xctest:
+                return this.xcTestOutputPath;
+        }
+    }
+
+    private get debuggingTestExecutableArgs(): string[] {
+        switch (this.testLibrary) {
+            case TestLibrary.swiftTesting:
+                return this.addBuildOptionsToArgs(
+                    this.addTestsToArgs(this.addSwiftTestingFlagsArgs([]))
+                );
+            case TestLibrary.xctest:
+                return this.testList;
+        }
     }
 
     private get sanitizerRuntimeEnvironment() {


### PR DESCRIPTION
Add XCTest.dll to PATH and supply arguments when running swift-testing tests. Also fixes extra whitespace in output when debugging XCTests on Windows.