### PR TITLE
Improve error reporting when SourceKit-LSP fails to start

### DIFF
--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -115,6 +115,7 @@ class RollingLog {
     private startIndex: number = 0;
     private endIndex: number = 0;
     private logCount: number = 0;
+    private appending: boolean = false;
 
     constructor(private maxLogs: number) {
         this._logs = new Array(maxLogs).fill(null);
@@ -133,6 +134,12 @@ class RollingLog {
     }
 
     appendLine(log: string) {
+        // Writing to a new line that isn't the very first, increment the end index
+        if (this.logCount > 0) {
+            this.endIndex = this.incrementIndex(this.endIndex);
+        }
+
+        // We're over the window size, move the start index
         if (this.logCount === this.maxLogs) {
             this.startIndex = this.incrementIndex(this.startIndex);
         } else {
@@ -140,16 +147,15 @@ class RollingLog {
         }
 
         this._logs[this.endIndex] = log;
-        this.endIndex = this.incrementIndex(this.endIndex);
     }
 
     append(log: string) {
-        const endIndex = this.endIndex - 1 < 0 ? Math.max(this.logCount - 1, 0) : this.endIndex;
-        if (this._logs[endIndex] === null) {
+        if (this.logCount === 0) {
             this.logCount = 1;
         }
-        const newLogLine = (this._logs[endIndex] ?? "") + log;
-        this._logs[endIndex] = newLogLine;
+        const newLogLine = (this._logs[this.endIndex] ?? "") + log;
+        this._logs[this.endIndex] = newLogLine;
+        this.appending = true;
     }
 
     replace(log: string) {

--- a/test/suite/ui/SwiftOutputChannel.test.ts
+++ b/test/suite/ui/SwiftOutputChannel.test.ts
@@ -56,6 +56,16 @@ suite("SwiftOutputChannel", function () {
         assert.deepEqual(channel.logs, ["b", "cd", "e"]);
     });
 
+    test("Appends after rolling over", () => {
+        channel.appendLine("a");
+        channel.appendLine("b");
+        channel.appendLine("c");
+        channel.appendLine("d");
+        channel.append("e");
+        channel.appendLine("f");
+        assert.deepEqual(channel.logs, ["c", "de", "f"]);
+    });
+
     test("Replaces", () => {
         channel.appendLine("a");
         channel.appendLine("b");
@@ -63,5 +73,12 @@ suite("SwiftOutputChannel", function () {
         channel.appendLine("d");
         channel.replace("e");
         assert.deepEqual(channel.logs, ["e"]);
+    });
+
+    test("AppendLine after append terminates appending line", () => {
+        channel.append("a");
+        channel.append("b");
+        channel.appendLine("c");
+        assert.deepEqual(channel.logs, ["ab", "c"]);
     });
 });


### PR DESCRIPTION
If SourceKit-LSP fails to initialize, typically because of unrecognized launch arguments, don't attempt to restart it and limit the number of erorr dialogs to just one descriptive one. Clicking the "Go to Output" button on this dialog takes you to the SourceKit-LSP Output panel which now shows the SourceKit-LSP launch error.