### PR TITLE
Support a Unified Test Binary

### DIFF
--- a/src/TestExplorer/TestParsers/TestEventStreamReader.ts
+++ b/src/TestExplorer/TestParsers/TestEventStreamReader.ts
@@ -74,8 +74,7 @@ export class UnixNamedPipeReader implements INamedPipeReader {
                     });
 
                     readable.on("drain", () => pipe.resume());
-
-                    pipe.on("error", () => fs.close(fd));
+                    pipe.on("error", () => pipe.close());
                     pipe.on("end", () => {
                         readable.push(null);
                         fs.close(fd);

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -425,11 +425,12 @@ export class TestRunner {
                     await execFile("mkfifo", [fifoPipePath], undefined, this.folderContext);
                 }
 
-                const testBuildConfig = TestingDebugConfigurationFactory.swiftTestingConfig(
+                const testBuildConfig = await TestingDebugConfigurationFactory.swiftTestingConfig(
                     this.folderContext,
                     fifoPipePath,
                     this.testKind,
                     this.testArgs.swiftTestArgs,
+                    new Date(),
                     true
                 );
 
@@ -467,7 +468,7 @@ export class TestRunner {
         }
 
         if (this.testArgs.hasXCTests) {
-            const testBuildConfig = TestingDebugConfigurationFactory.xcTestConfig(
+            const testBuildConfig = await TestingDebugConfigurationFactory.xcTestConfig(
                 this.folderContext,
                 this.testKind,
                 this.testArgs.xcTestArgs,
@@ -710,6 +711,8 @@ export class TestRunner {
         });
         subscriptions.push(buildTask);
 
+        const buildStartTime = new Date();
+
         // Perform a build all before the tests are run. We want to avoid the "Debug Anyway" dialog
         // since choosing that with no prior build, when debugging swift-testing tests, will cause
         // the extension to start listening to the fifo pipe when no results will be produced,
@@ -731,13 +734,15 @@ export class TestRunner {
                     await execFile("mkfifo", [fifoPipePath], undefined, this.folderContext);
                 }
 
-                const swiftTestBuildConfig = TestingDebugConfigurationFactory.swiftTestingConfig(
-                    this.folderContext,
-                    fifoPipePath,
-                    this.testKind,
-                    this.testArgs.swiftTestArgs,
-                    true
-                );
+                const swiftTestBuildConfig =
+                    await TestingDebugConfigurationFactory.swiftTestingConfig(
+                        this.folderContext,
+                        fifoPipePath,
+                        this.testKind,
+                        this.testArgs.swiftTestArgs,
+                        buildStartTime,
+                        true
+                    );
 
                 if (swiftTestBuildConfig !== null) {
                     swiftTestBuildConfig.testType = TestLibrary.swiftTesting;
@@ -765,7 +770,7 @@ export class TestRunner {
 
             // create launch config for testing
             if (this.testArgs.hasXCTests) {
-                const xcTestBuildConfig = TestingDebugConfigurationFactory.xcTestConfig(
+                const xcTestBuildConfig = await TestingDebugConfigurationFactory.xcTestConfig(
                     this.folderContext,
                     this.testKind,
                     this.testArgs.xcTestArgs,


### PR DESCRIPTION
With the merge of https://github.com/swiftlang/swift-package-manager/pull/7766 a `swift build --build-tests` produces a single binary that contains both XCTests and swift-testing tests.

Update the build configs when debugging tests to use this new unified test binary if it exists.

To determine if we're running a unified binary on macOS we can check for the presence of the swiftpm-testing-helper, which is used to run the swift-testing tests in the unified binary.

This utility isn't required on Windows and Linux as the test binary can be invoked directly. To determine if we're running a unified binary we check if the latest build produced a .swift-testing binary in the build folder. If it doesn't exist, or if it does exist but its `mtime` is older than the last build start time, we know its a unified binary. The `mtime` check is required in case the user updates their toolchain to a version that produces a unified binary but still has a .swift-testing binary in their .build folder left over from an old build.

In the future we can remove these checks once we're confident users on 6.0 and main toolchains have moved on to versions that generate a unified test binary. Tentatively I propose this to be around when Swift 6.0 is finalized and released.

This change only affects debugging tests. All other testing code paths use `swift test` which lets SwiftPM automatically handle the switch to the new unified binary.