### PR TITLE
Allow VS Code to recognise files with "sourcekit-lsp" scheme to provide Semantic Functionality through SourceKitLSP

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -518,7 +518,10 @@ export class WorkspaceContext implements vscode.Disposable {
     async focusUri(uri?: vscode.Uri) {
         this.currentDocument = uri ?? null;
         this.updateContextKeysForFile();
-        if (this.currentDocument?.scheme === "file") {
+        if (
+            this.currentDocument?.scheme === "file" ||
+            this.currentDocument?.scheme === "sourcekit-lsp"
+        ) {
             await this.focusPackageUri(this.currentDocument);
         }
     }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -44,6 +44,7 @@ export class LanguageClientManager {
 
     // document selector used by language client
     static appleLangDocumentSelector = [
+        { scheme: "sourcekit-lsp", language: "swift" },
         { scheme: "file", language: "swift" },
         { scheme: "untitled", language: "swift" },
         { scheme: "file", language: "objective-c" },

--- a/src/sourcekit-lsp/getReferenceDocument.ts
+++ b/src/sourcekit-lsp/getReferenceDocument.ts
@@ -22,7 +22,7 @@ export function activateGetReferenceDocument(client: langclient.LanguageClient):
         {
             provideTextDocumentContent: async (uri, token) => {
                 const params: GetReferenceDocumentParams = {
-                    uri: uri.toString(true),
+                    uri: client.code2ProtocolConverter.asUri(uri),
                 };
 
                 const result = await client.sendRequest(GetReferenceDocumentRequest, params, token);

--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -21,9 +21,8 @@ export function activatePeekDocuments(client: langclient.LanguageClient): vscode
         PeekDocumentsRequest.method,
         async (params: PeekDocumentsParams) => {
             const locations = params.locations.map(uri => {
-                const url = new URL(uri);
                 const location = new vscode.Location(
-                    vscode.Uri.parse(url.href, true),
+                    client.protocol2CodeConverter.asUri(uri),
                     new vscode.Position(0, 0)
                 );
 
@@ -32,10 +31,7 @@ export function activatePeekDocuments(client: langclient.LanguageClient): vscode
 
             await vscode.commands.executeCommand(
                 "editor.action.peekLocations",
-                vscode.Uri.from({
-                    scheme: "file",
-                    path: new URL(params.uri).pathname,
-                }),
+                client.protocol2CodeConverter.asUri(params.uri),
                 new vscode.Position(params.position.line, params.position.character),
                 locations,
                 "peek"


### PR DESCRIPTION
This PR makes VS Code to recognise files with scheme "sourcekit-lsp", thereby allowing them to be handled by SourceKitLSP and provide Semantic Functionality. Specifically, This PR enables Semantic Functionality in Macro Expansion Reference Document's Peeked Editors.

Refer to the sourcekit-lsp PR below for more information on what semantic functionality is supported as of now.

Accompanying PR in sourcekit-lsp repository: https://github.com/swiftlang/sourcekit-lsp/pull/1610

------
[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 