### PR TITLE
Add setting for background indexing

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,7 +12,7 @@ This document outlines useful configuration options not covered by the settings 
 
 If you're using a nightly (`main`) or recent `6.0` toolchain you can enable support for background indexing in Sourcekit-LSP. This removes the need to do a build before getting code completion and diagnostics.
 
-To enable support, set the `swift.backgroundIndexing` setting to `true`.
+To enable support, set the `swift.sourcekit-lsp.backgroundIndexing` setting to `true`.
 
 ### Support for 'Expand Macro'
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,14 +12,7 @@ This document outlines useful configuration options not covered by the settings 
 
 If you're using a nightly (`main`) or recent `6.0` toolchain you can enable support for background indexing in Sourcekit-LSP. This removes the need to do a build before getting code completion and diagnostics.
 
-To enable support, set the following Sourcekit-LSP server arguments in your settings.json, or add two new entries to the `Sourcekit-lsp: Server Arguments` entry in the extension settings page.
-
-```
-"swift.sourcekit-lsp.serverArguments": [
-  "--experimental-feature",
-  "background-indexing"
-]
-```
+To enable support, set the `swift.backgroundIndexing` setting to `true`.
 
 ### Support for 'Expand Macro'
 

--- a/package.json
+++ b/package.json
@@ -299,7 +299,7 @@
             "markdownEnumDescriptions": [
               "Use whichever diagnostics style `swiftc` produces by default.",
               "Use the `llvm` diagnostic style. This allows the parsing of \"notes\".",
-              "Use the `swift` diagnostic style. This means that \"notes\" will not be parsed. This option will not work for Swift versions prior to 5.10."
+              "Use the `swift` diagnostic style. This means that \"notes\" will not be parsed. This option has no effect in Swift versions prior to 5.10."
             ],
             "order": 9
           },
@@ -308,23 +308,6 @@
             "default": false,
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved. It is possible the background compilation will already be running when you attempt a compile yourself, so this is disabled by default.",
             "order": 10
-          },
-          "swift.backgroundIndexing": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Enable or disable background indexing. This option will not work for Swift versions prior to 6.0.",
-            "order": 11
-          },
-          "swift.backgroundPreparationMode": {
-            "type": "string",
-            "enum": [
-              "build",
-              "noLazy",
-              "enabled"
-            ],
-            "default": "enabled",
-            "markdownDescription": "Determines how background indexing should prepare a target. This option will not work for Swift versions prior to 6.0. Possible values are:\n- `build`: Build a target to prepare it\n- `noLazy`: Prepare a target without generating object files but do not do lazy type checking and function body skipping\n- `enabled`: Prepare a target without generating object files and the like",
-            "order": 12
           },
           "swift.actionAfterBuildError": {
             "type": "string",
@@ -339,32 +322,32 @@
               "Focus on Build Task Terminal"
             ],
             "markdownDescription": "Action after a Build task generates errors.",
-            "order": 13
+            "order": 11
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--scratch-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in the workspace.\n\nYou can use absolute path for directory or the relative path, which will use the workspace path as a base. Note that VS Code does not respect tildes (`~`) in paths which represents user home folder under *nix systems.",
-            "order": 14
+            "order": 12
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 15
+            "order": 13
           },
           "swift.warnAboutSymlinkCreation": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
             "scope": "application",
-            "order": 16
+            "order": 14
           },
           "swift.enableTerminalEnvironment": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Controls whether or not the extension will contribute environment variables defined in `Swift: Environment Variables` to the integrated terminal. If this is set to `true` and a custom `Swift: Path` is also set then the swift path is appended to the terminal's `PATH`.",
-            "order": 17
+            "order": 15
           }
         }
       },
@@ -454,6 +437,28 @@
             "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `['--log-level', 'debug']`",
             "order": 2
           },
+          "swift.sourcekit-lsp.backgroundIndexing": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable or disable background indexing. This option has no effect in Swift versions prior to 6.0.",
+            "order": 3
+          },
+          "swift.sourcekit-lsp.backgroundPreparationMode": {
+            "type": "string",
+            "enum": [
+              "build",
+              "noLazy",
+              "enabled"
+            ],
+            "default": "enabled",
+            "markdownDescription": "Determines how background indexing should prepare a target. Only used when Background Indexing is enabled. This option has no effect in Swift versions prior to 6.0.",
+            "enumDescriptions": [
+              "Build a target to prepare it",
+              "Prepare a target without generating object files but do not do lazy type checking and function body skipping",
+              "Prepare a target without generating object files and the like"
+            ],
+            "order": 4
+          },
           "swift.sourcekit-lsp.supported-languages": {
             "type": "array",
             "default": [
@@ -474,7 +479,7 @@
                 "cpp"
               ]
             },
-            "order": 4
+            "order": 5
           },
           "swift.sourcekit-lsp.trace.server": {
             "type": "string",
@@ -485,13 +490,13 @@
               "verbose"
             ],
             "markdownDescription": "Controls logging the communication between VS Code and the SourceKit-LSP language server. Logs can be viewed in Output > SourceKit Language Server.",
-            "order": 5
+            "order": 6
           },
           "swift.sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable SourceKit-LSP",
-            "order": 6
+            "order": 7
           },
           "sourcekit-lsp.serverPath": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -437,28 +437,6 @@
             "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `['--log-level', 'debug']`",
             "order": 2
           },
-          "swift.sourcekit-lsp.backgroundIndexing": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Enable or disable background indexing. This option has no effect in Swift versions prior to 6.0.",
-            "order": 3
-          },
-          "swift.sourcekit-lsp.backgroundPreparationMode": {
-            "type": "string",
-            "enum": [
-              "build",
-              "noLazy",
-              "enabled"
-            ],
-            "default": "enabled",
-            "markdownDescription": "Determines how background indexing should prepare a target. Only used when Background Indexing is enabled. This option has no effect in Swift versions prior to 6.0.",
-            "enumDescriptions": [
-              "Build a target to prepare it",
-              "Prepare a target without generating object files but do not do lazy type checking and function body skipping",
-              "Prepare a target without generating object files and the like"
-            ],
-            "order": 4
-          },
           "swift.sourcekit-lsp.supported-languages": {
             "type": "array",
             "default": [
@@ -479,7 +457,13 @@
                 "cpp"
               ]
             },
-            "order": 5
+            "order": 3
+          },
+          "swift.sourcekit-lsp.backgroundIndexing": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "**Experimental**: Enable or disable background indexing. This option has no effect in Swift versions prior to 6.0.",
+            "order": 4
           },
           "swift.sourcekit-lsp.trace.server": {
             "type": "string",
@@ -490,36 +474,19 @@
               "verbose"
             ],
             "markdownDescription": "Controls logging the communication between VS Code and the SourceKit-LSP language server. Logs can be viewed in Output > SourceKit Language Server.",
-            "order": 6
+            "order": 5
           },
           "swift.sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable SourceKit-LSP",
-            "order": 7
-          },
-          "sourcekit-lsp.serverPath": {
-            "type": "string",
-            "markdownDescription": "The path of the `sourcekit-lsp` executable. The default is to look in the path where `swift` is found.",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.serverPath#` instead.",
-            "order": 1
-          },
-          "sourcekit-lsp.serverArguments": {
-            "type": "array",
-            "default": [],
-            "items": {
-              "type": "string"
-            },
-            "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `['--log-level', 'debug']`",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.serverArguments#` instead.",
-            "order": 2
+            "order": 6
           },
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Display Inlay Hints. Inlay Hints are variable annotations indicating their inferred type. They are only available if you are using Swift 5.6 or later.",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#editor.inlayHints.enabled#` instead.",
-            "order": 3
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#editor.inlayHints.enabled#` instead."
           },
           "sourcekit-lsp.support-c-cpp": {
             "type": "string",
@@ -535,8 +502,21 @@
               "Disable when C/C++ extension is active"
             ],
             "markdownDescription": "Add LSP functionality for C/C++ files. By default this is set to disable when the C/C++ extension is active.",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.supported-languages#` instead.",
-            "order": 5
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.supported-languages#` instead."
+          },
+          "sourcekit-lsp.serverPath": {
+            "type": "string",
+            "markdownDescription": "The path of the `sourcekit-lsp` executable. The default is to look in the path where `swift` is found.",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.serverPath#` instead."
+          },
+          "sourcekit-lsp.serverArguments": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `['--log-level', 'debug']`",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.serverArguments#` instead."
           },
           "sourcekit-lsp.trace.server": {
             "type": "string",
@@ -547,15 +527,13 @@
               "verbose"
             ],
             "markdownDescription": "Traces the communication between VS Code and the SourceKit-LSP language server.",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.trace.server#` instead.",
-            "order": 6
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.trace.server#` instead."
           },
           "sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable the running of SourceKit-LSP.",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.disable#` instead.",
-            "order": 7
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.disable#` instead."
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -309,6 +309,23 @@
             "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved. It is possible the background compilation will already be running when you attempt a compile yourself, so this is disabled by default.",
             "order": 10
           },
+          "swift.backgroundIndexing": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable or disable background indexing. This option will not work for Swift versions prior to 6.0.",
+            "order": 11
+          },
+          "swift.backgroundPreparationMode": {
+            "type": "string",
+            "enum": [
+              "build",
+              "noLazy",
+              "enabled"
+            ],
+            "default": "enabled",
+            "markdownDescription": "Determines how background indexing should prepare a target. This option will not work for Swift versions prior to 6.0. Possible values are:\n- `build`: Build a target to prepare it\n- `noLazy`: Prepare a target without generating object files but do not do lazy type checking and function body skipping\n- `enabled`: Prepare a target without generating object files and the like",
+            "order": 12
+          },
           "swift.actionAfterBuildError": {
             "type": "string",
             "default": "Focus Terminal",
@@ -322,32 +339,32 @@
               "Focus on Build Task Terminal"
             ],
             "markdownDescription": "Action after a Build task generates errors.",
-            "order": 11
+            "order": 13
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
             "markdownDescription": "The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--scratch-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in the workspace.\n\nYou can use absolute path for directory or the relative path, which will use the workspace path as a base. Note that VS Code does not respect tildes (`~`) in paths which represents user home folder under *nix systems.",
-            "order": 12
+            "order": 14
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 13
+            "order": 15
           },
           "swift.warnAboutSymlinkCreation": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
             "scope": "application",
-            "order": 14
+            "order": 16
           },
           "swift.enableTerminalEnvironment": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Controls whether or not the extension will contribute environment variables defined in `Swift: Environment Variables` to the integrated terminal. If this is set to `true` and a custom `Swift: Path` is also set then the swift path is appended to the terminal's `PATH`.",
-            "order": 15
+            "order": 17
           }
         }
       },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -231,12 +231,6 @@ const configuration = {
             .getConfiguration("swift.sourcekit-lsp")
             .get("backgroundIndexing", false);
     },
-    /** background preparation mode */
-    get backgroundPreparationMode(): "build" | "noLazy" | "enabled" {
-        return vscode.workspace
-            .getConfiguration("swift.sourcekit-lsp")
-            .get("backgroundPreparationMode", "enabled");
-    },
     /** focus on problems view whenever there is a build error */
     get actionAfterBuildError(): ActionAfterBuildError {
         return vscode.workspace

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -227,12 +227,14 @@ const configuration = {
     },
     /** background indexing */
     get backgroundIndexing(): boolean {
-        return vscode.workspace.getConfiguration("swift").get("backgroundIndexing", false);
+        return vscode.workspace
+            .getConfiguration("swift.sourcekit-lsp")
+            .get("backgroundIndexing", false);
     },
     /** background preparation mode */
     get backgroundPreparationMode(): "build" | "noLazy" | "enabled" {
         return vscode.workspace
-            .getConfiguration("swift")
+            .getConfiguration("swift.sourcekit-lsp")
             .get("backgroundPreparationMode", "enabled");
     },
     /** focus on problems view whenever there is a build error */

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -225,6 +225,16 @@ const configuration = {
             .getConfiguration("swift")
             .get<boolean>("backgroundCompilation", false);
     },
+    /** background indexing */
+    get backgroundIndexing(): boolean {
+        return vscode.workspace.getConfiguration("swift").get("backgroundIndexing", false);
+    },
+    /** background preparation mode */
+    get backgroundPreparationMode(): "build" | "noLazy" | "enabled" {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get("backgroundPreparationMode", "enabled");
+    },
     /** focus on problems view whenever there is a build error */
     get actionAfterBuildError(): ActionAfterBuildError {
         return vscode.workspace

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,13 +98,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api | 
                         "Changing the Swift SDK path requires the project be reloaded."
                     );
                 }
-                // Restart the LSP if background indexing settings are changed.
-                if (
-                    event.affectsConfiguration("swift.backgroundIndexing") ||
-                    event.affectsConfiguration("swift.backgroundPreparationMode")
-                ) {
-                    workspaceContext.languageClientManager.restart();
-                }
             })
         );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,6 +98,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api | 
                         "Changing the Swift SDK path requires the project be reloaded."
                     );
                 }
+                // Restart the LSP if background indexing settings are changed.
+                if (
+                    event.affectsConfiguration("swift.backgroundIndexing") ||
+                    event.affectsConfiguration("swift.backgroundPreparationMode")
+                ) {
+                    workspaceContext.languageClientManager.restart();
+                }
             })
         );
 

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -585,6 +585,8 @@ export class LanguageClientManager {
                         "swift.debug": "swift.debug",
                     },
                 },
+                backgroundIndexing: configuration.backgroundIndexing,
+                backgroundPreparationMode: configuration.backgroundPreparationMode,
             },
         };
 

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -576,18 +576,7 @@ export class LanguageClientManager {
             // Avoid attempting to reinitialize multiple times. If we fail to initialize
             // we aren't doing anything different the second time and so will fail again.
             initializationFailedHandler: () => false,
-            initializationOptions: {
-                "workspace/peekDocuments": true, // workaround for client capability to handle `PeekDocumentsRequest`
-                "workspace/getReferenceDocument": true, // the client can handle URIs with scheme `sourcekit-lsp:`
-                "textDocument/codeLens": {
-                    supportedCommands: {
-                        "swift.run": "swift.run",
-                        "swift.debug": "swift.debug",
-                    },
-                },
-                backgroundIndexing: configuration.backgroundIndexing,
-                backgroundPreparationMode: configuration.backgroundPreparationMode,
-            },
+            initializationOptions: this.initializationOptions(),
         };
 
         return {
@@ -600,6 +589,30 @@ export class LanguageClientManager {
             errorHandler,
         };
     }
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    private initializationOptions(): any {
+        let options: any = {
+            "workspace/peekDocuments": true, // workaround for client capability to handle `PeekDocumentsRequest`
+            "workspace/getReferenceDocument": true, // the client can handle URIs with scheme `sourcekit-lsp:`
+            "textDocument/codeLens": {
+                supportedCommands: {
+                    "swift.run": "swift.run",
+                    "swift.debug": "swift.debug",
+                },
+            },
+        };
+
+        if (configuration.backgroundIndexing) {
+            options = {
+                ...options,
+                backgroundIndexing: configuration.backgroundIndexing,
+                backgroundPreparationMode: "enabled",
+            };
+        }
+        return options;
+    }
+    /* eslint-enable @typescript-eslint/no-explicit-any */
 
     private async startClient(
         client: langclient.LanguageClient,


### PR DESCRIPTION
Adds a setting that will send `backgroundIndexing: true` along with a `backgroundPreparationMode` in the SourceKit-LSP initialization request.

The server must be restarted when either of these settings are changed.

Issue: #987