### PR TITLE
Use unified test binary when computing coverage

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -69,6 +69,22 @@ export class TestingDebugConfigurationFactory {
         ).build();
     }
 
+    public static async testExecutableOutputPath(
+        ctx: FolderContext,
+        testKind: TestKind,
+        testLibrary: TestLibrary
+    ): Promise<string> {
+        return new TestingDebugConfigurationFactory(
+            ctx,
+            "",
+            testKind,
+            testLibrary,
+            [],
+            null,
+            true
+        ).testExecutableOutputPath();
+    }
+
     private constructor(
         private ctx: FolderContext,
         private fifoPipePath: string,


### PR DESCRIPTION
With the introduction of the new unified testing binary we need to supply it to lcov export instead of the .swift-testing binary.