### PR TITLE
Fix hanging build status in vscode 1.92

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -701,7 +701,7 @@ export class TestRunner {
         const subscriptions: vscode.Disposable[] = [];
         let buildExitCode = 0;
         const buildTask = vscode.tasks.onDidStartTask(e => {
-            if (e.execution.task.name === "Build All") {
+            if (e.execution.task.name === buildAllTask.name) {
                 const exec = e.execution.task.execution as SwiftExecution;
                 const didCloseBuildTask = exec.onDidClose(exitCode => {
                     buildExitCode = exitCode ?? 0;

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -76,7 +76,12 @@ export class SwiftBuildStatus implements vscode.Disposable {
                             done();
                         }
                     }),
-                    execution.onDidClose(done)
+                    execution.onDidClose(done),
+                    vscode.tasks.onDidEndTask(e => {
+                        if (e.execution.task === task) {
+                            done();
+                        }
+                    })
                 );
             });
         if (showBuildStatus === "progress" || showBuildStatus === "notification") {


### PR DESCRIPTION
Is hanging build status when debugging a test. The build task ends but the status keeps churning, never hiding itself. For some reason the execution's emitter never fires. For now putting this fix in to prevent the hang.