### PR TITLE
Create separate Build All Release task

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -682,20 +682,9 @@ export class TestRunner {
 
     /** Run test session inside debugger */
     async debugSession(token: vscode.CancellationToken, runState: TestRunnerTestRunState) {
-        const buildAllTask = await getBuildAllTask(this.folderContext);
+        const buildAllTask = await getBuildAllTask(this.folderContext, isRelease(this.testKind));
         if (!buildAllTask) {
             return;
-        }
-
-        if (isRelease(this.testKind)) {
-            buildAllTask.definition.args = [
-                ...buildAllTask.definition.args,
-                "-c",
-                "release",
-                "-Xswiftc",
-                "-enable-testing",
-            ];
-            buildAllTask.detail = `swift ${buildAllTask.definition.args.join(" ")}`;
         }
 
         const subscriptions: vscode.Disposable[] = [];


### PR DESCRIPTION
We were naively transforming the arguments of the returned Build All task to create one that would run a release version of Build All. Unfortunately the `task.execution` remained the same and so while upon inspection the task looked like it would run a release build it was not.

Create two separate versions of the Build All task, one for Debug and one for Release builds, and use the release version when building tests in release mode.