### PR TITLE
Use build description to check for unified testing binary

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -430,7 +430,6 @@ export class TestRunner {
                     fifoPipePath,
                     this.testKind,
                     this.testArgs.swiftTestArgs,
-                    new Date(),
                     true
                 );
 
@@ -700,8 +699,6 @@ export class TestRunner {
         });
         subscriptions.push(buildTask);
 
-        const buildStartTime = new Date();
-
         // Perform a build all before the tests are run. We want to avoid the "Debug Anyway" dialog
         // since choosing that with no prior build, when debugging swift-testing tests, will cause
         // the extension to start listening to the fifo pipe when no results will be produced,
@@ -729,7 +726,6 @@ export class TestRunner {
                         fifoPipePath,
                         this.testKind,
                         this.testArgs.swiftTestArgs,
-                        buildStartTime,
                         true
                     );
 


### PR DESCRIPTION
We were checking the `mtime` of the `<ProductName>.swift-testing` binary to determine if it was produced by the latest build. The issue with this is that when you run tests over and over without making any code changes the binary is never rewritten because it is already up to date.

Instead of checking the `mtime` of the .swift-testing binary in the build folder to determine if it was produced, use the build `description.json` and check the builtTestProducts list to see if the legacy `.swift-testing` binary was produced by the latest build.