### PR TITLE
Don't add "Build All - Release" task to list of provided tasks

### DIFF
--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -241,7 +241,7 @@ export async function getBuildAllTask(
             task.source === "swift"
     );
     if (!task) {
-        throw Error("Build All Task does not exist");
+        task = createBuildAllTask(folderContext, release);
     }
 
     return task;
@@ -446,9 +446,8 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
                 continue;
             }
 
-            // Create both debug and release Build All tasks.
+            // Create debug Build All task.
             tasks.push(createBuildAllTask(folderContext, false));
-            tasks.push(createBuildAllTask(folderContext, true));
 
             const executables = folderContext.swiftPackage.executableProducts;
             for (const executable of executables) {


### PR DESCRIPTION
With #1000 merged in, we are now showing the Release variant of the build all task in the list of provided tasks when running the "Run Task" command. We don't want that since only needed for debugging a test in release mode