### PR TITLE
Forward signal as exit code

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -706,7 +706,7 @@ export class TestRunner {
         await this.folderContext.taskQueue.queueOperation(new TaskOperation(buildAllTask));
 
         if (buildExitCode !== 0) {
-            throw new Error(`Build failed with exit code ${buildExitCode}`);
+            throw new Error(`${buildAllTask.name} failed with exit code ${buildExitCode}`);
         }
 
         const buildConfigs: Array<vscode.DebugConfiguration | undefined> = [];

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -110,7 +110,9 @@ export class SwiftPtyProcess implements SwiftProcess {
                 this.writeEmitter.fire(data);
             });
             this.spawnedProcess.onExit(event => {
-                if (typeof event.exitCode === "number") {
+                if (event.signal) {
+                    this.closeEmitter.fire(event.signal);
+                } else if (typeof event.exitCode === "number") {
                     this.closeEmitter.fire(event.exitCode);
                 } else {
                     this.closeEmitter.fire();


### PR DESCRIPTION
If the user hits ctrl+c during a task we want to treat that as an unsuccessful process execution and stop proceeding.

Forward the signal and ignore the exit code of a signal is present on process exit.

Issue: #1001