### PR TITLE
Fixup test w/ newer issue failed message

### DIFF
--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -228,7 +228,7 @@ suite("Test Explorer Suite", function () {
                 failed: [
                     {
                         test: "PackageTests.testRelease()",
-                        issues: ["Unconditionally failed", "Test was run in debug mode."],
+                        issues: ["Issue recorded", "Test was run in debug mode."],
                     },
                 ],
             });


### PR DESCRIPTION
`swift-testing` has updated the message it uses when recording an unconditional issue, as of:
https://github.com/swiftlang/swift-testing/commit/b7ef61e773292f5f28c02d9c269c44979123dcea