### PR TITLE
Add "Run Test Multiple Times"

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,16 @@
         "command": "swift.clearDiagnosticsCollection",
         "title": "Clear Diagnostics Collection",
         "category": "Swift"
+      },
+      {
+        "command": "swift.runTestsMultipleTimes",
+        "title": "Run Multiple Times...",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.runTestsUntilFailure",
+        "title": "Run Until Failure...",
+        "category": "Swift"
       }
     ],
     "configuration": [
@@ -598,6 +608,18 @@
       }
     ],
     "menus": {
+      "testing/item/context": [
+        {
+          "command": "swift.runTestsMultipleTimes",
+          "group": "testExtras",
+          "when": "testId"
+        },
+        {
+          "command": "swift.runTestsUntilFailure",
+          "group": "testExtras",
+          "when": "testId"
+        }
+      ],
       "commandPalette": [
         {
           "command": "swift.createNewProject",

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -41,7 +41,7 @@ export class TestExplorer {
     private onTestItemsDidChangeEmitter = new vscode.EventEmitter<vscode.TestController>();
     public onTestItemsDidChange: vscode.Event<vscode.TestController>;
 
-    private onDidCreateTestRunEmitter = new vscode.EventEmitter<TestRunProxy>();
+    public onDidCreateTestRunEmitter = new vscode.EventEmitter<TestRunProxy>();
     public onCreateTestRun: vscode.Event<TestRunProxy>;
 
     constructor(public folderContext: FolderContext) {


### PR DESCRIPTION
Adds two new items to the context menu when you right click a test in the test explorer:

- Run Multiple Times
- Run Until Failure

Selecting either of these promts with a text input where the user can input how many times they want to run the test(s).

If the user selected Run Until Failure the tests will be run a maximum number of times, stopping at the first iteration that produces a failure.

A current limitation in VS Code is if you have multiple tests selected in the Test Explorer (by shift or ctrl clicking them) only the first is passed to the command.

Issue: #832