### PR TITLE
Add New Swift File command

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,12 @@
         "category": "Swift"
       },
       {
+        "command": "swift.newFile",
+        "title": "Create New Swift File...",
+        "shortTitle": "Swift File",
+        "category": "Swift"
+      },
+      {
         "command": "swift.updateDependencies",
         "title": "Update Package Dependencies",
         "icon": "$(cloud-download)",
@@ -601,6 +607,10 @@
     ],
     "keybindings": [
       {
+        "command": "swift.newFile",
+        "key": "Alt+S Alt+N"
+      },
+      {
         "command": "swift.insertFunctionComment",
         "key": "Alt+Ctrl+/",
         "mac": "Alt+Cmd+/",
@@ -618,6 +628,19 @@
           "command": "swift.runTestsUntilFailure",
           "group": "testExtras",
           "when": "testId"
+        }
+      ],
+      "file/newFile": [
+        {
+          "command": "swift.newFile",
+          "group": "file"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "swift.newFile",
+          "group": "swift",
+          "when": "swift.isActivated"
         }
       ],
       "commandPalette": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -37,6 +37,7 @@ import { resetPackage } from "./commands/resetPackage";
 import { updateDependencies } from "./commands/dependencies/update";
 import { runPluginTask } from "./commands/runPluginTask";
 import { runTestMultipleTimes } from "./commands/testMultipleTimes";
+import { newSwiftFile } from "./commands/newFile";
 
 /**
  * References:
@@ -67,6 +68,7 @@ export function registerToolchainCommands(
  */
 export function register(ctx: WorkspaceContext): vscode.Disposable[] {
     return [
+        vscode.commands.registerCommand("swift.newFile", uri => newSwiftFile(uri)),
         vscode.commands.registerCommand("swift.resolveDependencies", () =>
             resolveDependencies(ctx)
         ),

--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as fs from "fs/promises";
+import * as path from "path";
+import * as vscode from "vscode";
+import { fileExists, pathExists } from "../utilities/filesystem";
+
+const extension = "swift";
+const defaultFileName = `Untitled.${extension}`;
+
+export async function newSwiftFile(
+    uri?: vscode.Uri,
+    isDirectory: (uri: vscode.Uri) => Promise<boolean> = async uri => {
+        return (await vscode.workspace.fs.stat(uri)).type === vscode.FileType.Directory;
+    }
+) {
+    if (uri) {
+        // Attempt to create the file at the given directory.
+        const dir = (await isDirectory(uri)) ? uri.fsPath : path.dirname(uri.fsPath);
+        const defaultName = path.join(dir, defaultFileName);
+        const givenPath = await vscode.window.showInputBox({
+            value: defaultName,
+            valueSelection: [dir.length + 1, defaultName.length - extension.length - 1],
+            prompt: "Enter a file path to be created",
+            validateInput: validatePathValid,
+        });
+        if (!givenPath) {
+            return;
+        }
+        const targetUri = vscode.Uri.file(givenPath);
+        try {
+            await fs.writeFile(targetUri.fsPath, "", "utf-8");
+            const document = await vscode.workspace.openTextDocument(targetUri);
+            await vscode.languages.setTextDocumentLanguage(document, "swift");
+            await vscode.window.showTextDocument(document);
+        } catch (err) {
+            vscode.window.showErrorMessage(`Failed to create ${targetUri.fsPath}`);
+        }
+    } else {
+        // If no path is supplied then open an untitled editor w/ Swift language type
+        const document = await vscode.workspace.openTextDocument({
+            language: "swift",
+        });
+        await vscode.window.showTextDocument(document);
+    }
+}
+
+async function validatePathValid(input: string) {
+    const inputPath = vscode.Uri.file(input).fsPath;
+    const filePathExists = await fileExists(inputPath);
+    if (filePathExists) {
+        return `Supplied path ${inputPath} already exists`;
+    }
+
+    const inputDir = path.dirname(inputPath);
+    const dirExists = await pathExists(inputDir);
+    if (!dirExists) {
+        return `Supplied directory ${inputDir} doesn't exist`;
+    }
+
+    return undefined;
+}

--- a/test/suite/commands/NewFile.test.ts
+++ b/test/suite/commands/NewFile.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -38,7 +38,9 @@ suite("NewFile Command Test Suite", () => {
         const folder = await TemporaryFolder.create();
         const file = path.join(folder.path, "MyFile.swift");
 
-        when(windowMock.showInputBox(anything())).thenReturn(Promise.resolve(file));
+        when(windowMock.showSaveDialog(anything())).thenReturn(
+            Promise.resolve(vscode.Uri.file(file))
+        );
 
         await newSwiftFile(vscode.Uri.file(folder.path), () => Promise.resolve(true));
 

--- a/test/suite/commands/NewFile.test.ts
+++ b/test/suite/commands/NewFile.test.ts
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2023 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// import * as assert from "assert";
+import * as vscode from "vscode";
+import * as assert from "assert";
+import * as path from "path";
+import { anything, deepEqual, verify, when } from "ts-mockito";
+import { newSwiftFile } from "../../../src/commands/newFile";
+import { mockNamespace } from "../../unit-tests/MockUtils";
+import { TemporaryFolder } from "../../../src/utilities/tempFolder";
+import { fileExists } from "../../../src/utilities/filesystem";
+
+suite("NewFile Command Test Suite", () => {
+    const workspaceMock = mockNamespace(vscode, "workspace");
+    const windowMock = mockNamespace(vscode, "window");
+    const languagesMock = mockNamespace(vscode, "languages");
+
+    test("Creates a blank file if no URI is provided", async () => {
+        await newSwiftFile(undefined);
+
+        verify(workspaceMock.openTextDocument(deepEqual({ language: "swift" }))).once();
+        verify(windowMock.showTextDocument(anything())).once();
+    });
+
+    test("Creates file at provided directory", async () => {
+        const folder = await TemporaryFolder.create();
+        const file = path.join(folder.path, "MyFile.swift");
+
+        when(windowMock.showInputBox(anything())).thenReturn(Promise.resolve(file));
+
+        await newSwiftFile(vscode.Uri.file(folder.path), () => Promise.resolve(true));
+
+        assert.ok(await fileExists(file));
+
+        verify(workspaceMock.openTextDocument(anything())).once();
+        verify(languagesMock.setTextDocumentLanguage(anything(), "swift")).once();
+        verify(windowMock.showTextDocument(anything())).once();
+    });
+});


### PR DESCRIPTION
Add a command that creates a new Swift File. Add it as an option to the File > New File picker. Add it as an option when right clicking a folder in a Swift project context. Add a keybinding of Opt+S Opt+N (or Alt+S Alt+N) to create a new Swift file.