### PR TITLE
Add swift.testBuildArguments Setting

### DIFF
--- a/assets/test/.vscode/settings.json
+++ b/assets/test/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "swift.disableAutoResolve": true
+    "swift.disableAutoResolve": true,
+    "swift.testBuildArguments": [
+        "-Xswiftc",
+        "-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
+    ]
 }

--- a/assets/test/.vscode/settings.json
+++ b/assets/test/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "swift.disableAutoResolve": true,
-    "swift.testBuildArguments": [
+    "swift.additionalTestArguments": [
         "-Xswiftc",
         "-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
     ]

--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -2,7 +2,11 @@ import PackageLib
 import XCTest
 
 final class PassingXCTestSuite: XCTestCase {
-  func testPassing() throws {}
+  func testPassing() throws {
+    #if !TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING
+    XCTFail("Expected TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING to be set at compilation")
+    #endif
+  }
 }
 
 // Should not run when PassingXCTestSuite is run.
@@ -43,7 +47,11 @@ import Testing
 
 @Test func topLevelTestPassing() {
   print("A print statement in a test.")
+  #if !TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING
+    Issue.record("Expected TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING to be set at compilation")
+  #endif
 }
+
 @Test func topLevelTestFailing() {
   #expect(1 == 2)
 }

--- a/package.json
+++ b/package.json
@@ -226,8 +226,7 @@
           "swift.path": {
             "type": "string",
             "default": "",
-            "markdownDescription": "Override the default path of the folder containing the Swift executables. The default is to look in the `PATH` environment variable. This path is also used to search for other executables used by the extension like `sourcekit-lsp` and `lldb`.",
-            "order": 1
+            "markdownDescription": "Override the default path of the folder containing the Swift executables. The default is to look in the `PATH` environment variable. This path is also used to search for other executables used by the extension like `sourcekit-lsp` and `lldb`."
           },
           "swift.buildArguments": {
             "type": "array",
@@ -235,8 +234,16 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Additional arguments to pass to `swift build`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task.",
-            "order": 2
+            "markdownDescription": "Additional arguments to pass to `swift build`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task."
+          },
+          "swift.testBuildArguments": {
+            "type": "array",
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "markdownDescription": "Additional arguments to pass to the `swift test` or `swift build` commands used when building and running tests from within VS Code.",
+            "scope": "machine-overridable"
           },
           "swift.testEnvironmentVariables": {
             "type": "object",
@@ -247,8 +254,7 @@
             },
             "default": {},
             "markdownDescription": "Environment variables to set when running tests. To set environment variables when debugging an application you should edit the `env` field in the relevant `launch.json` configuration.",
-            "scope": "machine-overridable",
-            "order": 3
+            "scope": "machine-overridable"
           },
           "swift.sanitizer": {
             "type": "string",
@@ -259,29 +265,25 @@
               "address"
             ],
             "markdownDescription": "Runtime [sanitizer instrumentation](https://www.swift.org/documentation/server/guides/llvm-sanitizers.html).",
-            "scope": "machine-overridable",
-            "order": 4
+            "scope": "machine-overridable"
           },
           "swift.searchSubfoldersForPackages": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Search sub-folders of workspace folder for Swift Packages at start up.",
-            "scope": "machine-overridable",
-            "order": 5
+            "scope": "machine-overridable"
           },
           "swift.autoGenerateLaunchConfigurations": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "When loading a `Package.swift`, auto-generate `launch.json` configurations for running any executables.",
-            "scope": "machine-overridable",
-            "order": 6
+            "scope": "machine-overridable"
           },
           "swift.disableAutoResolve": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable automatic running of `swift package resolve` whenever the `Package.swift` or `Package.resolve` files are updated. This will also disable searching for command plugins and the initial test discovery process.",
-            "scope": "machine-overridable",
-            "order": 7
+            "scope": "machine-overridable"
           },
           "swift.diagnosticsCollection": {
             "type": "string",
@@ -300,8 +302,7 @@
               "When merging diagnostics, give precedence to diagnostics from `swiftc`.",
               "When merging diagnostics, give precedence to diagnostics from `SourceKit`.",
               "Keep diagnostics from all providers."
-            ],
-            "order": 8
+            ]
           },
           "swift.diagnosticsStyle": {
             "type": "string",
@@ -316,14 +317,12 @@
               "Use whichever diagnostics style `swiftc` produces by default.",
               "Use the `llvm` diagnostic style. This allows the parsing of \"notes\".",
               "Use the `swift` diagnostic style. This means that \"notes\" will not be parsed. This option has no effect in Swift versions prior to 5.10."
-            ],
-            "order": 9
+            ]
           },
           "swift.backgroundCompilation": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved. It is possible the background compilation will already be running when you attempt a compile yourself, so this is disabled by default.",
-            "order": 10
+            "markdownDescription": "**Experimental**: Run `swift build` in the background whenever a file is saved. It is possible the background compilation will already be running when you attempt a compile yourself, so this is disabled by default."
           },
           "swift.actionAfterBuildError": {
             "type": "string",
@@ -337,33 +336,28 @@
               "Focus on Problems View",
               "Focus on Build Task Terminal"
             ],
-            "markdownDescription": "Action after a Build task generates errors.",
-            "order": 11
+            "markdownDescription": "Action after a Build task generates errors."
           },
           "swift.buildPath": {
             "type": "string",
             "default": "",
-            "markdownDescription": "The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--scratch-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in the workspace.\n\nYou can use absolute path for directory or the relative path, which will use the workspace path as a base. Note that VS Code does not respect tildes (`~`) in paths which represents user home folder under *nix systems.",
-            "order": 12
+            "markdownDescription": "The path to a directory that will be used for build artifacts. This path will be added to all swift package manager commands that are executed by vscode-swift extension via `--scratch-path` option. When no value provided - nothing gets passed to swift package manager and it will use its default value of `.build` folder in the workspace.\n\nYou can use absolute path for directory or the relative path, which will use the workspace path as a base. Note that VS Code does not respect tildes (`~`) in paths which represents user home folder under *nix systems."
           },
           "swift.disableSwiftPackageManagerIntegration": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer.",
-            "order": 13
+            "markdownDescription": "Disables automated Build Tasks, Package Dependency view, Launch configuration generation and TestExplorer."
           },
           "swift.warnAboutSymlinkCreation": {
             "type": "boolean",
             "default": true,
             "markdownDescription": "Controls whether or not the extension will warn about being unable to create symlinks. (Windows only)",
-            "scope": "application",
-            "order": 14
+            "scope": "application"
           },
           "swift.enableTerminalEnvironment": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "Controls whether or not the extension will contribute environment variables defined in `Swift: Environment Variables` to the integrated terminal. If this is set to `true` and a custom `Swift: Path` is also set then the swift path is appended to the terminal's `PATH`.",
-            "order": 15
+            "markdownDescription": "Controls whether or not the extension will contribute environment variables defined in `Swift: Environment Variables` to the integrated terminal. If this is set to `true` and a custom `Swift: Path` is also set then the swift path is appended to the terminal's `PATH`."
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -234,9 +234,9 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Additional arguments to pass to `swift build`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task."
+            "markdownDescription": "Additional arguments to pass to `swift` commands such as `swift build`, `swift package`, `swift test`, etc... Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task."
           },
-          "swift.testBuildArguments": {
+          "swift.additionalTestArguments": {
             "type": "array",
             "default": [],
             "items": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -58,7 +58,7 @@ export interface FolderConfiguration {
     /** Environment variables to set when running tests */
     readonly testEnvironmentVariables: { [key: string]: string };
     /** Extra arguments to set when building tests */
-    readonly testBuildArguments: string[];
+    readonly additionalTestArguments: string[];
     /** search sub-folder of workspace folder for Swift Packages */
     readonly searchSubfoldersForPackages: boolean;
     /** auto-generate launch.json configurations */
@@ -122,10 +122,10 @@ const configuration = {
                     .get<{ [key: string]: string }>("testEnvironmentVariables", {});
             },
             /** Extra arguments to pass to swift test and swift build when running and debugging tests. */
-            get testBuildArguments(): string[] {
+            get additionalTestArguments(): string[] {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
-                    .get<string[]>("testBuildArguments", []);
+                    .get<string[]>("additionalTestArguments", []);
             },
             /** auto-generate launch.json configurations */
             get autoGenerateLaunchConfigurations(): boolean {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,6 +57,8 @@ export interface DebuggerConfiguration {
 export interface FolderConfiguration {
     /** Environment variables to set when running tests */
     readonly testEnvironmentVariables: { [key: string]: string };
+    /** Extra arguments to set when building tests */
+    readonly testBuildArguments: string[];
     /** search sub-folder of workspace folder for Swift Packages */
     readonly searchSubfoldersForPackages: boolean;
     /** auto-generate launch.json configurations */
@@ -118,6 +120,12 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<{ [key: string]: string }>("testEnvironmentVariables", {});
+            },
+            /** Extra arguments to pass to swift test and swift build when running and debugging tests. */
+            get testBuildArguments(): string[] {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<string[]>("testBuildArguments", []);
             },
             /** auto-generate launch.json configurations */
             get autoGenerateLaunchConfigurations(): boolean {

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -25,7 +25,7 @@ import { BuildFlags } from "../toolchain/BuildFlags";
 import { TestLibrary } from "../TestExplorer/TestRunner";
 import { DisposableFileCollection } from "../utilities/tempFolder";
 import { TargetType } from "../SwiftPackage";
-import { TestingDebugConfigurationFactory } from "../debugger/buildConfig";
+import { TestingConfigurationFactory } from "../debugger/buildConfig";
 import { TestKind } from "../TestExplorer/TestKind";
 
 interface CodeCovFile {
@@ -144,7 +144,7 @@ export class TestCoverage {
     private async exportProfdata(types: TestLibrary[], mergedProfileFile: string): Promise<Buffer> {
         const coveredBinaries = new Set<string>();
         if (types.includes(TestLibrary.xctest)) {
-            let xcTestBinary = await TestingDebugConfigurationFactory.testExecutableOutputPath(
+            let xcTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
                 this.folderContext,
                 TestKind.coverage,
                 TestLibrary.xctest
@@ -156,7 +156,7 @@ export class TestCoverage {
         }
 
         if (types.includes(TestLibrary.swiftTesting)) {
-            const swiftTestBinary = await TestingDebugConfigurationFactory.testExecutableOutputPath(
+            const swiftTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
                 this.folderContext,
                 TestKind.coverage,
                 TestLibrary.swiftTesting

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -61,7 +61,7 @@ export class BuildConfigurationFactory {
             if (this.isTestBuild) {
                 additionalArgs = [
                     ...additionalArgs,
-                    ...configuration.folder(this.ctx.workspaceFolder).testBuildArguments,
+                    ...configuration.folder(this.ctx.workspaceFolder).additionalTestArguments,
                 ];
             }
         }
@@ -470,7 +470,10 @@ export class TestingConfigurationFactory {
         }
 
         // Add in any user specified test arguments.
-        result = [...result, ...configuration.folder(this.ctx.workspaceFolder).testBuildArguments];
+        result = [
+            ...result,
+            ...configuration.folder(this.ctx.workspaceFolder).additionalTestArguments,
+        ];
 
         // `link.exe` doesn't support duplicate weak symbols, and lld-link in an effort to
         // match link.exe also doesn't support them by default. We can use `-lldmingw` to get

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -24,15 +24,86 @@ import { DebugAdapter } from "./debugAdapter";
 import { TargetType } from "../SwiftPackage";
 import { Version } from "../utilities/version";
 import { TestLibrary } from "../TestExplorer/TestRunner";
-import { buildOptions } from "../tasks/SwiftTaskProvider";
 import { TestKind, isDebugging, isRelease } from "../TestExplorer/TestKind";
+import { buildOptions } from "../tasks/SwiftTaskProvider";
+
+export class BuildConfigurationFactory {
+    public static buildAll(
+        ctx: FolderContext,
+        isTestBuild: boolean,
+        isRelease: boolean
+    ): vscode.DebugConfiguration {
+        return new BuildConfigurationFactory(ctx, isTestBuild, isRelease).build();
+    }
+
+    private constructor(
+        private ctx: FolderContext,
+        private isTestBuild: boolean,
+        private isRelease: boolean
+    ) {}
+
+    private build(): vscode.DebugConfiguration {
+        let additionalArgs = buildOptions(this.ctx.workspaceContext.toolchain);
+        if (this.ctx.swiftPackage.getTargets(TargetType.test).length > 0) {
+            additionalArgs.push(...this.testDiscoveryFlag(this.ctx));
+        }
+
+        if (this.isRelease) {
+            additionalArgs = [...additionalArgs, "-c", "release"];
+        }
+
+        // don't build tests for iOS etc as they don't compile
+        if (this.ctx.workspaceContext.toolchain.buildFlags.getDarwinTarget() === undefined) {
+            additionalArgs = ["--build-tests", ...additionalArgs];
+            if (this.isRelease) {
+                additionalArgs = [...additionalArgs, "-Xswiftc", "-enable-testing"];
+            }
+            if (this.isTestBuild) {
+                additionalArgs = [
+                    ...additionalArgs,
+                    ...configuration.folder(this.ctx.workspaceFolder).testBuildArguments,
+                ];
+            }
+        }
+
+        return {
+            ...this.baseConfig,
+            program: "swift",
+            args: ["build", ...additionalArgs],
+            env: {},
+        };
+    }
+
+    /** flag for enabling test discovery */
+    private testDiscoveryFlag(ctx: FolderContext): string[] {
+        // Test discovery is only available in SwiftPM 5.1 and later.
+        if (ctx.workspaceContext.swiftVersion.isLessThan(new Version(5, 1, 0))) {
+            return [];
+        }
+        // Test discovery is always enabled on Darwin.
+        if (process.platform !== "darwin") {
+            const hasLinuxMain = ctx.linuxMain.exists;
+            const testDiscoveryByDefault = ctx.workspaceContext.swiftVersion.isGreaterThanOrEqual(
+                new Version(5, 4, 0)
+            );
+            if (hasLinuxMain || !testDiscoveryByDefault) {
+                return ["--enable-test-discovery"];
+            }
+        }
+        return [];
+    }
+
+    private get baseConfig() {
+        return getBaseConfig(this.ctx, true);
+    }
+}
 
 /**
  * Creates `vscode.DebugConfiguration`s for different combinations of
  * testing library, test kind and platform. Use the static `swiftTestingConfig`
  * and `xcTestConfig` functions to create
  */
-export class TestingDebugConfigurationFactory {
+export class TestingConfigurationFactory {
     public static async swiftTestingConfig(
         ctx: FolderContext,
         fifoPipePath: string,
@@ -40,7 +111,7 @@ export class TestingDebugConfigurationFactory {
         testList: string[],
         expandEnvVariables = false
     ): Promise<vscode.DebugConfiguration | null> {
-        return new TestingDebugConfigurationFactory(
+        return new TestingConfigurationFactory(
             ctx,
             fifoPipePath,
             testKind,
@@ -56,7 +127,7 @@ export class TestingDebugConfigurationFactory {
         testList: string[],
         expandEnvVariables = false
     ): Promise<vscode.DebugConfiguration | null> {
-        return new TestingDebugConfigurationFactory(
+        return new TestingConfigurationFactory(
             ctx,
             "",
             testKind,
@@ -71,7 +142,7 @@ export class TestingDebugConfigurationFactory {
         testKind: TestKind,
         testLibrary: TestLibrary
     ): Promise<string> {
-        return new TestingDebugConfigurationFactory(
+        return new TestingConfigurationFactory(
             ctx,
             "",
             testKind,
@@ -397,6 +468,10 @@ export class TestingDebugConfigurationFactory {
         if (isRelease(this.testKind)) {
             result = [...result, "-c", "release", "-Xswiftc", "-enable-testing"];
         }
+
+        // Add in any user specified test arguments.
+        result = [...result, ...configuration.folder(this.ctx.workspaceFolder).testBuildArguments];
+
         // `link.exe` doesn't support duplicate weak symbols, and lld-link in an effort to
         // match link.exe also doesn't support them by default. We can use `-lldmingw` to get
         // lld-link to allow duplicate weak symbols, but that also changes its library search
@@ -537,22 +612,26 @@ export class TestingDebugConfigurationFactory {
     }
 
     private get baseConfig() {
-        const { folder, nameSuffix } = getFolderAndNameSuffix(this.ctx, this.expandEnvVariables);
-        return {
-            type: DebugAdapter.adapterName,
-            request: "launch",
-            sourceLanguages: ["swift"],
-            name: `Test ${this.ctx.swiftPackage.name}`,
-            cwd: folder,
-            args: [],
-            preLaunchTask: `swift: Build All${nameSuffix}`,
-            terminal: "console",
-        };
+        return getBaseConfig(this.ctx, this.expandEnvVariables);
     }
 
     private get hasTestTarget(): boolean {
         return this.ctx.swiftPackage.getTargets(TargetType.test).length > 0;
     }
+}
+
+function getBaseConfig(ctx: FolderContext, expandEnvVariables: boolean) {
+    const { folder, nameSuffix } = getFolderAndNameSuffix(ctx, expandEnvVariables);
+    return {
+        type: DebugAdapter.adapterName,
+        request: "launch",
+        sourceLanguages: ["swift"],
+        name: `Test ${ctx.swiftPackage.name}`,
+        cwd: folder,
+        args: [],
+        preLaunchTask: `swift: Build All${nameSuffix}`,
+        terminal: "console",
+    };
 }
 
 export function getFolderAndNameSuffix(

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -45,7 +45,7 @@ suite("WorkspaceContext Test Suite", () => {
             await workspaceContext?.addPackageFolder(testAssetUri("package2"), workspaceFolder);
             assert.strictEqual(count, 1);
             observer?.dispose();
-        }).timeout(5000);
+        }).timeout(15000);
     });
 
     suite("Tasks", async function () {

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -461,7 +461,7 @@ suite("Test Explorer Suite", function () {
                                         text: "Expectation failed: (arg → 2) != 2",
                                     })}`,
                                 ],
-                                test: "PackageTests.parameterizedTest(_:)/PackageTests.swift:51:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [50])])",
+                                test: "PackageTests.parameterizedTest(_:)/PackageTests.swift:59:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [50])])",
                             },
                             {
                                 issues: [],

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -450,8 +450,8 @@ suite("Test Explorer Suite", function () {
 
                     assertTestResults(testRun, {
                         passed: [
-                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:51:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [49])])",
-                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:51:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [51])])",
+                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:59:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [49])])",
+                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:59:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [51])])",
                         ],
                         failed: [
                             {


### PR DESCRIPTION
Adds a new setting that allows users to specify extra arguments when running `swift test` and `swift build --build-tests` during a test run from inside VS Code.

For example users could set `swift.testBuildArguments: ["-Xswiftc", "-DTEST"]` to enable code guarded by an `#if TEST` compiler directive.

This patch required reworking how we do a build all before starting a debug session since using the premade Build All tasks do not allow for dynamically customizing arguments.