### PR TITLE
Include all files under src in coverage report

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -59,6 +59,7 @@ module.exports = defineConfig({
         // you can specify additional test configurations, too
     ],
     coverage: {
+        includeAll: true,
         include: ["**/src/**"],
         reporter: ["text", "html"],
     },


### PR DESCRIPTION
The current behaviour will not include files with 0% coverage.
Address this by adding the correct flag.

Issue: swiftlang#1021