### PR TITLE
Migrate to upstream `workspace/textDocumentContent`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "lcov-parse": "^1.0.0",
         "plist": "^3.1.0",
-        "vscode-languageclient": "^9.0.1",
+        "vscode-languageclient": "^10.0.0-next.13",
         "xml2js": "^0.6.2"
       },
       "devDependencies": {
@@ -955,10 +955,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+      "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5246,7 +5247,8 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -5293,58 +5295,67 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.6.tgz",
+      "integrity": "sha512-KCSvUNsFiVciG9iqjJKBZOd66CN3ZKohDlYRmoOi+pd8l15MFLZ8wRG4c+wuzePGba/8WcCG2TM+C/GVlvuaeA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.0.0-next.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0-next.13.tgz",
+      "integrity": "sha512-KLsOMJoYpkk36PIgcOjyZ4AekOfzp4kdWdRRbVKeVvSIrwrn/4RSZr0NlD6EvUBBJSsJW4WDrYY7Y3znkqa6+w==",
+      "license": "MIT",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^9.0.3",
+        "semver": "^7.6.0",
+        "vscode-languageserver-protocol": "3.17.6-next.11"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.91.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.17.6-next.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.6-next.11.tgz",
+      "integrity": "sha512-GeJxEp1TiLsp79f8WG5n10wLViXfgFKb99hU9K8m7KDWM95/QFEqWkm79f9LVm54tUK74I91a9EeiQLCS/FABQ==",
+      "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0-next.6",
+        "vscode-languageserver-types": "3.17.6-next.5"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+      "version": "3.17.6-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.5.tgz",
+      "integrity": "sha512-QFmf3Yl1tCgUQfA77N9Me/LXldJXkIVypQbty2rJ1DNHQkC+iwvm4Z2tXg9czSwlhvv0pD4pbF5mT7WhAglolw==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6099,9 +6110,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.39.tgz",
-      "integrity": "sha512-nPwTRDKUctxw3di5b4TfT3I0sWDiWoPQCZjXhvdkINntwr8lcoVCKsTgnXeRubKIlfnV+eN/HYk6Jb40tbcEAQ==",
+      "version": "18.19.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.45.tgz",
+      "integrity": "sha512-VZxPKNNhjKmaC1SUYowuXSRSMGyQGmQjvvA1xE4QZ0xce2kLtEhPDS+kqpCPBZYgqblCLQ2DAjSzmgCM5auvhA==",
       "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
@@ -9260,18 +9271,18 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
+      "version": "9.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.6.tgz",
+      "integrity": "sha512-KCSvUNsFiVciG9iqjJKBZOd66CN3ZKohDlYRmoOi+pd8l15MFLZ8wRG4c+wuzePGba/8WcCG2TM+C/GVlvuaeA=="
     },
     "vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.0.0-next.13",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0-next.13.tgz",
+      "integrity": "sha512-KLsOMJoYpkk36PIgcOjyZ4AekOfzp4kdWdRRbVKeVvSIrwrn/4RSZr0NlD6EvUBBJSsJW4WDrYY7Y3znkqa6+w==",
       "requires": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^9.0.3",
+        "semver": "^7.6.0",
+        "vscode-languageserver-protocol": "3.17.6-next.11"
       },
       "dependencies": {
         "brace-expansion": {
@@ -9283,9 +9294,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "9.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+          "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
@@ -9293,18 +9304,18 @@
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.17.6-next.11",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.6-next.11.tgz",
+      "integrity": "sha512-GeJxEp1TiLsp79f8WG5n10wLViXfgFKb99hU9K8m7KDWM95/QFEqWkm79f9LVm54tUK74I91a9EeiQLCS/FABQ==",
       "requires": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0-next.6",
+        "vscode-languageserver-types": "3.17.6-next.5"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+      "version": "3.17.6-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.5.tgz",
+      "integrity": "sha512-QFmf3Yl1tCgUQfA77N9Me/LXldJXkIVypQbty2rJ1DNHQkC+iwvm4Z2tXg9czSwlhvv0pD4pbF5mT7WhAglolw=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1273,7 +1273,7 @@
   "dependencies": {
     "lcov-parse": "^1.0.0",
     "plist": "^3.1.0",
-    "vscode-languageclient": "^9.0.1",
+    "vscode-languageclient": "^10.0.0-next.13",
     "xml2js": "^0.6.2"
   }
 }

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -21,7 +21,7 @@ import {
 } from "../sourcekit-lsp/lspExtensions";
 import { InitializeResult, RequestType } from "vscode-languageclient/node";
 import { SwiftPackage, TargetType } from "../SwiftPackage";
-import { Converter } from "vscode-languageclient/lib/common/protocolConverter";
+import { Converter } from "vscode-languageclient/$test/common/protocolConverter";
 
 interface ILanguageClient {
     get initializeResult(): InitializeResult | undefined;

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -581,13 +581,19 @@ export class LanguageClientManager {
             initializationOptions: this.initializationOptions(),
         };
 
+        const client = new langclient.LanguageClient(
+            "swift.sourcekit-lsp",
+            "SourceKit Language Server",
+            serverOptions,
+            clientOptions
+        );
+
+        // TODO: Remove once LSP 3.18 is official (we currently need this for
+        // the proposed `workspace/textDocumentContent` API)
+        client.registerProposedFeatures();
+
         return {
-            client: new langclient.LanguageClient(
-                "swift.sourcekit-lsp",
-                "SourceKit Language Server",
-                serverOptions,
-                clientOptions
-            ),
+            client,
             errorHandler,
         };
     }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -658,9 +658,15 @@ export class LanguageClientManager {
                     this.legacyInlayHints = activateLegacyInlayHints(client);
                 }
 
+                // TODO: This may have to be adjusted to the version
+                // https://github.com/swiftlang/sourcekit-lsp/pull/1639
+                // is merged to
+                if (this.workspaceContext.swiftVersion.isLessThan(new Version(6, 1, 0))) {
+                    this.legacyGetReferenceDocument = activateLegacyGetReferenceDocument(client);
+                    this.workspaceContext.subscriptions.push(this.legacyGetReferenceDocument);
+                }
+
                 this.peekDocuments = activatePeekDocuments(client);
-                this.legacyGetReferenceDocument = activateLegacyGetReferenceDocument(client);
-                this.workspaceContext.subscriptions.push(this.legacyGetReferenceDocument);
             })
             .catch(reason => {
                 this.workspaceContext.outputChannel.log(`${reason}`);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -29,7 +29,7 @@ import { DiagnosticsManager } from "../DiagnosticsManager";
 import { LSPLogger, LSPOutputChannel } from "./LSPOutputChannel";
 import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
 import { promptForDiagnostics } from "../commands/captureDiagnostics";
-import { activateGetReferenceDocument } from "./getReferenceDocument";
+import { activateLegacyGetReferenceDocument } from "./getReferenceDocument";
 
 interface SourceKitLogMessageParams extends langclient.LogMessageParams {
     logName?: string;
@@ -113,7 +113,7 @@ export class LanguageClientManager {
     private cancellationToken?: vscode.CancellationTokenSource;
     private legacyInlayHints?: vscode.Disposable;
     private peekDocuments?: vscode.Disposable;
-    private getReferenceDocument?: vscode.Disposable;
+    private legacyGetReferenceDocument?: vscode.Disposable;
     private restartedPromise?: Promise<void>;
     private currentWorkspaceFolder?: vscode.Uri;
     private waitingOnRestartCount: number;
@@ -251,7 +251,7 @@ export class LanguageClientManager {
         this.cancellationToken?.dispose();
         this.legacyInlayHints?.dispose();
         this.peekDocuments?.dispose();
-        this.getReferenceDocument?.dispose();
+        this.legacyGetReferenceDocument?.dispose();
         this.subscriptions.forEach(item => item.dispose());
         this.languageClient?.stop();
         this.namedOutputChannels.forEach(channel => channel.dispose());
@@ -402,8 +402,8 @@ export class LanguageClientManager {
         this.legacyInlayHints = undefined;
         this.peekDocuments?.dispose();
         this.peekDocuments = undefined;
-        this.getReferenceDocument?.dispose();
-        this.getReferenceDocument = undefined;
+        this.legacyGetReferenceDocument?.dispose();
+        this.legacyGetReferenceDocument = undefined;
         if (client) {
             this.cancellationToken?.cancel();
             this.cancellationToken?.dispose();
@@ -659,8 +659,8 @@ export class LanguageClientManager {
                 }
 
                 this.peekDocuments = activatePeekDocuments(client);
-                this.getReferenceDocument = activateGetReferenceDocument(client);
-                this.workspaceContext.subscriptions.push(this.getReferenceDocument);
+                this.legacyGetReferenceDocument = activateLegacyGetReferenceDocument(client);
+                this.workspaceContext.subscriptions.push(this.legacyGetReferenceDocument);
             })
             .catch(reason => {
                 this.workspaceContext.outputChannel.log(`${reason}`);

--- a/src/sourcekit-lsp/getReferenceDocument.ts
+++ b/src/sourcekit-lsp/getReferenceDocument.ts
@@ -14,18 +14,27 @@
 
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
-import { GetReferenceDocumentParams, GetReferenceDocumentRequest } from "./lspExtensions";
+import {
+    LegacyGetReferenceDocumentParams,
+    LegacyGetReferenceDocumentRequest,
+} from "./lspExtensions";
 
-export function activateGetReferenceDocument(client: langclient.LanguageClient): vscode.Disposable {
+export function activateLegacyGetReferenceDocument(
+    client: langclient.LanguageClient
+): vscode.Disposable {
     const getReferenceDocument = vscode.workspace.registerTextDocumentContentProvider(
         "sourcekit-lsp",
         {
             provideTextDocumentContent: async (uri, token) => {
-                const params: GetReferenceDocumentParams = {
+                const params: LegacyGetReferenceDocumentParams = {
                     uri: client.code2ProtocolConverter.asUri(uri),
                 };
 
-                const result = await client.sendRequest(GetReferenceDocumentRequest, params, token);
+                const result = await client.sendRequest(
+                    LegacyGetReferenceDocumentRequest,
+                    params,
+                    token
+                );
 
                 if (result) {
                     return result.content;

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -57,7 +57,7 @@ export const PeekDocumentsRequest = new langclient.RequestType<
 >("workspace/peekDocuments");
 
 // Get Reference Document
-export interface GetReferenceDocumentParams {
+export interface LegacyGetReferenceDocumentParams {
     /**
      * The `DocumentUri` of the custom scheme url for which content is required
      */
@@ -67,7 +67,7 @@ export interface GetReferenceDocumentParams {
 /**
  * Response containing `content` of `GetReferenceDocumentRequest`
  */
-export interface GetReferenceDocumentResult {
+export interface LegacyGetReferenceDocumentResult {
     content: string;
 }
 
@@ -75,9 +75,9 @@ export interface GetReferenceDocumentResult {
  * Request from the client to the server asking for contents of a URI having a custom scheme
  * For example: "sourcekit-lsp:"
  */
-export const GetReferenceDocumentRequest = new langclient.RequestType<
-    GetReferenceDocumentParams,
-    GetReferenceDocumentResult,
+export const LegacyGetReferenceDocumentRequest = new langclient.RequestType<
+    LegacyGetReferenceDocumentParams,
+    LegacyGetReferenceDocumentResult,
     unknown
 >("workspace/getReferenceDocument");
 

--- a/test/suite/BuildFlags.test.ts
+++ b/test/suite/BuildFlags.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { SwiftToolchain } from "../../src/toolchain/toolchain";
 import { ArgumentFilter, BuildFlags } from "../../src/toolchain/BuildFlags";

--- a/test/suite/DiagnosticsManager.test.ts
+++ b/test/suite/DiagnosticsManager.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { SwiftToolchain } from "../../src/toolchain/toolchain";
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../utilities";

--- a/test/suite/SwiftPackage.test.ts
+++ b/test/suite/SwiftPackage.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { testAssetUri } from "../fixtures";
 import { SwiftPackage } from "../../src/SwiftPackage";
 import { SwiftToolchain } from "../../src/toolchain/toolchain";

--- a/test/suite/WorkspaceContext.test.ts
+++ b/test/suite/WorkspaceContext.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { testAssetUri } from "../fixtures";
 import { FolderEvent, WorkspaceContext } from "../../src/WorkspaceContext";
 import { createBuildAllTask } from "../../src/tasks/SwiftTaskProvider";

--- a/test/suite/editor/CommentCompletion.test.ts
+++ b/test/suite/editor/CommentCompletion.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { CommentCompletionProviders } from "../../../src/editor/CommentCompletion";
 

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as swiftExtension from "../../src/extension";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { testAssetUri } from "../fixtures";

--- a/test/suite/tasks/SwiftExecution.test.ts
+++ b/test/suite/tasks/SwiftExecution.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { testSwiftTask } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { globalWorkspaceContextPromise } from "../extension.test";

--- a/test/suite/tasks/SwiftPseudoterminal.test.ts
+++ b/test/suite/tasks/SwiftPseudoterminal.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { TestSwiftProcess } from "../../fixtures";
 import { waitForClose, waitForWrite } from "../../utilities";

--- a/test/suite/tasks/SwiftTaskProvider.test.ts
+++ b/test/suite/tasks/SwiftTaskProvider.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { globalWorkspaceContextPromise } from "../extension.test";
 import { SwiftTaskProvider, createSwiftTask } from "../../../src/tasks/SwiftTaskProvider";

--- a/test/suite/tasks/TaskManager.test.ts
+++ b/test/suite/tasks/TaskManager.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { TaskManager } from "../../../src/tasks/TaskManager";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { globalWorkspaceContextPromise } from "../extension.test";

--- a/test/suite/tasks/TaskQueue.test.ts
+++ b/test/suite/tasks/TaskQueue.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { testAssetPath } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftExecOperation, TaskOperation, TaskQueue } from "../../../src/tasks/TaskQueue";

--- a/test/suite/testexplorer/DocumentSymbolTestDiscovery.test.ts
+++ b/test/suite/testexplorer/DocumentSymbolTestDiscovery.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { parseTestsFromDocumentSymbols } from "../../../src/TestExplorer/DocumentSymbolTestDiscovery";
 import { TestClass } from "../../../src/TestExplorer/TestDiscovery";

--- a/test/suite/testexplorer/LSPTestDiscovery.test.ts
+++ b/test/suite/testexplorer/LSPTestDiscovery.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import * as ls from "vscode-languageserver-protocol";
 import * as p2c from "vscode-languageclient/lib/common/protocolConverter";

--- a/test/suite/testexplorer/LSPTestDiscovery.test.ts
+++ b/test/suite/testexplorer/LSPTestDiscovery.test.ts
@@ -15,7 +15,7 @@
 import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import * as ls from "vscode-languageserver-protocol";
-import * as p2c from "vscode-languageclient/lib/common/protocolConverter";
+import * as p2c from "vscode-languageclient/$test/common/protocolConverter";
 import { beforeEach } from "mocha";
 import { InitializeResult, RequestType } from "vscode-languageclient";
 import { LSPTestDiscovery } from "../../../src/TestExplorer/LSPTestDiscovery";
@@ -55,7 +55,7 @@ class TestLanguageClient {
         };
     }
     get protocol2CodeConverter(): p2c.Converter {
-        return p2c.createConverter(undefined, true, true);
+        return p2c.createConverter(undefined, true, true, true);
     }
 
     sendRequest<P, R, E>(type: RequestType<P, R, E>): Promise<R> {

--- a/test/suite/testexplorer/SPMTestListOutputParser.test.ts
+++ b/test/suite/testexplorer/SPMTestListOutputParser.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { parseTestsFromSwiftTestListOutput } from "../../../src/TestExplorer/SPMTestDiscovery";
 import { TestClass } from "../../../src/TestExplorer/TestDiscovery";
 

--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { beforeEach } from "mocha";
 import {

--- a/test/suite/testexplorer/TestDiscovery.test.ts
+++ b/test/suite/testexplorer/TestDiscovery.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { beforeEach } from "mocha";
 import {

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { beforeEach } from "mocha";
 import { when, anything } from "ts-mockito";
 import { testAssetUri } from "../../fixtures";

--- a/test/suite/testexplorer/TestRunArguments.test.ts
+++ b/test/suite/testexplorer/TestRunArguments.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { beforeEach } from "mocha";
 import { TestRunArguments } from "../../../src/TestExplorer/TestRunArguments";
 

--- a/test/suite/testexplorer/XCTestOutputParser.test.ts
+++ b/test/suite/testexplorer/XCTestOutputParser.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import {
     darwinTestRegex,
     nonDarwinTestRegex,

--- a/test/suite/testexplorer/utilities.ts
+++ b/test/suite/testexplorer/utilities.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { reduceTestItemChildren } from "../../../src/TestExplorer/TestUtils";
 import { TestRunProxy } from "../../../src/TestExplorer/TestRunner";
 

--- a/test/suite/ui/SwiftOutputChannel.test.ts
+++ b/test/suite/ui/SwiftOutputChannel.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 
 suite("SwiftOutputChannel", function () {

--- a/test/suite/utilities/filesystem.test.ts
+++ b/test/suite/utilities/filesystem.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as path from "path";
 import {
     isPathInsidePath,

--- a/test/suite/utilities/utilities.test.ts
+++ b/test/suite/utilities/utilities.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as Stream from "stream";
 import {
     execFileStreamOutput,

--- a/test/suite/version.test.ts
+++ b/test/suite/version.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import { Version } from "../../src/utilities/version";
 
 suite("Version Test Suite", () => {

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as assert from "assert";
+import { strict as assert } from "assert";
 import * as vscode from "vscode";
 import { FolderEvent, WorkspaceContext } from "../../../src/WorkspaceContext";
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"module": "commonjs",
+		"module": "node16",
+		"moduleResolution": "node16",
 		"target": "ES2020",
 		"outDir": "out",
 		"lib": [


### PR DESCRIPTION
Sibling PR to

- https://github.com/swiftlang/sourcekit-lsp/pull/1639

The `workspace/textDocumentContent` API will be upstreamed as part of the upcoming version 3.18 of LSP, thus we no longer need a non-standard `workspace/getReferenceDocument` implementation. Some notes on the implementation:

- Using this API requires upgrading to `vscode-languageclient` version 10, which is currently in beta. The migration requires using a different module resolution and updating some imports.
- Proposed features have to be enabled explicitly on the `LanguageClient` instance
- Similar to the upstreaming process of the inlay hint request, we keep the legacy request around for now and gate it behind a Swift version check (currently testing for toolchain version < 6.1, this might have to be updated depending on when the sourcekit-lsp PR is merged).

Since we may want to hold off with this until LSP 3.18 is finalized and the sourcekit-lsp PR is merged, I'm marking this PR as a draft for now. It already works, however, and can be used for testing.