### PR TITLE
Fix coverage report

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -33,12 +33,11 @@ module.exports = defineConfig({
             mocha: {
                 ui: "tdd",
                 color: true,
-                // so doesn't timeout when breakpoint is hit
-                timeout: isDebugRun ? Number.MAX_SAFE_INTEGER : 3000,
                 timeout,
                 forbidOnly: isCIBuild,
                 grep: isFastTestRun ? "@slow" : undefined,
                 invert: isFastTestRun,
+                slow: 10000
             },
             installExtensions: ["vadimcn.vscode-lldb"],
             reuseMachineInstall: !isCIBuild,
@@ -50,9 +49,9 @@ module.exports = defineConfig({
             mocha: {
                 ui: "tdd",
                 color: true,
-                // so doesn't timeout when breakpoint is hit
-                timeout: isDebugRun ? Number.MAX_SAFE_INTEGER : 3000,
+                timeout,
                 forbidOnly: isCIBuild,
+                slow: 100
             },
             reuseMachineInstall: !isCIBuild,
         },
@@ -60,7 +59,7 @@ module.exports = defineConfig({
     ],
     coverage: {
         includeAll: true,
-        include: ["**/src/**"],
-        reporter: ["text", "html"],
+        exclude: ["**/test/**"],
+        reporter: ["text", "lcov"], // "lcov" also generates HTML
     },
 });

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,7 +31,8 @@
 				"${workspaceFolder}/assets/test"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
+				"${workspaceFolder}/out/**/*.js",
+				"${workspaceFolder}/dist/**/*.js"
 			],
 			"env": {
 				"VSCODE_DEBUG": "1"

--- a/package.json
+++ b/package.json
@@ -1256,10 +1256,11 @@
     "vadimcn.vscode-lldb"
   ],
   "scripts": {
-    "vscode:prepublish": "npm run esbuild-base -- --minify",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node18",
+    "vscode:prepublish": "npm run esbuild-bundle",
+    "esbuild-base": "rm -rf ./dist && esbuild './src/**/*.ts' --outdir=dist --format=cjs --platform=node --target=node18",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
+    "esbuild-bundle": "rm -rf ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify",
     "compile": "tsc",
     "watch": "tsc --watch",
     "lint": "eslint ./ --ext ts && tsc --noEmit",

--- a/test/suite/BackgroundCompilation.test.ts
+++ b/test/suite/BackgroundCompilation.test.ts
@@ -49,9 +49,8 @@ suite("BackgroundCompilation Test Suite", () => {
         });
 
         const uri = testAssetUri("defaultPackage/Sources/PackageExe/main.swift");
-        await vscode.workspace
-            .openTextDocument(uri.fsPath)
-            .then(doc => vscode.window.showTextDocument(doc));
+        const doc = await vscode.workspace.openTextDocument(uri.fsPath);
+        await vscode.window.showTextDocument(doc);
         await vscode.workspace.save(uri);
 
         await taskPromise;


### PR DESCRIPTION
Issue was the dist/extension.js file was what vscode-test was running as the extension as it was what was specified as the entry point in the package.json. So The globalWorkspaceContextPromise helper we use in a lot of tests to make sure the extension is activated, returns an instance of the WorkspaceContext. Any behaviour stimulated through that context is missed from the coverage report, and also any breakpoint hits are ignored. So for example the BackgroundCompilation instance that is created on extension activation was left out of the coverage report.

To fix, only bundle to a single extension.js file when packaging a vsix. When debugging or running tests we transpile all the files individually. The dist/extension.js file is still used when activating, but sourcemap now works so the coverage report is accurate.

Issue: #1021