### PR TITLE
Mark XCTests as passed without a second pass over the output

### DIFF
--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -195,7 +195,7 @@ export class XCTestOutputParser implements IXCTestOutputParser {
                         this.failTest(testIndex, { duration }, runState);
                         break;
                     case TestCompletionState.passed:
-                        // Tests are passed in the second pass below.
+                        this.passTest(testIndex, { duration }, runState);
                         break;
                     case TestCompletionState.skipped:
                         this.skipTest(testIndex, runState);
@@ -252,21 +252,6 @@ export class XCTestOutputParser implements IXCTestOutputParser {
             }
             // unrecognised output could be the continuation of a previous error message
             this.continueErrorMessage(line, runState);
-        }
-
-        // We need to run the passed checks in a separate pass to ensure we aren't in the situation
-        // where there is a symbol clash between different test targets and set the wrong test
-        // to be passed.
-        for (const line of lines) {
-            // Regex "Test Case '<class>.<function>' passed (<duration> seconds)"
-            const passedMatch = this.regex.finished.exec(line);
-            if (passedMatch && passedMatch[3] === TestCompletionState.passed) {
-                const testName = `${passedMatch[1]}/${passedMatch[2]}`;
-                const duration: number = +passedMatch[4];
-                const passedTestIndex = runState.getTestItemIndex(testName, undefined);
-                this.passTest(passedTestIndex, { duration }, runState);
-                continue;
-            }
         }
     }
 

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -370,14 +370,14 @@ suite("Test Explorer Suite", function () {
         });
 
         suite(runProfile, () => {
-            suite("swift-testing", function () {
+            suite(`swift-testing (${runProfile})`, function () {
                 suiteSetup(function () {
                     if (workspaceContext.swiftVersion.isLessThan(new Version(6, 0, 0))) {
                         this.skip();
                     }
                 });
 
-                test("Runs passing test", async function () {
+                test(`Runs passing test ${runProfile}`, async function () {
                     const testRun = await runTest(
                         testExplorer.controller,
                         runProfile,
@@ -394,7 +394,7 @@ suite("Test Explorer Suite", function () {
                     );
                 });
 
-                test("Runs failing test", async function () {
+                test(`Runs failing test ${runProfile}`, async function () {
                     const testRun = await runTest(
                         testExplorer.controller,
                         runProfile,
@@ -416,7 +416,7 @@ suite("Test Explorer Suite", function () {
                     });
                 });
 
-                test("Runs Suite", async function () {
+                test(`Runs Suite ${runProfile}`, async function () {
                     const testRun = await runTest(
                         testExplorer.controller,
                         runProfile,
@@ -441,7 +441,7 @@ suite("Test Explorer Suite", function () {
                     });
                 });
 
-                test("Runs parameterized test", async function () {
+                test(`Runs parameterized test ${runProfile}`, async function () {
                     const testRun = await runTest(
                         testExplorer.controller,
                         runProfile,
@@ -471,7 +471,7 @@ suite("Test Explorer Suite", function () {
                     });
                 });
 
-                test("Runs Suite", async function () {
+                test(`Runs Suite (${runProfile})`, async function () {
                     const testRun = await runTest(
                         testExplorer.controller,
                         runProfile,
@@ -496,7 +496,7 @@ suite("Test Explorer Suite", function () {
                     });
                 });
 
-                test("Runs All", async function () {
+                test(`Runs All (${runProfile})`, async function () {
                     const testRun = await runTest(
                         testExplorer.controller,
                         runProfile,
@@ -534,7 +534,7 @@ suite("Test Explorer Suite", function () {
                 });
             });
 
-            suite("XCTests", () => {
+            suite(`XCTests (${runProfile})`, () => {
                 test("Runs passing test", async function () {
                     const testRun = await runTest(
                         testExplorer.controller,


### PR DESCRIPTION
The lastTestItem was not being set right away when a test succeeded because tests were being marked as passed in a second pass of the XCTest output after a run completed.

Going by the removed comment this second pass was added to disambiguate passing tests with the same suite/test name across multiple targets.

However, the test target is present in the `testName` used to look up a test's index. For instance, it may look like
`TestTargetA/Suite/testFoo` and so would not be identical to `TestTargetB/Suite/testFoo`, and so we get the correct `testIndex` for either test.