### PR TITLE
Add Run Multiple menu items to test item gutter

### DIFF
--- a/package.json
+++ b/package.json
@@ -612,6 +612,18 @@
       }
     ],
     "menus": {
+      "testing/item/gutter": [
+        {
+          "command": "swift.runTestsMultipleTimes",
+          "group": "testExtras",
+          "when": "testId"
+        },
+        {
+          "command": "swift.runTestsUntilFailure",
+          "group": "testExtras",
+          "when": "testId"
+        }
+      ],
       "testing/item/context": [
         {
           "command": "swift.runTestsMultipleTimes",


### PR DESCRIPTION
We can add the Run Multiple Times and Run Until Failure menu items onto the green play button icon in the gutter of the editor. This is in addition to having it on individual items in the test explorer.