### PR TITLE
Show Swift test explorer context menu items only for Swift tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -616,30 +616,31 @@
         {
           "command": "swift.runTestsMultipleTimes",
           "group": "testExtras",
-          "when": "testId"
+          "when": "testId in swift.tests"
         },
         {
           "command": "swift.runTestsUntilFailure",
           "group": "testExtras",
-          "when": "testId"
+          "when": "testId in swift.tests"
         }
       ],
       "testing/item/context": [
         {
           "command": "swift.runTestsMultipleTimes",
           "group": "testExtras",
-          "when": "testId"
+          "when": "testId in swift.tests"
         },
         {
           "command": "swift.runTestsUntilFailure",
           "group": "testExtras",
-          "when": "testId"
+          "when": "testId in swift.tests"
         }
       ],
       "file/newFile": [
         {
           "command": "swift.newFile",
-          "group": "file"
+          "group": "file",
+          "when": "swift.isActivated"
         }
       ],
       "explorer/context": [

--- a/src/TestExplorer/TestUtils.ts
+++ b/src/TestExplorer/TestUtils.ts
@@ -29,3 +29,15 @@ export function reduceTestItemChildren<U>(
     });
     return accumulator;
 }
+
+/**
+ * Returns a flattented, iterable collection of test items in the collection.
+ */
+export function flattenTestItemCollection(coll: vscode.TestItemCollection): vscode.TestItem[] {
+    const items: vscode.TestItem[] = [];
+    coll.forEach(item => {
+        items.push(item);
+        items.push(...flattenTestItemCollection(item.children));
+    });
+    return items;
+}


### PR DESCRIPTION
Keep a flattened list of swift Test Explorer test IDs in the context and use a `when` clause on the context menu items to only show them on Swift tests in the Text Explorer.

Issue: #1047