### PR TITLE
Rename `workspace/getReferenceDocument` to `workspace/textDocumentContent`

### DIFF
--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -29,7 +29,7 @@ import { DiagnosticsManager } from "../DiagnosticsManager";
 import { LSPLogger, LSPOutputChannel } from "./LSPOutputChannel";
 import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
 import { promptForDiagnostics } from "../commands/captureDiagnostics";
-import { activateGetReferenceDocument } from "./getReferenceDocument";
+import { activateTextDocumentContent } from "./textDocumentContent";
 
 interface SourceKitLogMessageParams extends langclient.LogMessageParams {
     logName?: string;
@@ -113,7 +113,7 @@ export class LanguageClientManager {
     private cancellationToken?: vscode.CancellationTokenSource;
     private legacyInlayHints?: vscode.Disposable;
     private peekDocuments?: vscode.Disposable;
-    private getReferenceDocument?: vscode.Disposable;
+    private textDocumentContent?: vscode.Disposable;
     private restartedPromise?: Promise<void>;
     private currentWorkspaceFolder?: vscode.Uri;
     private waitingOnRestartCount: number;
@@ -251,7 +251,7 @@ export class LanguageClientManager {
         this.cancellationToken?.dispose();
         this.legacyInlayHints?.dispose();
         this.peekDocuments?.dispose();
-        this.getReferenceDocument?.dispose();
+        this.textDocumentContent?.dispose();
         this.subscriptions.forEach(item => item.dispose());
         this.languageClient?.stop();
         this.namedOutputChannels.forEach(channel => channel.dispose());
@@ -402,8 +402,8 @@ export class LanguageClientManager {
         this.legacyInlayHints = undefined;
         this.peekDocuments?.dispose();
         this.peekDocuments = undefined;
-        this.getReferenceDocument?.dispose();
-        this.getReferenceDocument = undefined;
+        this.textDocumentContent?.dispose();
+        this.textDocumentContent = undefined;
         if (client) {
             this.cancellationToken?.cancel();
             this.cancellationToken?.dispose();
@@ -596,7 +596,7 @@ export class LanguageClientManager {
     private initializationOptions(): any {
         let options: any = {
             "workspace/peekDocuments": true, // workaround for client capability to handle `PeekDocumentsRequest`
-            "workspace/getReferenceDocument": true, // the client can handle URIs with scheme `sourcekit-lsp:`
+            "workspace/textDocumentContent": true, // the client can handle URIs with scheme `sourcekit-lsp:`
             "textDocument/codeLens": {
                 supportedCommands: {
                     "swift.run": "swift.run",
@@ -659,8 +659,8 @@ export class LanguageClientManager {
                 }
 
                 this.peekDocuments = activatePeekDocuments(client);
-                this.getReferenceDocument = activateGetReferenceDocument(client);
-                this.workspaceContext.subscriptions.push(this.getReferenceDocument);
+                this.textDocumentContent = activateTextDocumentContent(client);
+                this.workspaceContext.subscriptions.push(this.textDocumentContent);
             })
             .catch(reason => {
                 this.workspaceContext.outputChannel.log(`${reason}`);

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -57,7 +57,7 @@ export const PeekDocumentsRequest = new langclient.RequestType<
 >("workspace/peekDocuments");
 
 // Get Reference Document
-export interface GetReferenceDocumentParams {
+export interface TextDocumentContentParams {
     /**
      * The `DocumentUri` of the custom scheme url for which content is required
      */
@@ -65,9 +65,9 @@ export interface GetReferenceDocumentParams {
 }
 
 /**
- * Response containing `content` of `GetReferenceDocumentRequest`
+ * Response containing `content` of `TextDocumentContentRequest`
  */
-export interface GetReferenceDocumentResult {
+export interface TextDocumentContentResult {
     content: string;
 }
 
@@ -75,11 +75,11 @@ export interface GetReferenceDocumentResult {
  * Request from the client to the server asking for contents of a URI having a custom scheme
  * For example: "sourcekit-lsp:"
  */
-export const GetReferenceDocumentRequest = new langclient.RequestType<
-    GetReferenceDocumentParams,
-    GetReferenceDocumentResult,
+export const TextDocumentContentRequest = new langclient.RequestType<
+    TextDocumentContentParams,
+    TextDocumentContentResult,
     unknown
->("workspace/getReferenceDocument");
+>("workspace/textDocumentContent");
 
 // Inlay Hints (pre Swift 5.6)
 export interface LegacyInlayHintsParams {

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -68,7 +68,7 @@ export interface TextDocumentContentParams {
  * Response containing `content` of `TextDocumentContentRequest`
  */
 export interface TextDocumentContentResult {
-    content: string;
+    text: string;
 }
 
 /**

--- a/src/sourcekit-lsp/textDocumentContent.ts
+++ b/src/sourcekit-lsp/textDocumentContent.ts
@@ -14,18 +14,18 @@
 
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
-import { GetReferenceDocumentParams, GetReferenceDocumentRequest } from "./lspExtensions";
+import { TextDocumentContentParams, TextDocumentContentRequest } from "./lspExtensions";
 
-export function activateGetReferenceDocument(client: langclient.LanguageClient): vscode.Disposable {
-    const getReferenceDocument = vscode.workspace.registerTextDocumentContentProvider(
+export function activateTextDocumentContent(client: langclient.LanguageClient): vscode.Disposable {
+    const textDocumentContent = vscode.workspace.registerTextDocumentContentProvider(
         "sourcekit-lsp",
         {
             provideTextDocumentContent: async (uri, token) => {
-                const params: GetReferenceDocumentParams = {
+                const params: TextDocumentContentParams = {
                     uri: client.code2ProtocolConverter.asUri(uri),
                 };
 
-                const result = await client.sendRequest(GetReferenceDocumentRequest, params, token);
+                const result = await client.sendRequest(TextDocumentContentRequest, params, token);
 
                 if (result) {
                     return result.content;
@@ -36,5 +36,5 @@ export function activateGetReferenceDocument(client: langclient.LanguageClient):
         }
     );
 
-    return getReferenceDocument;
+    return textDocumentContent;
 }

--- a/src/sourcekit-lsp/textDocumentContent.ts
+++ b/src/sourcekit-lsp/textDocumentContent.ts
@@ -28,7 +28,7 @@ export function activateTextDocumentContent(client: langclient.LanguageClient): 
                 const result = await client.sendRequest(TextDocumentContentRequest, params, token);
 
                 if (result) {
-                    return result.content;
+                    return result.text;
                 } else {
                     return "Unable to retrieve reference document";
                 }


### PR DESCRIPTION
Sibling PR to

- https://github.com/swiftlang/sourcekit-lsp/pull/1639

As suggested by @ahoppen in https://github.com/swiftlang/sourcekit-lsp/pull/1639#issuecomment-2311124611, this migrates our non-standard request to the upstream naming conventions for now, so we can defer the actual deprecation of our custom text document provider to the stabilization of LSP 3.18 (this will be done in #1027). Since the `getReferenceDocument` request has not shipped in a release toolchain yet, we don't need to keep it around for compatibility.

Marked as a draft PR until the sourcekit-lsp PR is merged.