### PR TITLE
Address flakey swift-testing test

### DIFF
--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -45,8 +45,12 @@ final class DebugReleaseTestSuite: XCTestCase {
 #if swift(>=6.0)
 import Testing
 
-@Test func topLevelTestPassing() {
+@Test func topLevelTestPassing() async throws {
   print("A print statement in a test.")
+  // Work around test output potentially occuring after the test end event.
+  // See https://github.com/swiftlang/vscode-swift/issues/1054
+  try await Task.sleep(nanoseconds: 100_000_000)
+
   #if !TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING
     Issue.record("Expected TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING to be set at compilation")
   #endif

--- a/test/suite/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/suite/testexplorer/TestExplorerIntegration.test.ts
@@ -450,8 +450,8 @@ suite("Test Explorer Suite", function () {
 
                     assertTestResults(testRun, {
                         passed: [
-                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:59:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [49])])",
-                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:59:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [51])])",
+                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:63:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [49])])",
+                            "PackageTests.parameterizedTest(_:)/PackageTests.swift:63:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [51])])",
                         ],
                         failed: [
                             {
@@ -461,7 +461,7 @@ suite("Test Explorer Suite", function () {
                                         text: "Expectation failed: (arg → 2) != 2",
                                     })}`,
                                 ],
-                                test: "PackageTests.parameterizedTest(_:)/PackageTests.swift:59:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [50])])",
+                                test: "PackageTests.parameterizedTest(_:)/PackageTests.swift:63:2/argumentIDs: Optional([Testing.Test.Case.Argument.ID(bytes: [50])])",
                             },
                             {
                                 issues: [],


### PR DESCRIPTION
The `topLevelTestPassing()` test asserts that a print statement is captured during a test. However because of #1054 it is possible that this print is saved to the test run after the swift-testing test end JSON event has been recieved. Until this issue is addressed, add a 0.1 second delay to ensure the print is captured before the test end event.