### PR TITLE
Use swift-testing stdout as test results log verbatim

### DIFF
--- a/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/suite/testexplorer/SwiftTestingOutputParser.test.ts
@@ -23,7 +23,6 @@ import {
     EventMessage,
     SourceLocation,
     TestSymbol,
-    SymbolRenderer,
     MessageRenderer,
 } from "../../../src/TestExplorer/TestParsers/SwiftTestingOutputParser";
 import { TestRunState, TestStatus } from "./MockTestRunState";
@@ -153,7 +152,7 @@ suite("SwiftTestingOutputParser Suite", () => {
                 timing: {
                     timestamp: 0,
                 },
-                output: renderedMessages.map(message => `${message}\r\n`),
+                output: [],
             },
         ]);
     }
@@ -274,7 +273,6 @@ suite("SwiftTestingOutputParser Suite", () => {
             true
         );
         const symbol = TestSymbol.pass;
-        const renderedSymbol = SymbolRenderer.symbol(symbol);
         const makeEvent = (kind: ExtractPayload<EventRecord>["kind"], testId?: string) =>
             testEvent(kind, testId, [{ text: kind, symbol }]);
 
@@ -292,10 +290,7 @@ suite("SwiftTestingOutputParser Suite", () => {
         assert.deepEqual(testRunState.tests, [
             {
                 name: "MyTests.MyTests/testOutput()",
-                output: [
-                    `\u001b[92m${renderedSymbol}\u001b[0m testCaseStarted\r\n`,
-                    `\u001b[92m${renderedSymbol}\u001b[0m testCaseEnded\r\n`,
-                ],
+                output: [],
                 status: TestStatus.passed,
                 timing: {
                     timestamp: 0,
@@ -303,10 +298,7 @@ suite("SwiftTestingOutputParser Suite", () => {
             },
             {
                 name: "MyTests.MyTests/testOutput2()",
-                output: [
-                    `\u001b[92m${renderedSymbol}\u001b[0m testCaseStarted\r\n`,
-                    `\u001b[92m${renderedSymbol}\u001b[0m testCaseEnded\r\n`,
-                ],
+                output: [],
                 status: TestStatus.passed,
                 timing: {
                     timestamp: 0,


### PR DESCRIPTION
Instead of reconstructing the swift-testing output from a combination of stdout and the JSON event stream, simply pass stdout through directly and use that as the test results log. Use the JSON event stream to drive test pass/fail/skip/issue/etc behaviour.

This resolves a race condition between the JSON event stream and stdout interleaving output in an incorrect order.

This approach has the drawback of no longer associating individual lines of output derived from the JSON event stream with a specific test, however this was offering limited benefit since user output wasn't captured in this way. Once every line of output can be accounted for in the JSON event stream we can add this functionality back in with user output included.

Issue: #1054