### PR TITLE
Remove `experimental` from swift-testing flags

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -441,10 +441,10 @@ export class TestingConfigurationFactory {
     private addSwiftTestingFlagsArgs(args: string[]): string[] {
         return [
             ...args,
-            "--enable-experimental-swift-testing",
-            "--experimental-event-stream-version",
+            "--enable-swift-testing",
+            "--event-stream-version",
             "0",
-            "--experimental-event-stream-output",
+            "--event-stream-output-path",
             this.fifoPipePath,
         ];
     }


### PR DESCRIPTION
These have been stabilized and the `experimental` versions of the flags have been deprecated.