### PR TITLE
Include "clang" diagnostics from SourceKit-LSP

### DIFF
--- a/assets/test/diagnosticsC/Package.swift
+++ b/assets/test/diagnosticsC/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyPoint",
+    products: [
+        .library(name: "MyPoint", targets: ["MyPoint"]),
+    ],
+    targets: [
+        .target(name: "MyPoint"),
+    ]
+)

--- a/assets/test/diagnosticsC/Sources/MyPoint/MyPoint.c
+++ b/assets/test/diagnosticsC/Sources/MyPoint/MyPoint.c
@@ -1,0 +1,9 @@
+#include "MyPoint.h"
+
+int func() {
+    struct MyPoint p;
+    p.x = 1;
+    p.y = bar;
+    p.z = 2
+    return p.x;
+}

--- a/assets/test/diagnosticsC/Sources/MyPoint/include/MyPoint.h
+++ b/assets/test/diagnosticsC/Sources/MyPoint/include/MyPoint.h
@@ -1,0 +1,4 @@
+struct MyPoint {
+   int x;
+   int y;
+};

--- a/assets/test/diagnosticsCpp/Package.swift
+++ b/assets/test/diagnosticsCpp/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "MyPoint",
+    products: [
+        .library(name: "MyPoint", targets: ["MyPoint"]),
+    ],
+    targets: [
+        .target(name: "MyPoint"),
+    ]
+)

--- a/assets/test/diagnosticsCpp/Sources/MyPoint/MyPoint.cpp
+++ b/assets/test/diagnosticsCpp/Sources/MyPoint/MyPoint.cpp
@@ -1,0 +1,9 @@
+#include "MyPoint.h"
+
+int func() {
+    MyPoint* p = new MyPoint2();
+    p->x = 1;
+    p->y = bar;
+    p.z = 2
+    return p.x;
+}

--- a/assets/test/diagnosticsCpp/Sources/MyPoint/include/MyPoint.h
+++ b/assets/test/diagnosticsCpp/Sources/MyPoint/include/MyPoint.h
@@ -1,0 +1,5 @@
+class MyPoint {
+   public:
+      int x;
+      int y;
+};


### PR DESCRIPTION
* Include "clang" in the list of diagnostics sources
* Fix regex to not include "[-Wcode]" that compiler outputs for C/C++ diagnostics
* Clean up the "(fix available)" SourceKit includes in clang messages so that merging works proper
* Add new tests to watch for clang diagnostics

Issue: #1028