### PR TITLE
Refresh the test explorer when the package changes

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -161,6 +161,13 @@ export class FolderContext implements vscode.Disposable {
         this.testExplorer = undefined;
     }
 
+    /** Refresh the tests in the test explorer for this folder */
+    refreshTestExplorer() {
+        if (this.testExplorer?.controller.resolveHandler) {
+            this.testExplorer.controller.resolveHandler(undefined);
+        }
+    }
+
     /** Return if package folder has a test explorer */
     hasTestExplorer() {
         return this.testExplorer !== undefined;

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -147,6 +147,8 @@ export class TestExplorer {
                             }
                         } else if (!hasTestTargets && folder.hasTestExplorer()) {
                             folder.removeTestExplorer();
+                        } else if (folder.hasTestExplorer()) {
+                            folder.refreshTestExplorer();
                         }
                     }
                     break;


### PR DESCRIPTION
Currently if the user adds or removes a test target from the package manifest this change is not reflected in the test list of the test explorer.

When the package manifest is updated, refresh the test explorer by making a workspace/test's LSP request.