### PR TITLE
Open version specific manifest if applicable

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -91,7 +91,11 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         vscode.commands.registerCommand("swift.switchPlatform", () => switchPlatform()),
         vscode.commands.registerCommand("swift.resetPackage", () => resetPackage(ctx)),
         vscode.commands.registerCommand("swift.runScript", () => runSwiftScript(ctx)),
-        vscode.commands.registerCommand("swift.openPackage", () => openPackage(ctx)),
+        vscode.commands.registerCommand("swift.openPackage", () => {
+            if (ctx.currentFolder) {
+                openPackage(ctx.toolchain.swiftVersion, ctx.currentFolder.folder);
+            }
+        }),
         vscode.commands.registerCommand("swift.runSnippet", () => runSnippet(ctx)),
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),
         vscode.commands.registerCommand("swift.runPluginTask", () => runPluginTask()),

--- a/src/commands/openPackage.ts
+++ b/src/commands/openPackage.ts
@@ -13,19 +13,39 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import { WorkspaceContext } from "../WorkspaceContext";
+import { Version } from "../utilities/version";
+import { fileExists } from "../utilities/filesystem";
 
 /**
- * Open Package.swift for in focus project
+ * Open Package.swift for in focus project. If there is a version specific manifest that
+ * matches the user's current Swift version that file is opened, otherwise opens Package.swift.
  * @param workspaceContext Workspace context, required to get current project
  */
-export async function openPackage(workspaceContext: WorkspaceContext) {
-    if (workspaceContext.currentFolder) {
-        const packagePath = vscode.Uri.joinPath(
-            workspaceContext.currentFolder.folder,
-            "Package.swift"
-        );
+export async function openPackage(swiftVersion: Version, currentFolder: vscode.Uri) {
+    const packagePath = await packageSwiftFile(currentFolder, swiftVersion);
+    if (packagePath) {
         const document = await vscode.workspace.openTextDocument(packagePath);
         vscode.window.showTextDocument(document);
     }
+}
+
+async function packageSwiftFile(
+    currentFolder: vscode.Uri,
+    version: Version
+): Promise<vscode.Uri | null> {
+    // Follow the logic outlined in the SPM documentation on version specific manifest selection
+    // https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection
+    const files = [
+        `Package@swift-${version.major}.${version.minor}.${version.patch}.swift`,
+        `Package@swift-${version.major}.${version.minor}.swift`,
+        `Package@swift-${version.major}.swift`,
+        "Package.swift",
+    ].map(file => vscode.Uri.joinPath(currentFolder, file));
+
+    for (const file of files) {
+        if (await fileExists(file.fsPath)) {
+            return file;
+        }
+    }
+    return null;
 }

--- a/test/suite/commands/openPackage.test.ts
+++ b/test/suite/commands/openPackage.test.ts
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// import * as assert from "assert";
+import * as vscode from "vscode";
+import * as path from "path";
+import { anything, objectContaining, spy, verify, when } from "ts-mockito";
+import { mockNamespace } from "../../unit-tests/MockUtils";
+import { openPackage } from "../../../src/commands/openPackage";
+import { Version } from "../../../src/utilities/version";
+import * as fs from "../../../src/utilities/filesystem";
+
+suite("OpenPackage Command Test Suite", () => {
+    const workspaceMock = mockNamespace(vscode, "workspace");
+    const windowMock = mockNamespace(vscode, "window");
+    const fsSpy = spy(fs);
+
+    async function runTestWithMockFs(version: Version, expected: string, paths: string[]) {
+        const basePath = "/test";
+        const expectedPath = path.join(basePath, expected);
+        paths.forEach(p => {
+            when(fsSpy.fileExists(path.join(basePath, p))).thenResolve(true);
+        });
+        when(windowMock.showTextDocument(anything())).thenResolve();
+        await openPackage(version, vscode.Uri.file(basePath));
+
+        verify(workspaceMock.openTextDocument(objectContaining({ fsPath: expectedPath }))).once();
+        verify(windowMock.showTextDocument(anything())).once();
+    }
+
+    test("Opens nothing when there is no package.swift", async () => {
+        await openPackage(new Version(6, 0, 0), vscode.Uri.file("/test"));
+
+        verify(windowMock.showTextDocument(anything())).never();
+    });
+
+    test("Opens Package.swift file", async () => {
+        await runTestWithMockFs(new Version(6, 0, 0), "Package.swift", ["Package.swift"]);
+    });
+
+    test("Opens Package@swift-6.0.0.swift file", async () => {
+        await runTestWithMockFs(new Version(6, 0, 0), "Package@swift-6.0.0.swift", [
+            "Package.swift",
+            "Package@swift-6.0.0.swift",
+        ]);
+    });
+
+    test("Opens Package@swift-6.1.2.swift file", async () => {
+        await runTestWithMockFs(new Version(6, 1, 2), "Package@swift-6.1.2.swift", [
+            "Package.swift",
+            "Package@swift-6.swift",
+            "Package@swift-6.1.swift",
+            "Package@swift-6.1.2.swift",
+        ]);
+    });
+});


### PR DESCRIPTION
The language status item has a link to the Package.swift file. If the user has a version specific manifest file in the form `Package@swift-[version].swift` where the version matches their currently installed Swift version, open that Package.swift instead.

Issue: #1070