### PR TITLE
Fix Several Windows Debugging Issues

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -191,12 +191,17 @@ export class TestingConfigurationFactory {
                 ...swiftRuntimeEnv(),
                 ...configuration.folder(this.ctx.workspaceFolder).testEnvironmentVariables,
             };
-            // On Windows, add XCTest.dll to the Path
+            // On Windows, add XCTest.dll/Testing.dll to the Path
             // and run the .xctest executable from the .build directory.
             const runtimePath = this.ctx.workspaceContext.toolchain.runtimePath;
             const xcTestPath = this.ctx.workspaceContext.toolchain.xcTestPath;
             if (xcTestPath && xcTestPath !== runtimePath) {
                 testEnv.Path = `${xcTestPath};${testEnv.Path ?? process.env.Path}`;
+            }
+
+            const swiftTestingPath = this.ctx.workspaceContext.toolchain.swiftTestingPath;
+            if (swiftTestingPath && swiftTestingPath !== runtimePath) {
+                testEnv.Path = `${swiftTestingPath};${testEnv.Path ?? process.env.Path}`;
             }
 
             return {
@@ -507,7 +512,9 @@ export class TestingConfigurationFactory {
     }
 
     private get artifactFolderForTestKind(): string {
-        return isRelease(this.testKind) ? "release" : "debug";
+        const mode = isRelease(this.testKind) ? "release" : "debug";
+        const triple = this.ctx.workspaceContext.toolchain.unversionedTriple;
+        return triple ? path.join(triple, mode) : mode;
     }
 
     private xcTestOutputPath(): string {

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -77,9 +77,14 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
     ): Promise<vscode.DebugConfiguration> {
         launchConfig.env = this.convertEnvironmentVariables(launchConfig.env);
         // Fix the program path on Windows to include the ".exe" extension
-        if (this.platform === "win32" && path.extname(launchConfig.program) !== ".exe") {
+        if (
+            this.platform === "win32" &&
+            launchConfig.testType === undefined &&
+            path.extname(launchConfig.program) !== ".exe"
+        ) {
             launchConfig.program += ".exe";
         }
+
         // Delegate to CodeLLDB if that's the debug adapter we have selected
         if (DebugAdapter.getDebugAdapterType(this.swiftVersion) === "lldb-vscode") {
             launchConfig.type = "lldb";

--- a/test/suite/tasks/SwiftTaskProvider.test.ts
+++ b/test/suite/tasks/SwiftTaskProvider.test.ts
@@ -68,7 +68,12 @@ suite("SwiftTaskProvider Test Suite", () => {
                 new SwiftToolchain(
                     "/invalid/swift/path",
                     "/invalid/toolchain/path",
-                    "1.2.3",
+                    {
+                        compilerVersion: "1.2.3",
+                        paths: {
+                            runtimeLibraryPaths: [],
+                        },
+                    },
                     new Version(1, 2, 3)
                 )
             );


### PR DESCRIPTION
Fixes up some issues with Windows debugging found in the latest 6.0 toolchain:
- Add Testing.dll to the PATH same as XCTest.dll
- Don't append .exe when debugging testing binaries
- Don't follow incorrectly created symlink at `.\build\debug`, point to real folder at the build triple path