### PR TITLE
Add tests for swift-plugin tasks

### DIFF
--- a/assets/test/.vscode/tasks.json
+++ b/assets/test/.vscode/tasks.json
@@ -29,6 +29,17 @@
 			"group": "build",
 			"label": "swift: Build All from tasks.json",
 			"detail": "swift build --show-bin-path"
+		},
+		{
+			"type": "swift-plugin",
+			"command": "command_plugin",
+			"args": ["--foo"],
+			"cwd": "command-plugin",
+			"problemMatcher": [
+				"$swiftc"
+			],
+			"label": "swift: command-plugin from tasks.json",
+			"detail": "swift package command_plugin --foo"
 		}
 	]
 }

--- a/assets/test/command-plugin/Package.swift
+++ b/assets/test/command-plugin/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "command-plugin",
+    products: [
+        // Products can be used to vend plugins, making them visible to other packages.
+        .plugin(
+            name: "command-plugin",
+            targets: ["command-plugin"]),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .plugin(
+            name: "command-plugin",
+            capability: .command(intent: .custom(
+                verb: "command_plugin",
+                description: "prints hello world"
+            ))
+        ),
+    ]
+)

--- a/assets/test/command-plugin/Plugins/command-plugin/command-plugin.swift
+++ b/assets/test/command-plugin/Plugins/command-plugin/command-plugin.swift
@@ -1,0 +1,21 @@
+import PackagePlugin
+
+@main
+struct command_plugin: CommandPlugin {
+    // Entry point for command plugins applied to Swift Packages.
+    func performCommand(context: PluginContext, arguments: [String]) async throws {
+        print("Hello, World!")
+    }
+}
+
+#if canImport(XcodeProjectPlugin)
+import XcodeProjectPlugin
+
+extension command_plugin: XcodeCommandPlugin {
+    // Entry point for command plugins applied to Xcode projects.
+    func performCommand(context: XcodePluginContext, arguments: [String]) throws {
+        print("Hello, World!")
+    }
+}
+
+#endif

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -131,7 +131,7 @@ export class FolderContext implements vscode.Disposable {
     /** Load Swift Plugins and store in Package */
     async loadSwiftPlugins() {
         const plugins = await SwiftPackage.loadPlugins(
-            this.workspaceFolder.uri,
+            this.folder,
             this.workspaceContext.toolchain
         );
         this.swiftPackage.plugins = plugins;

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -20,6 +20,7 @@ import configuration from "../configuration";
 import { swiftRuntimeEnv } from "../utilities/utilities";
 import { SwiftExecution } from "../tasks/SwiftExecution";
 import { resolveTaskCwd } from "../utilities/tasks";
+import { SwiftTask } from "./SwiftTaskProvider";
 
 // Interface class for defining task configuration
 interface TaskConfig {
@@ -113,7 +114,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
      * @param config
      * @returns
      */
-    createSwiftPluginTask(plugin: PackagePlugin, config: TaskConfig): vscode.Task {
+    createSwiftPluginTask(plugin: PackagePlugin, config: TaskConfig): SwiftTask {
         const swift = this.workspaceContext.toolchain.getToolchainExecutable("swift");
 
         // Add relative path current working directory
@@ -155,7 +156,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         }
         task.detail = `${prefix}swift ${swiftArgs.join(" ")}`;
         task.presentationOptions = presentation;
-        return task;
+        return task as SwiftTask;
     }
 
     /**

--- a/test/suite/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/suite/tasks/SwiftPluginTaskProvider.test.ts
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as assert from "assert";
+import { WorkspaceContext } from "../../../src/WorkspaceContext";
+import { folderContextPromise, globalWorkspaceContextPromise } from "../extension.test";
+import { SwiftPluginTaskProvider } from "../../../src/tasks/SwiftPluginTaskProvider";
+import { FolderContext } from "../../../src/FolderContext";
+import { executeTaskAndWaitForResult, mutable, waitForEndTaskProcess } from "../../utilities";
+
+suite("SwiftPluginTaskProvider Test Suite", () => {
+    let workspaceContext: WorkspaceContext;
+    let folderContext: FolderContext;
+
+    suiteSetup(async () => {
+        workspaceContext = await globalWorkspaceContextPromise;
+        folderContext = await folderContextPromise("command-plugin");
+        assert.notEqual(workspaceContext.folders.length, 0);
+        await folderContext.loadSwiftPlugins();
+        assert.notEqual(folderContext.swiftPackage.plugins.length, 0);
+    });
+
+    suite("createSwiftPluginTask", () => {
+        let taskProvider: SwiftPluginTaskProvider;
+
+        setup(() => {
+            taskProvider = new SwiftPluginTaskProvider(workspaceContext);
+        });
+
+        test("Exit code on success", async () => {
+            const task = taskProvider.createSwiftPluginTask(folderContext.swiftPackage.plugins[0], {
+                cwd: folderContext.folder,
+                scope: folderContext.workspaceFolder,
+            });
+            const { exitCode, output } = await executeTaskAndWaitForResult(task);
+            assert.equal(exitCode, 0);
+            assert.equal(output.trim(), "Hello, World!");
+        }).timeout(10000);
+
+        test("Exit code on failure", async () => {
+            const task = taskProvider.createSwiftPluginTask(
+                {
+                    command: "not_a_command",
+                    name: "not_a_command",
+                    package: "command-plugin",
+                },
+                {
+                    cwd: folderContext.folder,
+                    scope: folderContext.workspaceFolder,
+                }
+            );
+            mutable(task.execution).command = "/definitely/not/swift";
+            const { exitCode } = await executeTaskAndWaitForResult(task);
+            assert.notEqual(exitCode, 0);
+        }).timeout(10000);
+    });
+
+    suite("provideTasks", () => {
+        suite("includes command plugin provided by the extension", async () => {
+            let task: vscode.Task | undefined;
+
+            setup(async () => {
+                const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
+                task = tasks.find(t => t.name === "command-plugin");
+            });
+
+            test("provides", () => {
+                assert.equal(task?.detail, "swift package command_plugin");
+            });
+
+            test("executes", async () => {
+                assert(task);
+                const exitPromise = waitForEndTaskProcess(task);
+                await vscode.tasks.executeTask(task);
+                const exitCode = await exitPromise;
+                assert.equal(exitCode, 0);
+            }).timeout(30000); // 30 seconds to run
+        });
+
+        suite("includes command plugin provided by tasks.json", async () => {
+            let task: vscode.Task | undefined;
+
+            setup(async () => {
+                const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
+                task = tasks.find(t => t.name === "swift: command-plugin from tasks.json");
+            });
+
+            test("provides", () => {
+                assert.equal(task?.detail, "swift package command_plugin --foo");
+            });
+
+            test("executes", async () => {
+                assert(task);
+                const exitPromise = waitForEndTaskProcess(task);
+                await vscode.tasks.executeTask(task);
+                const exitCode = await exitPromise;
+                assert.equal(exitCode, 0);
+            }).timeout(30000); // 30 seconds to run
+        });
+    });
+});

--- a/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -1,0 +1,261 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as assert from "assert";
+import { WorkspaceContext } from "../../../src/WorkspaceContext";
+import { SwiftPluginTaskProvider } from "../../../src/tasks/SwiftPluginTaskProvider";
+import { SwiftToolchain } from "../../../src/toolchain/toolchain";
+import { SwiftExecution } from "../../../src/tasks/SwiftExecution";
+import { Version } from "../../../src/utilities/version";
+import { BuildFlags } from "../../../src/toolchain/BuildFlags";
+import { anything, deepEqual, instance, mock, when } from "ts-mockito";
+
+suite("SwiftPluginTaskProvider Unit Test Suite", () => {
+    let workspaceContext: WorkspaceContext;
+    let workspaceFolder: vscode.WorkspaceFolder;
+    let toolchain: SwiftToolchain;
+    let buildFlags: BuildFlags;
+
+    setup(async () => {
+        workspaceContext = mock(WorkspaceContext);
+        toolchain = mock(SwiftToolchain);
+        buildFlags = mock(BuildFlags);
+        workspaceFolder = {
+            uri: vscode.Uri.file("/path/to/workspace"),
+            name: "myWorkspace",
+            index: 0,
+        };
+        when(buildFlags.withSwiftSDKFlags(anything())).thenCall(args => args);
+        when(toolchain.swiftVersion).thenReturn(new Version(6, 0, 0));
+        when(toolchain.buildFlags).thenReturn(instance(buildFlags));
+        when(toolchain.getToolchainExecutable("swift")).thenReturn("/path/to/bin/swift");
+        when(workspaceContext.toolchain).thenReturn(instance(toolchain));
+    });
+
+    suite("resolveTask", () => {
+        test("uses SwiftExecution", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift",
+                    args: [],
+                },
+                workspaceFolder,
+                "run PackageExe",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            assert.equal(resolvedTask.execution instanceof SwiftExecution, true);
+        });
+
+        test("uses toolchain swift path", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift",
+                    args: [],
+                },
+                workspaceFolder,
+                "run PackageExe",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.equal(swiftExecution.command, "/path/to/bin/swift");
+        });
+
+        test("includes task's cwd", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    cwd: `${workspaceFolder.uri.fsPath}/myCWD`,
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.equal(swiftExecution.options.cwd, `${workspaceFolder.uri.fsPath}/myCWD`);
+        });
+
+        test("includes scope cwd", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.equal(swiftExecution.options.cwd, workspaceFolder.uri.fsPath);
+        });
+
+        test("includes resolved cwd", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    cwd: "myCWD",
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.equal(swiftExecution.options.cwd, `${workspaceFolder.uri.fsPath}/myCWD`);
+        });
+
+        test("includes fallback cwd", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    cwd: "myCWD",
+                },
+                vscode.TaskScope.Global,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.equal(swiftExecution.options.cwd, "myCWD");
+        });
+
+        test("includes command as argument", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    command: "my-plugin",
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.deepEqual(swiftExecution.args, ["package", "my-plugin"]);
+        });
+
+        test("includes sdk flags", async () => {
+            when(buildFlags.withSwiftSDKFlags(deepEqual(["package", "my-plugin"]))).thenReturn([
+                "package",
+                "my-plugin",
+                "--sdk",
+                "/path/to/sdk",
+            ]);
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    command: "my-plugin",
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.deepEqual(swiftExecution.args, [
+                "package",
+                "my-plugin",
+                "--sdk",
+                "/path/to/sdk",
+            ]);
+        });
+
+        test("disables sandbox", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    command: "my-plugin",
+                    disableSandbox: true,
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.deepEqual(swiftExecution.args, ["package", "--disable-sandbox", "my-plugin"]);
+        });
+
+        test("allows writing to package directory", async () => {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            const task = new vscode.Task(
+                {
+                    type: "swift-plugin",
+                    args: [],
+                    command: "my-plugin",
+                    allowWritingToPackageDirectory: true,
+                },
+                workspaceFolder,
+                "MyPlugin",
+                "swift"
+            );
+            const resolvedTask = taskProvider.resolveTask(
+                task,
+                new vscode.CancellationTokenSource().token
+            );
+            const swiftExecution = resolvedTask.execution as SwiftExecution;
+            assert.deepEqual(swiftExecution.args, [
+                "package",
+                "--allow-writing-to-package-directory",
+                "my-plugin",
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
* Wrote mostly unit tests for resolveTask and provideTasks
* Wrote some integration tests to make sure the vscode task APIs like fetchTasks and executeTasks work with these tasks
* Make sure can run a plugin task provided by the extension or resolved from the tasks.json

Issue: #1038