### PR TITLE
Warn instead of error on missing test framework version

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -754,7 +754,10 @@ export class SwiftToolchain {
         const plistKey = type === "XCTest" ? "XCTEST_VERSION" : "SWIFT_TESTING_VERSION";
         const version = infoPlist.DefaultProperties[plistKey];
         if (!version) {
-            throw Error(`Info.plist is missing the ${plistKey} key.`);
+            new SwiftOutputChannel("swift", true).appendLine(
+                `Warning: ${platformManifest} is missing the ${plistKey} key.`
+            );
+            return undefined;
         }
 
         if (swiftVersion.isGreaterThanOrEqual(new Version(5, 7, 0))) {


### PR DESCRIPTION
If the user's toolchain doesn't contain swift-testing its possible that the SWIFT_TESTING_VERSION key is missing from the platform manifest plist. If this is the case, log and return undefined instead of erroring and halting Toolchain setup.

Issue #1096 