### PR TITLE
Revert using universal debug adapter name

### DIFF
--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -24,9 +24,13 @@ import { SwiftToolchain } from "../toolchain/toolchain";
  * Class managing which debug adapter we are using. Will only setup lldb-vscode/lldb-dap if it is available.
  */
 export class DebugAdapter {
+    private static debugAdapaterExists = false;
+
     /** Debug adapter name */
     public static get adapterName(): string {
-        return "swift-lldb";
+        return configuration.debugger.useDebugAdapterFromToolchain && this.debugAdapaterExists
+            ? "swift-lldb"
+            : "lldb";
     }
 
     /** Return debug adapter for toolchain */
@@ -74,10 +78,12 @@ export class DebugAdapter {
                 );
             }
             workspace.outputChannel.log(`Failed to find ${lldbDebugAdapterPath}`);
+            this.debugAdapaterExists = false;
             contextKeys.lldbVSCodeAvailable = false;
             return false;
         }
 
+        this.debugAdapaterExists = true;
         contextKeys.lldbVSCodeAvailable = true;
         return true;
     }


### PR DESCRIPTION
The CodeLLDB extension expects the debug adapter to be called `lldb`. If we are using it and we don't call `registerDebugAdapterTrackerFactory` with `lldb` as the adapter name then we fail to get logs in the debugSessionCallback when running tests. This prevents XCTests results from being parsed, and hides the swift-testing output.

Revert a portion of #1024 that always set the debug adapter name to `swift-lldb` and use `lldb` when we're using CodeLLDB as the debug adapter.

Issue #1100