### PR TITLE
Only copy required files into Docker work directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 # dependencies
-RUN apt-get update && apt-get install -y curl gpg libasound2 libgbm1 libgtk-3-0 libnss3 xvfb build-essential
+RUN apt-get update && apt-get install -y rsync curl gpg libasound2 libgbm1 libgtk-3-0 libnss3 xvfb build-essential
 
 RUN useradd --user-group --create-home --system --skel /dev/null --home-dir /vscode vscode
 

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -3,7 +3,8 @@ set -ex
 current_directory=$(pwd)
 
 mkdir /tmp/code
-cp -r ./ /tmp/code/
+# Add the -v flag to see what is getting copied in to the working folder
+rsync -a --exclude 'node_modules' --exclude '.git' --exclude '.vscode-test' --exclude '.build' ./ /tmp/code/
 cd /tmp/code
 
 npm ci

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -4,7 +4,13 @@ current_directory=$(pwd)
 
 mkdir /tmp/code
 # Add the -v flag to see what is getting copied in to the working folder
-rsync -a --exclude 'node_modules' --exclude '.git' --exclude '.vscode-test' --exclude '.build' ./ /tmp/code/
+rsync -a --exclude "node_modules" \
+    --exclude "out" \
+    --exclude "dist" \
+    --exclude ".git" \
+    --exclude ".vscode-test" \
+    --exclude ".build" \
+    ./ /tmp/code/
 cd /tmp/code
 
 npm ci


### PR DESCRIPTION
Use `rsync` to exclude copying unnecessary files in to the working directory. This mainly helps speed up running the containers during local development since the developer may already have `node_modules`, `.build`, and `.vscode-test`, all of which can be quite large.