### PR TITLE
Check for broken links in CI

### DIFF
--- a/docs/contributor/test-strategy.md
+++ b/docs/contributor/test-strategy.md
@@ -1,6 +1,6 @@
 # Swift for Visual Studio Code test strategy
 
-This document covers the structure of tests as well as plans for the future. For a more in depth explanation of how to write and structure tests for your contributions, please see the [Writing Effective Tests](./writing-effective-tests.md) document in this repository
+This document covers the structure of tests as well as plans for the future. For a more in depth explanation of how to write and structure tests for your contributions, please see the [Writing Tests for VS Code Swift](./writing-tests-for-vscode-swift.md) document in this repository.
 
 The recommended way for [testing extensions](https://code.visualstudio.com/api/working-with-extensions/testing-extension) involves using either the new [vscode-test-cli](https://github.com/microsoft/vscode-test-cli) or creating your [own mocha test runner](https://code.visualstudio.com/api/working-with-extensions/testing-extension#advanced-setup-your-own-runner). Either approach results in Visual Studio Code getting downloaded, and a window spawned. This is necessary to have access the the APIs of the `vscode` namespace, to stimulate behaviour (ex. `vscode.tasks.executeTasks`) and obtain state (ex. `vscode.languages.getDiagnostics`).
 

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -124,3 +124,7 @@ EOF
 done
 
 rm "$tmp"
+
+printf "=> Checking for broken links in documentation... "
+find . -name node_modules -prune -o -name \*.md -print0 | xargs -0 -n1 npx markdown-link-check
+printf "\033[0;32mokay.\033[0m\n"


### PR DESCRIPTION
Check for broken links as part of the `soundness` job. The job will fail if a link returns a non 200 HTTP status code.

Fixes a broken link in `./docs/contributor/test-strategy.md`