### PR TITLE
Fix unit test that gets skipped if not on Windows

### DIFF
--- a/test/unit-tests/debugger/lldb.test.ts
+++ b/test/unit-tests/debugger/lldb.test.ts
@@ -26,6 +26,7 @@ import {
     mockGlobalObject,
     mockObject,
     MockedFunction,
+    mockGlobalValue,
 } from "../../MockUtils";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
@@ -34,9 +35,11 @@ suite("debugger.lldb Tests", () => {
     suite("getLLDBLibPath Tests", () => {
         let mockToolchain: MockedObject<SwiftToolchain>;
         let mockFindLibLLDB: MockedFunction<(typeof lldb)["findLibLLDB"]>;
+        const mockedPlatform = mockGlobalValue(process, "platform");
         const mockUtil = mockGlobalModule(util);
 
         setup(() => {
+            mockedPlatform.setValue("darwin");
             mockFindLibLLDB = sinon.stub();
             mockToolchain = mockObject<SwiftToolchain>({
                 getLLDB: mockFn(),
@@ -50,17 +53,14 @@ suite("debugger.lldb Tests", () => {
             expect(result.failure).to.have.property("message", "Failed to get LLDB");
         });
 
-        test("should return failure when execFile throws an error on windows", async function () {
-            if (process.platform !== "win32") {
-                this.skip();
-            } else {
-                mockToolchain.getLLDB.resolves("/path/to/lldb");
-                mockUtil.execFile.rejects(new Error("execFile failed"));
-                const result = await lldb.getLLDBLibPath(instance(mockToolchain));
-                // specific behaviour: return success and failure both undefined
-                expect(result.failure).to.equal(undefined);
-                expect(result.success).to.equal(undefined);
-            }
+        test("should return failure when execFile throws an error on windows", async () => {
+            mockedPlatform.setValue("win32");
+            mockToolchain.getLLDB.resolves("/path/to/lldb");
+            mockUtil.execFile.rejects(new Error("execFile failed"));
+            const result = await lldb.getLLDBLibPath(instance(mockToolchain));
+            // specific behaviour: return success and failure both undefined
+            expect(result.failure).to.equal(undefined);
+            expect(result.success).to.equal(undefined);
         });
 
         test("should return failure if findLibLLDB returns falsy values", async () => {

--- a/test/unit-tests/debugger/lldb.test.ts
+++ b/test/unit-tests/debugger/lldb.test.ts
@@ -39,7 +39,6 @@ suite("debugger.lldb Tests", () => {
         const mockUtil = mockGlobalModule(util);
 
         setup(() => {
-            mockedPlatform.setValue("darwin");
             mockFindLibLLDB = sinon.stub();
             mockToolchain = mockObject<SwiftToolchain>({
                 getLLDB: mockFn(),


### PR DESCRIPTION
There's a unit test that gets skipped if the platform isn't Windows in order to test some functionality of `getLLDBLibPath()`. Use `mockGlobalValue()` here to set the value of `process.platform` so that the test can run on all platforms.