### PR TITLE
Use source-map-support to provide better stack traces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "prettier": "3.3.2",
         "sinon": "^19.0.2",
         "sinon-chai": "^3.7.0",
+        "source-map-support": "^0.5.21",
         "strip-ansi": "^6.0.1",
         "typescript": "^5.5.3"
       },
@@ -2233,6 +2234,13 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "dev": true
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -5846,6 +5854,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -8049,6 +8078,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "call-bind": {
@@ -10663,6 +10698,22 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "spdx-correct": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1322,6 +1322,7 @@
     "prettier": "3.3.2",
     "sinon": "^19.0.2",
     "sinon-chai": "^3.7.0",
+    "source-map-support": "^0.5.21",
     "strip-ansi": "^6.0.1",
     "typescript": "^5.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -1268,9 +1268,9 @@
   "scripts": {
     "vscode:prepublish": "npm run esbuild-bundle",
     "esbuild-base": "del-cli ./dist && esbuild \"./src/**/*.ts\" --outdir=dist --format=cjs --platform=node --target=node18",
-    "esbuild": "npm run esbuild-base -- --sourcemap",
-    "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
-    "esbuild-bundle": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify",
+    "esbuild": "npm run esbuild-base",
+    "esbuild-watch": "npm run esbuild-base -- --watch",
+    "esbuild-bundle": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify --sourcemap",
     "compile": "tsc",
     "watch": "tsc --watch",
     "lint": "eslint ./ --ext ts && tsc --noEmit",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -263,7 +263,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api | 
         // show this error message as the VS Code error message only shows when running
         // the extension through the debugger
         vscode.window.showErrorMessage(`Activating Swift extension failed: ${errorMessage}`);
-        throw Error(errorMessage);
+        throw error;
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Use source-map-support to get better stack traces
+import "source-map-support/register";
+
 import * as vscode from "vscode";
 import * as commands from "./commands";
 import * as debug from "./debugger/launch";

--- a/test/common.ts
+++ b/test/common.ts
@@ -11,6 +11,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+// Use source-map-support to get better stack traces
+import "source-map-support/register";
+
 import * as chai from "chai";
 import * as sinonChai from "sinon-chai";
 import * as chaiAsPromised from "chai-as-promised";


### PR DESCRIPTION
The stack traces that we get from users' logs and the ones within the tests aren't very helpful since they point to transpiled code. Use the `source-map-support` module to automatically re-map stack traces in errors to their original source location to make it easier to find problems in the future. I've also updated our build scripts to always generate source maps even when packaging for production.