### PR TITLE
Ensure that integration tests execute the same code as the extension

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -27,7 +27,7 @@ module.exports = defineConfig({
     tests: [
         {
             label: "integrationTests",
-            files: ["out/test/common.js", "out/test/integration-tests/**/*.test.js"],
+            files: ["dist/test/common.js", "dist/test/integration-tests/**/*.test.js"],
             version: process.env["VSCODE_VERSION"] ?? "stable",
             workspaceFolder: "./assets/test",
             launchArgs: [
@@ -50,7 +50,7 @@ module.exports = defineConfig({
         },
         {
             label: "unitTests",
-            files: ["out/test/common.js", "out/test/unit-tests/**/*.test.js"],
+            files: ["dist/test/common.js", "dist/test/unit-tests/**/*.test.js"],
             version: process.env["VSCODE_VERSION"] ?? "stable",
             launchArgs: [
                 "--disable-extensions",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
 	// See http://go.microsoft.com/fwlink/?LinkId=827846
 	// for the documentation about the extensions.json format
 	"recommendations": [
-		"connor4312.esbuild-problem-matchers",
 		"dbaeumer.vscode-eslint",
 		"esbenp.prettier-vscode"
 	]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,6 @@
 				"--profile=testing-debug"
 			],
 			"outFiles": [
-				"${workspaceFolder}/out/**/*.js",
 				"${workspaceFolder}/dist/**/*.js"
 			],
 			"env": {
@@ -45,7 +44,7 @@
 			"testConfiguration": "${workspaceFolder}/.vscode-test.js",
 			"testConfigurationLabel": "unitTests",
 			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
+				"${workspaceFolder}/dist/**/*.js"
 			],
 			"preLaunchTask": "compile-tests"
 		}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 // Place your settings in this file to overwrite default and user settings.
 {
     "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
+        "dist": false // set this to true to hide the "dist" folder with the compiled JS files
     },
     "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
+        "dist": true // set this to false to include "dist" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,11 +6,12 @@
 		{
 			"label": "build",
 			"type": "npm",
-			"script": "esbuild",
-			"problemMatcher": "$esbuild",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
 			"presentation": {
 				"reveal": "never"
 			},
+			"isBackground": true,
 			"group": {
 				"kind": "build",
 				"isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,9 +6,8 @@
 		{
 			"label": "build",
 			"type": "npm",
-			"script": "esbuild-watch",
-			"problemMatcher": "$esbuild-watch",
-			"isBackground": true,
+			"script": "esbuild",
+			"problemMatcher": "$esbuild",
 			"presentation": {
 				"reveal": "never"
 			},

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ nvm install
 npm install
 ```
 
-When you first open the project in VS Code you will be recommended to also install [`ESLint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint), [`Prettier - Code formatter`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [`esbuild Problem Matchers`](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers). Please do so. `ESLint`, `Prettier - Code formatter` is used to ensure a consistent style and we expect everyone who contributes to follow this style as well. `esbuild Problem Matchers` provides proper error output from building the project.
+When you first open the project in VS Code you will be recommended to also install [`ESLint`](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [`Prettier - Code formatter`](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode). Please do so. `ESLint`, `Prettier - Code formatter` is used to ensure a consistent style and we expect everyone who contributes to follow this style as well.
 
 To run your version of the Swift extension while in VS Code, press `F5`. This will open up another instance of VS Code with it running. You can use the original version of VS Code to debug it.
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "workspaceContains:compile_commands.json",
     "onDebugResolve:swift-lldb"
   ],
-  "main": "./dist/extension.js",
+  "main": "./dist/src/extension.js",
   "contributes": {
     "icons": {
       "swift-icon": {
@@ -1267,11 +1267,9 @@
   ],
   "scripts": {
     "vscode:prepublish": "npm run esbuild-bundle",
-    "esbuild-base": "del-cli ./dist && esbuild \"./src/**/*.ts\" --outdir=dist --format=cjs --platform=node --target=node18",
-    "esbuild": "npm run esbuild-base",
-    "esbuild-watch": "npm run esbuild-base -- --watch",
-    "esbuild-bundle": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify --sourcemap",
-    "compile": "tsc",
+    "esbuild": "del-cli ./dist && esbuild \"./src/**/*.ts\" --outdir=dist/src --format=cjs --platform=node --target=node18 --sourcemap",
+    "esbuild-bundle": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/src/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify  --sourcemap",
+    "compile": "del-cli ./dist && tsc",
     "watch": "tsc --watch",
     "lint": "eslint ./ --ext ts && tsc --noEmit",
     "format": "prettier --check *.json src test",
@@ -1283,7 +1281,7 @@
     "integration-test": "npm test -- --label integrationTests",
     "unit-test": "npm test -- --label unitTests",
     "coverage": "npm test -- --coverage",
-    "compile-tests": "del-cli ./assets/test/**/.build && npm run compile && npm run esbuild",
+    "compile-tests": "del-cli ./assets/test/**/.build && npm run compile",
     "package": "vsce package",
     "dev-package": "vsce package --no-update-package-json 1.12.0-dev",
     "preview-package": "vsce package --pre-release",

--- a/package.json
+++ b/package.json
@@ -1266,11 +1266,10 @@
     "vadimcn.vscode-lldb"
   ],
   "scripts": {
-    "vscode:prepublish": "npm run esbuild-bundle",
-    "esbuild": "del-cli ./dist && esbuild \"./src/**/*.ts\" --outdir=dist/src --format=cjs --platform=node --target=node18 --sourcemap",
-    "esbuild-bundle": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/src/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify  --sourcemap",
+    "vscode:prepublish": "npm run bundle",
+    "bundle": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/src/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify --sourcemap",
     "compile": "del-cli ./dist && tsc",
-    "watch": "tsc --watch",
+    "watch": "del-cli ./dist && tsc --watch",
     "lint": "eslint ./ --ext ts && tsc --noEmit",
     "format": "prettier --check *.json src test",
     "pretest": "npm run compile-tests",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,5 @@
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
   },
-  "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
-  ],
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2020",
-    "outDir": "out",
+    "outDir": "dist",
     "lib": ["ES2020"],
     "sourceMap": true,
     "strict": true /* enable all strict type-checking options */
@@ -11,5 +11,8 @@
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
   },
-  "exclude": ["node_modules", ".vscode-test"]
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
 }


### PR DESCRIPTION
Build the test code and source into `./dist` rather than `./out`. This fixes two issues:

1. The test code used to import different source modules from VS Code which caused issues during integration tests.
2. The code coverage for integration tests was inconsistent as it was coming from code executed from both the `dist` and `out` folders.

The downside of this approach is that building in `watch` mode can overwrite files when you try to run a test at the same time. Thankfully, this can be easily solved by performing a separate build every time the extension host is launched. There is no noticeable performance impact with this as `esbuild` is quite fast.