### PR TITLE
Fix error in extension.test.ts

### DIFF
--- a/test/integration-tests/extension.test.ts
+++ b/test/integration-tests/extension.test.ts
@@ -14,32 +14,39 @@
 
 import * as vscode from "vscode";
 import * as assert from "assert";
-import * as swiftExtension from "../../src/extension";
+import { Api } from "../../src/extension";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { getBuildAllTask } from "../../src/tasks/SwiftTaskProvider";
 import { SwiftExecution } from "../../src/tasks/SwiftExecution";
 import { testAssetUri } from "../fixtures";
 import { FolderContext } from "../../src/FolderContext";
 
-export const rootWorkspaceFolder = vscode.workspace.workspaceFolders?.values().next().value;
-export const globalWorkspaceContextPromise = new Promise<WorkspaceContext>(resolve => {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.values().next().value;
-    if (!workspaceFolder) {
-        throw new Error("No workspace folders found in workspace");
+function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
+    const result = vscode.workspace.workspaceFolders?.at(0);
+    if (!result) {
+        throw new Error("No workspace folders are present");
     }
-    const ext = vscode.extensions.getExtension<swiftExtension.Api>("sswg.swift-lang")!;
-    ext.activate().then(api => {
-        const packageFolder = testAssetUri("defaultPackage");
-        api.workspaceContext
-            .addPackageFolder(packageFolder, rootWorkspaceFolder)
-            .then(() => resolve(api.workspaceContext));
-    });
-});
+    return result;
+}
+
+export const globalWorkspaceContextPromise: Promise<WorkspaceContext> = (async () => {
+    const workspaceFolder = getRootWorkspaceFolder();
+    const ext = vscode.extensions.getExtension<Api>("sswg.swift-lang");
+    if (!ext) {
+        throw new Error(`Unable to find extension "sswg.swift-lang"`);
+    }
+    const api = await ext.activate();
+    const packageFolder = testAssetUri("defaultPackage");
+    await api.workspaceContext.addPackageFolder(packageFolder, workspaceFolder);
+    return api.workspaceContext;
+})();
+
 export const folderContextPromise = async (name: string): Promise<FolderContext> => {
+    const workspaceFolder = getRootWorkspaceFolder();
     const workspaceContext = await globalWorkspaceContextPromise;
     let folder = workspaceContext.folders.find(f => f.workspaceFolder.name === `test/${name}`);
     if (!folder) {
-        folder = await workspaceContext.addPackageFolder(testAssetUri(name), rootWorkspaceFolder);
+        folder = await workspaceContext.addPackageFolder(testAssetUri(name), workspaceFolder);
     }
     return folder;
 };

--- a/test/integration-tests/extension.test.ts
+++ b/test/integration-tests/extension.test.ts
@@ -23,9 +23,7 @@ import { FolderContext } from "../../src/FolderContext";
 
 function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     const result = vscode.workspace.workspaceFolders?.at(0);
-    if (!result) {
-        throw new Error("No workspace folders are present");
-    }
+    assert(result, "No workspace folders were opened for the tests to use");
     return result;
 }
 


### PR DESCRIPTION
VS Code recently updated its built-in TypeScript Language Server to v5.6.2 which shows an error in `extension.test.ts` that is not present in CI (currently this repo uses TypeScript 5.5.2). However, this is a legitimate issue as the `rootWorkspaceFolder` variable can indeed be undefined.

I've simply fixed up the code in this area to properly handle the fact that the variable can be undefined as well as an issue where a `throw` would not have been handled properly. However, I'm hesitant to jump to TypeScript 5.6.2 since TypeScript ESLint currently does not support 5.6.