### PR TITLE
Rename the extension from `sswg.swift-lang` to `swiftlang.vscode-swift`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,10 @@ If you haven't already, follow the instructions in [Development](#development) t
 npm run dev-package
 ```
 
-This builds a file that looks like `swift-lang-[version]-dev.vsix`. Now install the extension with:
+This builds a file that looks like `vscode-swift-[version]-dev.vsix`. Now install the extension with:
 
 ```sh
-code --install-extension swift-lang-[version]-dev.vsix
+code --install-extension vscode-swift-[version]-dev.vsix
 ```
 
 Alternatively you can install the extension from the Extensions panel by clicking the `...` button at the top of the panel and choosing `Install from VSIX...`.

--- a/README.md
+++ b/README.md
@@ -12,17 +12,19 @@ This extension adds language support for Swift to Visual Studio Code. It support
 
 Swift support uses [SourceKit LSP](https://github.com/apple/sourcekit-lsp) for the [language server](https://microsoft.github.io/language-server-protocol/overviews/lsp/overview/) to power code completion and [LLDB](https://github.com/vadimcn/vscode-lldb) to enable debugging.
 
-The extension is developed by members of the Swift Community and maintained by the [SSWG](https://www.swift.org/sswg/). The aim is to provide a first-class, feature complete extension to make developing Swift applications on all platforms a seamless experience.
+The aim is to provide a first-class, feature complete extension to make developing Swift applications on all platforms a seamless experience.
 
 If you experience any issues or want to propose new features please [create an issue](https://github.com/swiftlang/vscode-swift/issues/new) or post on the [swift.org forums](https://forums.swift.org) in the [VS Code Swift Extension category](https://forums.swift.org/c/related-projects/vscode-swift-extension/).
 
 ## Contributing
 
-The Swift for Visual Studio Code extension is a community driven project, developed by the amazing Swift community. Any kind of contribution is appreciated, including code, tests and documentation. For more details see [CONTRIBUTING.md](CONTRIBUTING.md).
+The Swift for Visual Studio Code extension is a community driven project originally created by the [Swift Server Working Group](https://www.swift.org/sswg/) and now maintained as part of the [swiftlang organization](https://github.com/swiftlang/). Contributions are appreciated, including code, tests and documentation. For more details see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+To give clarity of what is expected of our members, Swift has adopted the code of conduct defined by the Contributor Covenant. This document is used across many open source communities, and we think it articulates our values well. For more, see the [Code of Conduct](https://swift.org/code-of-conduct/).
 
 ## Installation
 
-For the extension to work, you must have Swift installed on your system. Please see the [Getting Started Guide on Swift.org](https://www.swift.org/getting-started/) for details on how to install Swift on your system. Install the extension from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sswg.swift-lang) and open a Swift package! You'll be prompted to install and configure the CodeLLDB extension, which you should do so.
+For the extension to work, you must have Swift installed on your system. Please see the [Getting Started Guide on Swift.org](https://www.swift.org/getting-started/) for details on how to install Swift on your system. Install the extension from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=swiftlang.vscode-swift) and open a Swift package! You'll be prompted to install and configure the CodeLLDB extension, which you should do so.
 
 ## Features
 

--- a/docs/remote-dev.md
+++ b/docs/remote-dev.md
@@ -21,7 +21,7 @@ First create the directory. Next, create `devcontainer.json` and insert the foll
     "name": "Swift 5.5",
     "image": "swift:5.5",
     "extensions": [
-      "sswg.swift-lang"
+      "swiftlang.vscode-swift"
     ],
     "settings": {
       "lldb.library": "/usr/lib/liblldb.so"
@@ -73,7 +73,7 @@ Your `devcontainer.json` should look something like this
     "service": "app",
     "workspaceFolder": "/workspace",
     "extensions": [
-      "sswg.swift-lang",
+      "swiftlang.vscode-swift",
     ],
     "settings": {
       "lldb.library": "/usr/lib/liblldb.so"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "swift-lang",
   "version": "1.11.4",
+  "name": "vscode-swift",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "swift-lang",
       "version": "1.11.4",
       "hasInstallScript": true,
+      "name": "vscode-swift",
       "dependencies": {
         "@vscode/codicons": "^0.0.36",
         "lcov-parse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "swift-lang",
+  "name": "vscode-swift",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
   "version": "1.11.4",
-  "publisher": "sswg",
+  "publisher": "swiftlang",
   "icon": "icon.png",
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
   ],
   "keywords": [
     "swift",
+    "swiftlang",
     "sswg"
   ],
   "activationEvents": [

--- a/test/integration-tests/ExtensionActivation.test.ts
+++ b/test/integration-tests/ExtensionActivation.test.ts
@@ -33,7 +33,7 @@ suite("Extension Activation/Deactivation Tests", () => {
 
         async function activate(currentTest?: Mocha.Test) {
             assert.ok(await activateExtension(currentTest), "Extension did not return its API");
-            const ext = vscode.extensions.getExtension("sswg.swift-lang");
+            const ext = vscode.extensions.getExtension("swiftlang.vscode-swift");
             assert.ok(ext, "Extension is not found");
             assert.strictEqual(ext.isActive, true);
         }
@@ -57,7 +57,7 @@ suite("Extension Activation/Deactivation Tests", () => {
     test("Deactivation", async function () {
         const workspaceContext = await activateExtension(this.test as Mocha.Test);
         await deactivateExtension();
-        const ext = vscode.extensions.getExtension("sswg.swift-lang");
+        const ext = vscode.extensions.getExtension("swiftlang.vscode-swift");
         assert(ext);
         assert.equal(workspaceContext.subscriptions.length, 0);
     });

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -129,7 +129,7 @@ const extensionBootstrapper = (() => {
                     `Extension is already activated. Last test that activated the extension: ${lastTestName}`
                 );
             }
-            const extensionId = "sswg.swift-lang";
+            const extensionId = "swiftlang.vscode-swift";
             const ext = vscode.extensions.getExtension<Api>(extensionId);
             if (!ext) {
                 throw new Error(`Unable to find extension "${extensionId}"`);
@@ -138,7 +138,7 @@ const extensionBootstrapper = (() => {
             let workspaceContext: WorkspaceContext | undefined;
 
             // We can only _really_ call activate through
-            // `vscode.extensions.getExtension<Api>("sswg.swift-lang")` once.
+            // `vscode.extensions.getExtension<Api>("swiftlang.vscode-swift")` once.
             // Subsequent activations must be done through the returned API object.
             if (!activator) {
                 activatedAPI = await ext.activate();


### PR DESCRIPTION
In preparation for the move in the VS Code marketplace, rename the extension ID and associated references in the documentation.