### PR TITLE
Don't mark swift-testing test case results as runnable

### DIFF
--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -231,8 +231,13 @@ export function upsertTestItem(
     // parent tags down the tree as children are upserted.
     testItem = applyTagsToChildren(testItem);
 
-    // Manually add the test style as a tag so we can filter by test type.
-    newItem.tags = [{ id: testItem.style }, ...testItem.tags];
+    const hasTestStyleTag = testItem.tags.find(tag => tag.id === testItem.style);
+
+    // Manually add the test style as a tag if it isn't already in the tags list.
+    // This lets the user filter by test type.
+    newItem.tags = hasTestStyleTag
+        ? [...testItem.tags]
+        : [{ id: testItem.style }, ...testItem.tags];
 
     if (testItem.disabled === false) {
         newItem.tags = [...newItem.tags, runnableTag];

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -18,7 +18,7 @@ import * as stream from "stream";
 import * as os from "os";
 import * as asyncfs from "fs/promises";
 import { FolderContext } from "../FolderContext";
-import { execFile, getErrorDescription } from "../utilities/utilities";
+import { compactMap, execFile, getErrorDescription } from "../utilities/utilities";
 import { createSwiftTask } from "../tasks/SwiftTaskProvider";
 import configuration from "../configuration";
 import { WorkspaceContext } from "../WorkspaceContext";
@@ -127,7 +127,12 @@ export class TestRunProxy {
                 testClass.location = undefined;
 
                 // Results should inherit any tags from the parent.
-                testClass.tags = parent.tags.map(t => new vscode.TestTag(t.id));
+                // Until we can rerun a swift-testing test with an individual argument, mark
+                // the argument test items as not runnable. This should be revisited when
+                // https://github.com/swiftlang/swift-testing/issues/671 is resolved.
+                testClass.tags = compactMap(parent.tags, t =>
+                    t.id === runnableTag.id ? null : new vscode.TestTag(t.id)
+                );
 
                 const added = upsertTestItem(this.controller, testClass, parent);
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -206,6 +206,26 @@ export function wait(milliseconds: number): Promise<void> {
 }
 
 /**
+ * Returns an array containing the non-null and non-undefined results of calling
+ * the given transformation with each element of this sequence.
+ *
+ * @param arr An array to map
+ * @param transform A transformation function to apply to each element
+ * @returns An array containing the non-null and non-undefined results of calling transform on each element
+ */
+export function compactMap<T, U>(
+    arr: readonly T[],
+    transform: (value: T) => U | null | undefined
+): U[] {
+    return arr.reduce<U[]>((acc, item) => {
+        const result = transform(item);
+        if (result !== null && result !== undefined) {
+            acc.push(result);
+        }
+        return acc;
+    }, []);
+}
+/**
  * Get path to swift executable, or executable in swift bin folder
  *
  * @param exe name of executable to return


### PR DESCRIPTION
When running a swift-testing test that takes arguments the results are added to the Test Explorer showing their pass/fail status. At this time these tests cannot be run with a specific argument so these tests should not be marked as runnable. This prevents the "Run", "Debug" and "Coverage" buttons from appearing on the test items in the explorer.

Issue: #1147