### PR TITLE
Associate XCTest suite start/stop with test item

### DIFF
--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -20,6 +20,14 @@ import * as vscode from "vscode";
 export interface ITestRunState {
     // excess data from previous parse that was not processed
     excess?: string;
+
+    // the currently running suite, with the test target included, i.e: TestTarget.Suite
+    // note that TestTarget is only present on Darwin.
+    activeSuite?: string;
+
+    // output captured before a test has run in a suite
+    pendingSuiteOutput?: string[];
+
     // failed test state
     failedTest?: {
         testIndex: number;

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -323,7 +323,7 @@ export class TestRunner {
 
     /**
      * If the request has no test items to include in the run,
-     * default to usig all the items in the `TestController`.
+     * default to using all the items in the `TestController`.
      */
     private ensureRequestIncludesTests(request: vscode.TestRunRequest): vscode.TestRunRequest {
         if ((request.include?.length ?? 0) > 0) {
@@ -1261,13 +1261,9 @@ export class TestRunnerTestRunState implements ITestRunState {
             return;
         }
 
-        const uri = this.testRun.testItems[index].uri;
-        const range = this.testRun.testItems[index].range;
-        let location: vscode.Location | undefined;
-        if (uri && range) {
-            location = new vscode.Location(uri, range);
-        }
-
-        this.testRun.appendOutputToTest(output, this.testRun.testItems[index], location);
+        const testItem = this.testRun.testItems[index];
+        const { uri, range } = testItem;
+        const location = uri && range ? new vscode.Location(uri, range) : undefined;
+        this.testRun.appendOutputToTest(output, testItem, location);
     }
 }

--- a/test/integration-tests/testexplorer/MockTestRunState.ts
+++ b/test/integration-tests/testexplorer/MockTestRunState.ts
@@ -67,6 +67,7 @@ export class TestRunState implements ITestRunState {
         lineNumber: number;
         complete: boolean;
     };
+    allOutput: string[] = [];
 
     public testItemFinder: ITestItemFinder;
 
@@ -123,6 +124,7 @@ export class TestRunState implements ITestRunState {
         if (index !== undefined) {
             this.testItemFinder.tests[index].output.push(output);
         }
+        this.allOutput.push(output);
     }
 
     // started suite


### PR DESCRIPTION
Capture the XCTest output associated with suites and assocaite it with the test item that appears in the test run history. This makes it easy to see the start/end time output of a suite by clicking on it.

In order to capture the test target for a suite we need to wait for the first test that executes within that suite in order to get the target. For whatever reason, XCTest does not print a suites target, only a test's when it starts. The approach is if a suite starts, queue output up until the first test run, then associate the last line of queued output with the test target found on the started test. Lines before the last line are not assocaited with a test (these are typically the top level suite like "Selected Tests" or the test target name.

Issue: #1148