### PR TITLE
Improve Test Cancellation

### DIFF
--- a/src/commands/testMultipleTimes.ts
+++ b/src/commands/testMultipleTimes.ts
@@ -39,20 +39,20 @@ export async function runTestMultipleTimes(
     if (!str || !currentFolder.testExplorer) {
         return;
     }
-
+    const token = new vscode.CancellationTokenSource();
     const numExecutions = parseInt(str);
     const testExplorer = currentFolder.testExplorer;
     const runner = new TestRunner(
         TestKind.standard,
         new vscode.TestRunRequest([test]),
         currentFolder,
-        testExplorer.controller
+        testExplorer.controller,
+        token.token
     );
 
     testExplorer.onDidCreateTestRunEmitter.fire(runner.testRun);
 
     const testRunState = new TestRunnerTestRunState(runner.testRun);
-    const token = new vscode.CancellationTokenSource();
 
     vscode.commands.executeCommand("workbench.panel.testResults.view.focus");
 
@@ -63,7 +63,7 @@ export async function runTestMultipleTimes(
 
         const runState = await (testRunner !== undefined
             ? testRunner()
-            : runner.runSession(token.token, testRunState));
+            : runner.runSession(testRunState));
 
         runStates.push(runState);
 

--- a/src/utilities/cancellation.ts
+++ b/src/utilities/cancellation.ts
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+
+/**
+ * An implementation of `vscode.CancellationToken` that monitors multiple child
+ * tokens and emits on the `onCancellationRequested` event when any of them are cancelled.
+ */
+export class CompositeCancellationToken implements vscode.CancellationToken, vscode.Disposable {
+    private tokens: vscode.CancellationToken[] = [];
+    private disposables: vscode.Disposable[] = [];
+    private cancellationRequestedEmitter: vscode.EventEmitter<unknown> = new vscode.EventEmitter();
+    private cancelled: boolean = false;
+
+    public onCancellationRequested: vscode.Event<unknown> = this.cancellationRequestedEmitter.event;
+
+    public constructor(...tokens: vscode.CancellationToken[]) {
+        tokens.forEach(token => this.add(token));
+    }
+
+    public get isCancellationRequested(): boolean {
+        return this.tokens.find(t => t.isCancellationRequested) !== undefined;
+    }
+
+    public add(token: vscode.CancellationToken) {
+        this.tokens.push(token);
+        this.disposables.push(
+            token.onCancellationRequested(e => {
+                // Ensure we only trigger once even if multiple children are cancelled.
+                if (this.cancelled) {
+                    return;
+                }
+                this.cancelled = true;
+                this.cancellationRequestedEmitter.fire(e);
+            })
+        );
+    }
+
+    public dispose() {
+        this.disposables.forEach(d => d.dispose());
+    }
+}


### PR DESCRIPTION
There are two ways to cancel a running test, one via the Cancel button at the top of the test explorer, and the other using the Cancel button in the test run tree in the bottom right of the Test Results output panel.

We were handling cancellation via the first method, but the one in the test run tree uses a different cancellation token to indicate a test run should be cancelled. It is is found on the constructed vscode.TestRun.

In our situation we want both of these to do the same thing, cancel the build if its running and stop the test run if its running.

Create a `CompositeCancellationToken` that wraps both these child tokens and performs cancellation if either of them request cancellation.

This approach also centralizes the cancellation logic to the `TestRunProxy`, removing the need to pass the test explorer's token around to the `TestRunner` methods.

This patch also improves cancellation when debugging, ensuring that if you're doing a swift-testing + XCTest debugging run and you cancel during the first test type the second one wont start.

Finally, print a "Test run cancelled" message in the test run output to make it easier to see if a run was cancelled. This is helpful when you're looking through the test results tree at old runs.

Issue: #1145