### PR TITLE
Unblock CI check for unacceptable language

### DIFF
--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,0 +1,3 @@
+NOTICE.txt
+src/utilities/utilities.ts
+src/tasks/SwiftProcess.ts

--- a/.unacceptablelanguageignore
+++ b/.unacceptablelanguageignore
@@ -1,3 +1,2 @@
-NOTICE.txt
 src/utilities/utilities.ts
 src/tasks/SwiftProcess.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,7 +327,7 @@ Merge debug adapter changes from v1.6.x prerelease builds into main release.
 ### Fixed
 
 - Ensure we catch errors when decoding `Info.plist` on Windows.
-- Killing of `xctest` process if testing is cancelled.
+- Halt `xctest` process if testing is cancelled.
 
 ## 1.2.0 - 2023-03-22
 
@@ -587,14 +587,14 @@ Version 0.5.0 of vscode-swift now requires v1.65.0 of Visual Studio Code
 ### Added
 
 - Store XCTest class locations in related TestItem. This will augment source code with an icon to run all the tests in a class.
-- Cancellation support for tests. When you cancel a test the underlying process is killed (previously it was left running).
+- Cancellation support for tests. When you cancel a test the underlying process is halted (previously it was left running).
 - Show Test Explorer output view as soon as testing starts.
 - Option to enable/disable the auto-generation of launch.json configurations (default: on).
 - Option to add compile errors to the problems view (default: on).
 
 ### Changed
 
-- Run non-debug test sessions outside of debugger. Now a crash test will not hang inside the debugger. Also we can stream test output to the test explorer view.
+- Run non-debug test sessions outside of debugger. Now a crash test will not suspend inside the debugger. Also we can stream test output to the test explorer view.
 - Show skipped tests as skipped, instead of passed.
 
 ## 0.4.0 - 2022-03-22

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ To begin development on the VS Code extension for Swift you will need to install
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 ```
-More details on nvm installation can be found in the [README](https://github.com/nvm-sh/nvm/blob/master/README.md) from its GitHub repository.
+More details on nvm installation can be found in the [README](https://github.com/nvm-sh/nvm/?tab=readme-ov-file) from its GitHub repository.
 
 Once you have installed nvm, you can clone and configure the repository.
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -34,6 +34,6 @@ This product contains source code from Apple's SourceKit LSP project
 This product contains source code from CodeLLDB vscode LLDB extension
 
   * LICENSE (MIT):
-    * https://github.com/vadimcn/vscode-lldb/blob/master/LICENSE
+    * https://github.com/vadimcn/codelldb/tree/HEAD/LICENSE
   * HOMEPAGE:
     * https://github.com/vadimcn/vscode-lldb

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -249,7 +249,7 @@ export class TestExplorer {
                 // get build options before build is run so we can be sure they aren't changed
                 // mid-build
                 const testBuildOptions = buildOptions(toolchain);
-                // normally we wouldn't run the build here, but you can hang swiftPM on macOS
+                // normally we wouldn't run the build here, but you can suspend swiftPM on macOS
                 // if you try and list tests while skipping the build if you are using a different
                 // sanitizer settings
                 if (process.platform === "darwin" && configuration.sanitizer !== "off") {

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -61,9 +61,9 @@ export interface SwiftProcess {
      */
     handleInput(s: string): void;
     /**
-     * Forcefully kill the pty process. Optionally can provide a signal.
+     * Forcefully terminate the pty process. Optionally can provide a signal.
      */
-    kill(signal?: NodeJS.Signals): void;
+    terminate(signal?: NodeJS.Signals): void;
     /**
      * Resize the pty to match the new {@link vscode.Pseudoterminal} dimensions
      *
@@ -129,7 +129,7 @@ export class SwiftPtyProcess implements SwiftProcess {
         this.spawnedProcess?.write(s);
     }
 
-    kill(signal?: NodeJS.Signals): void {
+    terminate(signal?: NodeJS.Signals): void {
         if (!this.spawnedProcess) {
             return;
         }

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -81,16 +81,16 @@ export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Dispos
     /**
      * Called by vscode when the user interacts with the
      * terminal. Here we will handle any special sequences,
-     * ex. ctrl+c to kill, and otherwise pass the input along
+     * ex. ctrl+c to terminate, and otherwise pass the input along
      * to {@link SwiftProcess.handleInput}
      *
      * @param data VT sequence as a string
      */
     handleInput(data: string): void {
         const buf: Buffer = Buffer.from(data);
-        // Kill on ctrl+c
+        // Terminate process on ctrl+c
         if (buf.length === 1 && buf[0] === 3) {
-            this.swiftProcess.kill();
+            this.swiftProcess.terminate();
         } else {
             this.swiftProcess.handleInput(data);
         }
@@ -105,6 +105,6 @@ export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Dispos
     onDidClose: vscode.Event<number | void> = this.closeEmitter.event;
 
     close(): void {
-        this.swiftProcess.kill();
+        this.swiftProcess.terminate();
     }
 }

--- a/test/MockUtils.ts
+++ b/test/MockUtils.ts
@@ -118,7 +118,7 @@ function replaceWithMocks<T>(obj: Partial<T>): MockedObject<T> {
             }
         } catch (error) {
             // Certain VSCode internals are locked behind API flags that will
-            // throw an error if not set. Hang onto the error and throw it later
+            // throw an error if not set. Hold onto the error and throw it later
             // if this property is actually accessed by the test.
             (error as any)._wasThrownByRealObject = true;
             result[property] = error;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -72,7 +72,7 @@ export class TestSwiftProcess implements SwiftProcess {
         this.closeEmitter.fire(exitCode);
     }
 
-    kill(): void {
+    terminate(): void {
         this.close(8);
     }
 


### PR DESCRIPTION
Rewords documentation and APIs that don't meet Apple's unacceptable language standards. Unblocks the CI check that runs the check-unacceptable-language.sh script.

Issue: #1161