### PR TITLE
Don't allow major updates of typescript-eslint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "strip-ansi"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/vscode"
     groups:
       all-dependencies:


### PR DESCRIPTION
Major update breaks dependabot. Will leave until a later time when we can properly move to version 8
https://github.com/swiftlang/vscode-swift/pull/1160

Issue: #1136