### PR TITLE
Don't allow major updates of chai

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@typescript-eslint/*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "*chai*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/vscode"
     groups:
       all-dependencies:


### PR DESCRIPTION
Major update breaks dependabot. Will leave until a later time when we can properly migrate to the next major version of the various chai dependencies.

https://github.com/swiftlang/vscode-swift/pull/1167

Issue: #1136