### PR TITLE
Don't allow major updates of vsce

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "*chai*"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@vscode/vsce"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@types/vscode"
     groups:
       all-dependencies:


### PR DESCRIPTION
Major update breaks dependabot because require going to node.js 20. Will leave until a later time when we can properly migrate to the next major version of node.js and vsce

https://github.com/swiftlang/vscode-swift/pull/1171

Issue: #1136