### PR TITLE
Update licence header

### DIFF
--- a/.licenseignore
+++ b/.licenseignore
@@ -1,0 +1,12 @@
+.devcontainer
+*.md
+*.woff
+*.json
+*.txt
+*.png
+*.jpg
+*.code-snippets
+\.**
+LICENSE
+assets/test/*
+docker

--- a/.mocha-reporter.js
+++ b/.mocha-reporter.js
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,7 +4,7 @@ Visual Studio Code Swift Extension project
 
 This source file is part of the VS Code Swift open source project
 
-Copyright (c) 2021 the VS Code Swift project authors
+Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 Licensed under Apache License v2.0
 
 See LICENSE.txt for license information

--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the VS Code Swift open source project
 ##
-## Copyright (c) 2021 the VS Code Swift project authors
+## Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the VS Code Swift open source project
+##
+## Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
 # This file is supplanted by the GitHub Actions enabled in 
 # https://github.com/swiftlang/vscode-swift/pull/1159,

--- a/scripts/tag_release.sh
+++ b/scripts/tag_release.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the VS Code Swift open source project
 ##
-## Copyright (c) 2021 the VS Code Swift project authors
+## Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/LinuxMain.ts
+++ b/src/LinuxMain.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/DocumentSymbolTestDiscovery.ts
+++ b/src/TestExplorer/DocumentSymbolTestDiscovery.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/SPMTestDiscovery.ts
+++ b/src/TestExplorer/SPMTestDiscovery.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestDiscovery.ts
+++ b/src/TestExplorer/TestDiscovery.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestKind.ts
+++ b/src/TestExplorer/TestKind.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestParsers/TestEventStreamReader.ts
+++ b/src/TestExplorer/TestParsers/TestEventStreamReader.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestUtils.ts
+++ b/src/TestExplorer/TestUtils.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/TestExplorer/TestXUnitParser.ts
+++ b/src/TestExplorer/TestXUnitParser.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/attachDebugger.ts
+++ b/src/commands/attachDebugger.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/createNewProject.ts
+++ b/src/commands/createNewProject.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/dependencies/edit.ts
+++ b/src/commands/dependencies/edit.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/dependencies/resolve.ts
+++ b/src/commands/dependencies/resolve.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/dependencies/unedit.ts
+++ b/src/commands/dependencies/unedit.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/dependencies/update.ts
+++ b/src/commands/dependencies/update.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/dependencies/useLocal.ts
+++ b/src/commands/dependencies/useLocal.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/insertFunctionComment.ts
+++ b/src/commands/insertFunctionComment.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/openInExternalEditor.ts
+++ b/src/commands/openInExternalEditor.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/openInWorkspace.ts
+++ b/src/commands/openInWorkspace.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/openPackage.ts
+++ b/src/commands/openPackage.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/reindexProject.ts
+++ b/src/commands/reindexProject.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/resetPackage.ts
+++ b/src/commands/resetPackage.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/runParallelTests.ts
+++ b/src/commands/runParallelTests.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/runPluginTask.ts
+++ b/src/commands/runPluginTask.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/runSwiftScript.ts
+++ b/src/commands/runSwiftScript.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/switchPlatform.ts
+++ b/src/commands/switchPlatform.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/testMultipleTimes.ts
+++ b/src/commands/testMultipleTimes.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/commands/utilities.ts
+++ b/src/commands/utilities.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/editor/DocumentParser.ts
+++ b/src/editor/DocumentParser.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/LSPOutputChannel.ts
+++ b/src/sourcekit-lsp/LSPOutputChannel.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/getReferenceDocument.ts
+++ b/src/sourcekit-lsp/getReferenceDocument.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/inlayHints.ts
+++ b/src/sourcekit-lsp/inlayHints.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/lspExtensions.ts
+++ b/src/sourcekit-lsp/lspExtensions.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/uriConverters.ts
+++ b/src/sourcekit-lsp/uriConverters.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/TaskManager.ts
+++ b/src/tasks/TaskManager.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/tasks/TaskQueue.ts
+++ b/src/tasks/TaskQueue.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/toolchain/BuildFlags.ts
+++ b/src/toolchain/BuildFlags.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/toolchain/Sanitizer.ts
+++ b/src/toolchain/Sanitizer.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/ReadOnlyDocumentProvider.ts
+++ b/src/ui/ReadOnlyDocumentProvider.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/ReloadExtension.ts
+++ b/src/ui/ReloadExtension.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/StatusItem.ts
+++ b/src/ui/StatusItem.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/win32.ts
+++ b/src/ui/win32.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/ui/withDelayedProgress.ts
+++ b/src/ui/withDelayedProgress.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/cancellation.ts
+++ b/src/utilities/cancellation.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/filesystem.ts
+++ b/src/utilities/filesystem.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/native.ts
+++ b/src/utilities/native.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/result.ts
+++ b/src/utilities/result.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/utilities/version.ts
+++ b/src/utilities/version.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/MockUtils.ts
+++ b/test/MockUtils.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/common.ts
+++ b/test/common.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/BackgroundCompilation.test.ts
+++ b/test/integration-tests/BackgroundCompilation.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/SwiftPackage.test.ts
+++ b/test/integration-tests/SwiftPackage.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/commands/NewFile.test.ts
+++ b/test/integration-tests/commands/NewFile.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/commands/openPackage.test.ts
+++ b/test/integration-tests/commands/openPackage.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/commands/runTestMultipleTimes.test.ts
+++ b/test/integration-tests/commands/runTestMultipleTimes.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/debugger/lldb.test.ts
+++ b/test/integration-tests/debugger/lldb.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/editor/CommentCompletion.test.ts
+++ b/test/integration-tests/editor/CommentCompletion.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/extension.test.ts
+++ b/test/integration-tests/extension.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2022 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/tasks/SwiftExecution.test.ts
+++ b/test/integration-tests/tasks/SwiftExecution.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/tasks/SwiftPseudoterminal.test.ts
+++ b/test/integration-tests/tasks/SwiftPseudoterminal.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/tasks/TaskManager.test.ts
+++ b/test/integration-tests/tasks/TaskManager.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/tasks/TaskQueue.test.ts
+++ b/test/integration-tests/tasks/TaskQueue.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/DocumentSymbolTestDiscovery.test.ts
+++ b/test/integration-tests/testexplorer/DocumentSymbolTestDiscovery.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/LSPTestDiscovery.test.ts
+++ b/test/integration-tests/testexplorer/LSPTestDiscovery.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/MockTestRunState.ts
+++ b/test/integration-tests/testexplorer/MockTestRunState.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/SPMTestListOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SPMTestListOutputParser.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/TestDiscovery.test.ts
+++ b/test/integration-tests/testexplorer/TestDiscovery.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/TestRunArguments.test.ts
+++ b/test/integration-tests/testexplorer/TestRunArguments.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/XCTestOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/XCTestOutputParser.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/testexplorer/utilities.ts
+++ b/test/integration-tests/testexplorer/utilities.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/ui/SwiftOutputChannel.test.ts
+++ b/test/integration-tests/ui/SwiftOutputChannel.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/utilities/filesystem.test.ts
+++ b/test/integration-tests/utilities/filesystem.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/integration-tests/utilities/utilities.test.ts
+++ b/test/integration-tests/utilities/utilities.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/MockUtils.test.ts
+++ b/test/unit-tests/MockUtils.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/debugger/attachDebugger.test.ts
+++ b/test/unit-tests/debugger/attachDebugger.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/debugger/debugAdapter.test.ts
+++ b/test/unit-tests/debugger/debugAdapter.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/debugger/debugAdapterFactory.test.ts
+++ b/test/unit-tests/debugger/debugAdapterFactory.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/debugger/lldb.test.ts
+++ b/test/unit-tests/debugger/lldb.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/sourcekit-lsp/uriConverters.test.ts
+++ b/test/unit-tests/sourcekit-lsp/uriConverters.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/unit-tests/tasks/SwiftTaskProvider.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/toolchain/BuildFlags.test.ts
+++ b/test/unit-tests/toolchain/BuildFlags.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2023 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/toolchain/toolchain.test.ts
+++ b/test/unit-tests/toolchain/toolchain.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/unit-tests/ui/PackageDependencyProvider.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/ui/ReloadExtension.test.ts
+++ b/test/unit-tests/ui/ReloadExtension.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/ui/SwiftBuildStatus.test.ts
+++ b/test/unit-tests/ui/SwiftBuildStatus.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/utilities/filesystem.test.ts
+++ b/test/unit-tests/utilities/filesystem.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/utilities/utilities.test.ts
+++ b/test/unit-tests/utilities/utilities.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/unit-tests/utilities/version.test.ts
+++ b/test/unit-tests/utilities/version.test.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024 Apple Inc. and the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
In order to comply with the check-licence-header.sh script located in the github-workflows repo the licence header string needs to be updated.

Script can be found here:
https://github.com/swiftlang/github-workflows/blob/main/.github/workflows/scripts/check-license-header.sh

This will allow us to enable the licence header check in the new GH Actions PR workflow.