### PR TITLE
Swift Testing Attachments Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ default.profraw
 *.vsix
 .vscode-test
 .build
+.index-build
 .DS_Store
 assets/documentation-webview
 assets/test/**/Package.resolved

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,24 @@
       "request": "launch",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
       "runtimeArgs": ["${workspaceFolder}/scripts/update_swift_docc_render.ts"]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage",
+      "name": "Debug PackageExe (assets/test/defaultPackage)",
+      "program": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage/.build/debug/PackageExe",
+      "preLaunchTask": "swift: Build Debug PackageExe (assets/test/defaultPackage)"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "args": [],
+      "cwd": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage",
+      "name": "Release PackageExe (assets/test/defaultPackage)",
+      "program": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage/.build/release/PackageExe",
+      "preLaunchTask": "swift: Build Release PackageExe (assets/test/defaultPackage)"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,24 +45,6 @@
       "request": "launch",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
       "runtimeArgs": ["${workspaceFolder}/scripts/update_swift_docc_render.ts"]
-    },
-    {
-      "type": "lldb",
-      "request": "launch",
-      "args": [],
-      "cwd": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage",
-      "name": "Debug PackageExe (assets/test/defaultPackage)",
-      "program": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage/.build/debug/PackageExe",
-      "preLaunchTask": "swift: Build Debug PackageExe (assets/test/defaultPackage)"
-    },
-    {
-      "type": "lldb",
-      "request": "launch",
-      "args": [],
-      "cwd": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage",
-      "name": "Release PackageExe (assets/test/defaultPackage)",
-      "program": "${workspaceFolder:vscode-swift}/assets/test/defaultPackage/.build/release/PackageExe",
-      "preLaunchTask": "swift: Build Release PackageExe (assets/test/defaultPackage)"
     }
   ]
 }

--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -42,9 +42,13 @@ final class DebugReleaseTestSuite: XCTestCase {
   }
 }
 
-#if swift(>=6.0)
+#if swift(>=6.1)
+@_spi(Experimental) import Testing
+#elseif swift(>=6.0)
 import Testing
+#endif
 
+#if swift(>=6.0)
 @Test func topLevelTestPassing() {
   print("A print statement in a test.")
   #if !TEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING
@@ -98,7 +102,12 @@ struct MixedSwiftTestingSuite {
   }
   #expect(2 == 3)
 }
+#endif
 
+#if swift(>=6.1)
+@Test func testAttachment() throws {
+  Attachment("Hello, world!", named: "hello.txt").attach()
+}
 #endif
 
 final class DuplicateSuffixTests: XCTestCase {

--- a/package.json
+++ b/package.json
@@ -437,7 +437,7 @@
           },
           "swift.attachmentsPath": {
             "type": "string",
-            "default": "./.build/attachments",
+            "default": ".build/attachments",
             "markdownDescription": "The path to a directory that will be used to store attachments produced during a test run.\n\nA relative path resolves relative to the root directory of the workspace running the test(s)",
             "scope": "machine-overridable"
           }

--- a/package.json
+++ b/package.json
@@ -434,6 +434,12 @@
                 }
               }
             }
+          },
+          "swift.attachmentsPath": {
+            "type": "string",
+            "default": "./.build/attachments",
+            "markdownDescription": "The path to a directory that will be used to store attachments produced during a test run.\n\nA relative path resolves relative to the root directory of the workspace running the test(s)",
+            "scope": "machine-overridable"
           }
         }
       },

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -97,7 +97,7 @@ interface RunEnded {
 }
 
 interface ValueAttached {
-    kind: "valueAttached";
+    kind: "_valueAttached";
     _attachment: {
         path?: string;
     };
@@ -469,7 +469,7 @@ export class SwiftTestingOutputParser {
                 this.completionMap.set(testIndex, true);
                 runState.completed(testIndex, { timestamp: item.payload.instant.absolute });
                 return;
-            } else if (item.payload.kind === "valueAttached" && item.payload._attachment.path) {
+            } else if (item.payload.kind === "_valueAttached" && item.payload._attachment.path) {
                 const testID = this.idFromOptionalTestCase(item.payload.testID);
                 const testIndex = this.getTestCaseIndex(runState, testID);
 

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -513,7 +513,7 @@ export class SymbolRenderer {
      * @param message An event message, typically found on an `EventRecordPayload`.
      * @returns A string colorized with ANSI escape codes.
      */
-    static eventMessageSymbol(symbol: TestSymbol): string {
+    public static eventMessageSymbol(symbol: TestSymbol): string {
         return this.colorize(symbol, this.symbol(symbol));
     }
 

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -283,7 +283,7 @@ export class TestRunProxy {
                 const testItem = this._testItems[parseInt(key)];
                 const attachments = this.attachments[key];
                 this.appendOutput(
-                    `\r\n${testItem.label}${SymbolRenderer.ansiEscapeCodePrefix}90m reported ${attachments.length} attachment${attachments.length === 1 ? "" : "s"}:${SymbolRenderer.resetANSIEscapeCode}`
+                    `\r\n${testItem.label}${SymbolRenderer.ansiEscapeCodePrefix}90m recorded ${attachments.length} attachment${attachments.length === 1 ? "" : "s"}:${SymbolRenderer.resetANSIEscapeCode}`
                 );
 
                 for (const attachment of attachments) {
@@ -574,7 +574,7 @@ export class TestRunner {
                         swiftTestingConfigFile,
                         {
                             // TODO: This ought to be a configuration file
-                            experimentalAttachmentPath: "/Users/plemarquand/Desktop/ttt",
+                            experimentalAttachmentsPath: "/Users/plemarquand/Desktop/ttt",
                         }
                     );
                     const testBuildConfig = await TestingConfigurationFactory.swiftTestingConfig(
@@ -849,7 +849,7 @@ export class TestRunner {
                         fifoPipePath,
                         swiftTestingConfigFile,
                         {
-                            experimentalAttachmentPath: "/Users/plemarquand/Desktop/ttt",
+                            experimentalAttachmentsPath: "/Users/plemarquand/Desktop/ttt",
                         }
                     );
 

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -27,7 +27,11 @@ import {
     ParallelXCTestOutputParser,
     XCTestOutputParser,
 } from "./TestParsers/XCTestOutputParser";
-import { SwiftTestingOutputParser, SymbolRenderer } from "./TestParsers/SwiftTestingOutputParser";
+import {
+    SwiftTestingOutputParser,
+    SymbolRenderer,
+    TestSymbol,
+} from "./TestParsers/SwiftTestingOutputParser";
 import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
 import { TaskOperation } from "../tasks/TaskQueue";
 import { TestXUnitParser } from "./TestXUnitParser";
@@ -286,7 +290,7 @@ export class TestRunProxy {
             if (attachment) {
                 attachment = path.dirname(attachment);
                 this.appendOutput(
-                    `\r\n${SymbolRenderer.ansiEscapeCodePrefix}90mRecorded ${totalAttachments} attachment${totalAttachments === 1 ? "" : "s"} to ${attachment}${SymbolRenderer.resetANSIEscapeCode}`
+                    `${SymbolRenderer.eventMessageSymbol(TestSymbol.attachment)} ${SymbolRenderer.ansiEscapeCodePrefix}90mRecorded ${totalAttachments} attachment${totalAttachments === 1 ? "" : "s"} to ${attachment}${SymbolRenderer.resetANSIEscapeCode}`
                 );
             }
         }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -65,6 +65,8 @@ export interface FolderConfiguration {
     readonly autoGenerateLaunchConfigurations: boolean;
     /** disable automatic running of swift package resolve */
     readonly disableAutoResolve: boolean;
+    /** location to save swift-testing attachments */
+    readonly attachmentsPath: string;
     /** look up saved permissions for the supplied plugin */
     pluginPermissions(pluginId: string): PluginPermissionConfiguration;
 }
@@ -161,6 +163,11 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<boolean>("searchSubfoldersForPackages", false);
+            },
+            get attachmentsPath(): string {
+                return vscode.workspace
+                    .getConfiguration("swift", workspaceFolder)
+                    .get<string>("attachmentsPath", "./.build/attachments");
             },
             pluginPermissions(pluginId: string): PluginPermissionConfiguration {
                 return (

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -100,7 +100,7 @@ export class BuildConfigurationFactory {
 }
 
 interface SwiftTestingConfigFile {
-    experimentalAttachmentPath: string | undefined;
+    experimentalAttachmentsPath: string | undefined;
 }
 
 export class SwiftTestingBuildAguments {

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -83,12 +83,31 @@ export class TemporaryFolder {
         path: string,
         process: () => Promise<Return>
     ): Promise<Return> {
+        return this.withNamedTemporaryFiles([path], process);
+    }
+
+    /**
+     * Run a process and delete the supplied files once that
+     * process has finished.
+     *
+     * @param paths File paths to temporary files
+     * @param process Process to run
+     * @returns return value of process
+     */
+    static async withNamedTemporaryFiles<Return>(
+        paths: string[],
+        process: () => Promise<Return>
+    ): Promise<Return> {
         try {
             const rt = await process();
-            await fs.rm(path, { force: true });
+            for (const path of paths) {
+                await fs.rm(path, { force: true });
+            }
             return rt;
         } catch (error) {
-            await fs.rm(path, { force: true });
+            for (const path of paths) {
+                await fs.rm(path, { force: true });
+            }
             throw error;
         }
     }

--- a/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -45,6 +45,7 @@ suite("SwiftTestingOutputParser Suite", () => {
     beforeEach(() => {
         outputParser = new SwiftTestingOutputParser(
             () => {},
+            () => {},
             () => {}
         );
     });
@@ -241,7 +242,8 @@ suite("SwiftTestingOutputParser Suite", () => {
                     status: TestStatus.enqueued,
                     output: [],
                 });
-            }
+            },
+            () => {}
         );
         await outputParser.watch("file:///mock/named/pipe", testRunState, events);
 


### PR DESCRIPTION
Support swift-testing attachments. Currently prints the attachments out as a report at the end of a test run. In order to leverage them we set the `--experimental-attachment-path` defined by a new `swift.attachmentsPath` setting. This is a directory path which can be global or scoped to the workspace. It can be relative or absolute. If relative, the absolute path is computed relative to the project workspace root. Defaults to `.build/attachments`.

If the `attachmentsPath` directory doesn't exist, it is created. Each test run that produces attachments creates a subfolder named with the date/time of the test run, and places the runs attachments within it. 

This will only work with nightly toolchains as it isn't in 6.0 or 6.1.

<img width="1978" alt="Screenshot 2025-01-10 at 3 36 44 PM" src="https://github.com/user-attachments/assets/10a0f972-98c2-40fd-b1ce-0c1f440bf499" />
