### PR TITLE
Temporarily reenable old licence check

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -18,6 +18,7 @@ npm ci
 npm run lint
 npm run format
 npm run package
+npm run test-soundness -- --force-run
 
 (xvfb-run -a npm run coverage; echo $? > exitcode) | grep -Ev "Failed to connect to the bus|GPU stall due to ReadPixels" && rm -rf "${current_directory}/coverage" && (cp -R ./coverage "${current_directory}" || true)
 exit "$(<exitcode)"

--- a/package.json
+++ b/package.json
@@ -1274,6 +1274,7 @@
     "format": "prettier --check .",
     "pretest": "npm run compile-tests",
     "soundness": "docker compose -f docker/docker-compose.yaml -p swift-vscode-soundness-prb run --rm soundness",
+    "test-soundness": "scripts/soundness.sh",
     "test": "vscode-test",
     "test-ci": "docker/test-ci.sh ci",
     "test-nightly": "docker/test-ci.sh nightly",

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -1,6 +1,122 @@
 #!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the VS Code Swift open source project
+##
+## Copyright (c) 2021 the VS Code Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
 
-# This file is supplanted by the GitHub Actions enabled in 
-# https://github.com/swiftlang/vscode-swift/pull/1159,
-# remove this file once that has been merged.
-exit 0
+if [[ "$1" != "--force-run" ]]; then
+    # This file is supplanted by the GitHub Actions enabled in
+    # https://github.com/swiftlang/vscode-swift/pull/1159,
+    # Until https://github.com/swiftlang/vscode-swift/pull/1176 is
+    # merged we still run the licence check here via the docker/test.sh
+    # with the --force-run flag, and the soundness Jenkins job is skipped
+    # with this exit 0. This lets us run this licence check in the GitHub Actions
+    # until the standard licence check in GH Actions can be used.
+    exit 0
+fi
+
+set -eu
+here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function replace_acceptable_years() {
+    # this needs to replace all acceptable forms with 'YEARS'
+    sed -e 's/20[12][0123456789]-20[12][0123456789]/YEARS/' -e 's/20[12][0123456789]/YEARS/'
+}
+
+printf "=> Checking license headers... "
+tmp=$(mktemp /tmp/.vscode-swift-soundness_XXXXXX)
+
+for language in typescript-or-javascript bash; do
+  declare -a matching_files
+  matching_files=( -name '*' )
+  case "$language" in
+      typescript-or-javascript)
+        matching_files=( -name '*.js' -o -name '*.ts' )
+        cat > "$tmp" <<"EOF"
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) YEARS the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+EOF
+        ;;
+      bash)
+        matching_files=( -name '*.sh' )
+        cat > "$tmp" <<"EOF"
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the VS Code Swift open source project
+##
+## Copyright (c) YEARS the VS Code Swift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+EOF
+      ;;
+    *)
+      echo >&2 "ERROR: unknown language '$language'"
+      ;;
+  esac
+
+  expected_lines=$(cat "$tmp" | wc -l)
+  expected_sha=$(cat "$tmp" | shasum)
+
+  (
+    cd "$here/.."
+    {
+        find . \
+            \( \! -path './.build/*' -a \
+            \( \! -path './node_modules/*' -a \
+            \( \! -path './out/*' -a \
+            \( \! -path './.vscode-test/*' -a \
+            \( \! -path './docker/*' -a \
+            \( \! -path './dist/*' -a \
+            \( \! -path './assets/*' -a \
+            \( \! -path './coverage/*' -a \
+            \( "${matching_files[@]}" \) \
+            \) \) \) \) \) \) \) \)
+
+        if [[ "$language" = bash ]]; then
+            # add everything with a shell shebang too
+            git grep --full-name -l '#!/bin/bash'
+            git grep --full-name -l '#!/bin/sh'
+        fi
+    } | while read line; do
+      if [[ "$(cat "$line" | replace_acceptable_years | head -n $expected_lines | shasum)" != "$expected_sha" ]]; then
+        printf "\033[0;31mmissing headers in file '$line'!\033[0m\n"
+        diff -u <(cat "$line" | replace_acceptable_years | head -n $expected_lines) "$tmp"
+        exit 1
+      fi
+    done
+    printf "\033[0;32mokay.\033[0m\n"
+  )
+done
+
+rm "$tmp"
+
+# printf "=> Checking for broken links in documentation... "
+# find . -name node_modules -prune -o -name \*.md -print0 | xargs -0 -n1 npx markdown-link-check
+# printf "\033[0;32mokay.\033[0m\n"

--- a/src/utilities/native.ts
+++ b/src/utilities/native.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the VS Code Swift open source project
@@ -12,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-
+/* eslint-disable @typescript-eslint/no-require-imports */
 import * as vscode from "vscode";
 
 // To not electron-rebuild for every platform and arch, we want to


### PR DESCRIPTION
This allows us to turn off the licence check GitHub Action temporarily until we can merge #1176, which unblocks #1159, allowing us to start using the GitHub Actions CI flow.