### PR TITLE
Add disableASLR to all debug configurations

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -26,6 +26,7 @@ import { Version } from "../utilities/version";
 import { TestLibrary } from "../TestExplorer/TestRunner";
 import { TestKind, isDebugging, isRelease } from "../TestExplorer/TestKind";
 import { buildOptions } from "../tasks/SwiftTaskProvider";
+import { CI_DISABLE_ASLR } from "./lldb";
 
 export class BuildConfigurationFactory {
     public static buildAll(
@@ -649,13 +650,7 @@ function getBaseConfig(ctx: FolderContext, expandEnvVariables: boolean) {
         args: [],
         preLaunchTask: `swift: Build All${nameSuffix}`,
         terminal: "console",
-        // DisableASLR when running in Docker CI https://stackoverflow.com/a/78471987
-        ...(process.env["CI"]
-            ? {
-                  disableASLR: false,
-                  initCommands: ["settings set target.disable-aslr false"],
-              }
-            : {}),
+        ...CI_DISABLE_ASLR,
     };
 }
 

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -20,6 +20,7 @@ import { stringArrayInEnglish, swiftLibraryPathKey, swiftRuntimeEnv } from "../u
 import { DebugAdapter } from "./debugAdapter";
 import { getFolderAndNameSuffix } from "./buildConfig";
 import configuration from "../configuration";
+import { CI_DISABLE_ASLR } from "./lldb";
 
 /**
  * Edit launch.json based on contents of Swift Package.
@@ -123,6 +124,7 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
             args: [],
             cwd: folder,
             env: swiftRuntimeEnv(true),
+            ...CI_DISABLE_ASLR,
         };
         return [
             {
@@ -162,6 +164,7 @@ export function createSnippetConfiguration(
         args: [],
         cwd: folder,
         env: swiftRuntimeEnv(true),
+        ...CI_DISABLE_ASLR,
     };
 }
 

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -23,6 +23,15 @@ import { execFile, getErrorDescription } from "../utilities/utilities";
 import { Result } from "../utilities/result";
 import { SwiftToolchain } from "../toolchain/toolchain";
 
+export const CI_DISABLE_ASLR =
+    // DisableASLR when running in Docker CI https://stackoverflow.com/a/78471987
+    process.env["CI"]
+        ? {
+              disableASLR: false,
+              initCommands: ["settings set target.disable-aslr false"],
+          }
+        : {};
+
 /**
  * Get LLDB library for given LLDB executable
  * @param executable LLDB executable


### PR DESCRIPTION
- The original GH Actions change has this option added to build config, but not to other configurations like launch and snippet.
- This causes commands that passes through debugger but disregard breakpoints like the run build command to fail in CI.
- This would also show up once we have a nightly workflow going.
- Both issues described above will be addressed by this PR.

Issue: #1198