### PR TITLE
Sort test actions at the top of the workflow jobs list

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,19 +5,6 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  soundness:
-    name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
-    with:
-      # Pending https://github.com/swiftlang/vscode-swift/pull/1176
-      license_header_check_enabled: false
-      license_header_check_project_name: "VS Code Swift"
-      api_breakage_check_enabled: false
-      docs_check_enabled: false
-      format_check_enabled: false
-      shell_check_enabled: true
-      unacceptable_language_check_enabled: true
-
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
@@ -37,3 +24,16 @@ jobs:
         echo "$NODE_PATH" >> $GITHUB_PATH
       linux_build_command: ./docker/test.sh
       enable_windows_checks: false
+
+  soundness:
+    name: Soundness
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    with:
+      # Pending https://github.com/swiftlang/vscode-swift/pull/1176
+      license_header_check_enabled: false
+      license_header_check_project_name: "VS Code Swift"
+      api_breakage_check_enabled: false
+      docs_check_enabled: false
+      format_check_enabled: false
+      shell_check_enabled: true
+      unacceptable_language_check_enabled: true


### PR DESCRIPTION
Reorder the jobs so that the tests appear at the top of the list. This should make it so developers don't have to scroll the jobs list to see what tests failed.