### PR TITLE
Fix debugging entire XCTest targets

### DIFF
--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -123,7 +123,8 @@ export class TestRunArguments {
                 const { xcTestResult, swiftTestResult } = this.simplifyTestArgs(
                     testItem,
                     xcTestArgs,
-                    swiftTestArgs
+                    swiftTestArgs,
+                    isDebug
                 );
 
                 return {
@@ -156,12 +157,23 @@ export class TestRunArguments {
     private simplifyTestArgs(
         testItem: vscode.TestItem,
         xcTestArgs: vscode.TestItem[],
-        swiftTestArgs: vscode.TestItem[]
+        swiftTestArgs: vscode.TestItem[],
+        isDebug: boolean
     ): { xcTestResult: vscode.TestItem[]; swiftTestResult: vscode.TestItem[] } {
         // If we've worked all the way up to a test target, it may have both swift-testing
         // and XCTests.
         const isTestTarget = !!testItem.tags.find(tag => tag.id === "test-target");
+
         if (isTestTarget) {
+            // We cannot simplify away test suites leaving only the target if we are debugging,
+            // since the exact names of test suites to run need to be passed to the xctest binary.
+            // It will not debug all tests with only the target name.
+            if (isDebug) {
+                return {
+                    xcTestResult: xcTestArgs,
+                    swiftTestResult: swiftTestArgs,
+                };
+            }
             return {
                 // Add a trailing .* to match a test target name exactly.
                 // This prevents TestTarget matching TestTarget2.

--- a/test/integration-tests/testexplorer/TestRunArguments.test.ts
+++ b/test/integration-tests/testexplorer/TestRunArguments.test.ts
@@ -313,4 +313,35 @@ suite("TestRunArguments Suite", () => {
             testItems: [testTargetId, xcSuiteId, xcTestId, anotherXcSuiteId, anotherXcTestId1],
         });
     });
+
+    test("Full XCTest Target (debug mode)", () => {
+        const xcTestId2 = "XCTest Item 2";
+        const anotherXcSuiteId = "Another XCTest Suite";
+        const anotherXcTestId1 = "Another XCTest Item 1";
+        const anotherXcTestId2 = "Another XCTest Item 2";
+        const dsl = `
+        tt:${testTargetId}
+            xc:${xcSuiteId}
+                xc:${xcTestId}
+                xc:${xcTestId2}
+            xc:${anotherXcSuiteId}
+                xc:${anotherXcTestId1}
+                xc:${anotherXcTestId2}
+        `;
+        createTestItemTree(controller, dsl);
+        const testArgs = new TestRunArguments(runRequestByIds([testTargetId]), true);
+        assertRunArguments(testArgs, {
+            xcTestArgs: [xcSuiteId, anotherXcSuiteId],
+            swiftTestArgs: [],
+            testItems: [
+                anotherXcTestId1,
+                anotherXcTestId2,
+                anotherXcSuiteId,
+                xcSuiteId,
+                testTargetId,
+                xcTestId2,
+                xcTestId,
+            ],
+        });
+    });
 });


### PR DESCRIPTION
When right clicking a test target and debugging the tests, no XCTests are run.

The test run argument simplification code would simplify too much when debugging a test target; the `xctest` binary does not accept a test target as an `-XCTest` argument. Only fully specified test names or test suites are permitted.

Issue: #1207