### PR TITLE
Simpler test activation/deactivation in tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,8 @@
 				"${workspaceFolder}/dist/**/*.js"
 			],
 			"env": {
-				"VSCODE_DEBUG": "1"
+				"VSCODE_DEBUG": "1",
+				"VSCODE_TEST": "1"
 			},
 			"preLaunchTask": "compile-tests"
 		},

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -59,6 +59,7 @@ export class DiagnosticsManager implements vscode.Disposable {
     private diagnosticCollection: vscode.DiagnosticCollection =
         vscode.languages.createDiagnosticCollection("swift");
     private allDiagnostics: Map<string, vscode.Diagnostic[]> = new Map();
+    private disposed = false;
 
     constructor(context: WorkspaceContext) {
         this.onDidChangeConfigurationDisposible = vscode.workspace.onDidChangeConfiguration(e => {
@@ -114,6 +115,10 @@ export class DiagnosticsManager implements vscode.Disposable {
         sourcePredicate: SourcePredicate,
         newDiagnostics: vscode.Diagnostic[]
     ): void {
+        if (this.disposed) {
+            return;
+        }
+
         const isFromSourceKit = !sourcePredicate(DiagnosticsManager.swiftc);
         // Is a descrepency between SourceKit-LSP and older versions
         // of Swift as to whether the first letter is capitalized or not,
@@ -230,6 +235,7 @@ export class DiagnosticsManager implements vscode.Disposable {
     }
 
     dispose() {
+        this.disposed = true;
         this.diagnosticCollection.dispose();
         this.onDidStartTaskDisposible.dispose();
         this.onDidChangeConfigurationDisposible.dispose();

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -171,6 +171,14 @@ export class WorkspaceContext implements vscode.Disposable {
         this.lastFocusUri = vscode.window.activeTextEditor?.document.uri;
     }
 
+    async stop() {
+        try {
+            await this.languageClientManager.stop();
+        } catch {
+            // ignore
+        }
+    }
+
     dispose() {
         this.folders.forEach(f => f.dispose());
         this.folders.length = 0;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export interface Api {
     workspaceContext?: WorkspaceContext;
     outputChannel: SwiftOutputChannel;
     activate(): Promise<Api>;
-    deactivate(): void;
+    deactivate(): Promise<void>;
 }
 
 /**
@@ -114,7 +114,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 workspaceContext: undefined,
                 outputChannel,
                 activate: () => activate(context),
-                deactivate: () => deactivate(context),
+                deactivate: async () => {
+                    await workspaceContext.stop();
+                    await deactivate(context);
+                },
             };
         }
 
@@ -257,7 +260,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             workspaceContext,
             outputChannel,
             activate: () => activate(context),
-            deactivate: () => deactivate(context),
+            deactivate: async () => {
+                await workspaceContext.stop();
+                await deactivate(context);
+            },
         };
     } catch (error) {
         const errorMessage = getErrorDescription(error);
@@ -269,7 +275,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 }
 
 async function deactivate(context: vscode.ExtensionContext): Promise<void> {
-    console.debug("Deactivating Swift for Visual Studio Code...");
     contextKeys.isActivated = false;
     context.subscriptions.forEach(subscription => subscription.dispose());
     context.subscriptions.length = 0;

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -245,6 +245,14 @@ export class LanguageClientManager {
         this.cancellationToken = new vscode.CancellationTokenSource();
     }
 
+    // The language client stops asnyhronously, so we need to wait for it to stop
+    // instead of doing it in dispose, which must be synchronous.
+    async stop() {
+        if (this.languageClient && this.languageClient.state === langclient.State.Running) {
+            await this.languageClient.dispose();
+        }
+    }
+
     dispose() {
         this.cancellationToken?.cancel();
         this.cancellationToken?.dispose();
@@ -252,7 +260,6 @@ export class LanguageClientManager {
         this.peekDocuments?.dispose();
         this.getReferenceDocument?.dispose();
         this.subscriptions.forEach(item => item.dispose());
-        this.languageClient?.stop();
         this.namedOutputChannels.forEach(channel => channel.dispose());
     }
 

--- a/test/integration-tests/BackgroundCompilation.test.ts
+++ b/test/integration-tests/BackgroundCompilation.test.ts
@@ -14,30 +14,24 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { beforeEach, afterEach } from "mocha";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { testAssetUri } from "../fixtures";
 import { waitForNoRunningTasks } from "../utilities";
 import { Workbench } from "../../src/utilities/commands";
-import { activateExtension, deactivateExtension, updateSettings } from "./utilities/testutilities";
+import { activateExtensionForTest, updateSettings } from "./utilities/testutilities";
 
 suite("BackgroundCompilation Test Suite", () => {
     let workspaceContext: WorkspaceContext;
-    let settingsTeardown: () => Promise<void>;
 
-    beforeEach(async function () {
-        workspaceContext = await activateExtension(this.currentTest);
-
-        assert.notEqual(workspaceContext.folders.length, 0);
-        await waitForNoRunningTasks();
-        settingsTeardown = await updateSettings({
-            "swift.backgroundCompilation": true,
-        });
-    });
-
-    afterEach(async () => {
-        await settingsTeardown();
-        await deactivateExtension();
+    activateExtensionForTest({
+        async setup(ctx) {
+            workspaceContext = ctx;
+            assert.notEqual(workspaceContext.folders.length, 0);
+            await waitForNoRunningTasks();
+            return await updateSettings({
+                "swift.backgroundCompilation": true,
+            });
+        },
     });
 
     suiteTeardown(async () => {

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -23,11 +23,7 @@ import { DiagnosticsManager } from "../../src/DiagnosticsManager";
 import { FolderContext } from "../../src/FolderContext";
 import { Version } from "../../src/utilities/version";
 import { Workbench } from "../../src/utilities/commands";
-import {
-    activateExtension,
-    deactivateExtension,
-    folderInRootWorkspace,
-} from "./utilities/testutilities";
+import { activateExtensionForSuite, folderInRootWorkspace } from "./utilities/testutilities";
 
 const waitForDiagnostics = (uris: vscode.Uri[], allowEmpty: boolean = true) =>
     new Promise<void>(res =>
@@ -95,26 +91,26 @@ suite("DiagnosticsManager Test Suite", async function () {
     let cppUri: vscode.Uri;
     let cppHeaderUri: vscode.Uri;
 
-    suiteSetup(async function () {
-        workspaceContext = await activateExtension(this.currentTest);
-        toolchain = workspaceContext.toolchain;
-        workspaceFolder = testAssetWorkspaceFolder("diagnostics");
-        cWorkspaceFolder = testAssetWorkspaceFolder("diagnosticsC");
-        cppWorkspaceFolder = testAssetWorkspaceFolder("diagnosticsCpp");
-        folderContext = await folderInRootWorkspace("diagnostics", workspaceContext);
-        cFolderContext = await folderInRootWorkspace("diagnosticsC", workspaceContext);
-        cppFolderContext = await folderInRootWorkspace("diagnosticsCpp", workspaceContext);
-        mainUri = vscode.Uri.file(`${workspaceFolder.uri.path}/Sources/main.swift`);
-        funcUri = vscode.Uri.file(`${workspaceFolder.uri.path}/Sources/func.swift`);
-        cUri = vscode.Uri.file(`${cWorkspaceFolder.uri.path}/Sources/MyPoint/MyPoint.c`);
-        cppUri = vscode.Uri.file(`${cppWorkspaceFolder.uri.path}/Sources/MyPoint/MyPoint.cpp`);
-        cppHeaderUri = vscode.Uri.file(
-            `${cppWorkspaceFolder.uri.path}/Sources/MyPoint/include/MyPoint.h`
-        );
-    });
+    activateExtensionForSuite({
+        async setup(ctx) {
+            this.timeout(60000);
 
-    suiteTeardown(async () => {
-        await deactivateExtension();
+            workspaceContext = ctx;
+            toolchain = workspaceContext.toolchain;
+            workspaceFolder = testAssetWorkspaceFolder("diagnostics");
+            cWorkspaceFolder = testAssetWorkspaceFolder("diagnosticsC");
+            cppWorkspaceFolder = testAssetWorkspaceFolder("diagnosticsCpp");
+            folderContext = await folderInRootWorkspace("diagnostics", workspaceContext);
+            cFolderContext = await folderInRootWorkspace("diagnosticsC", workspaceContext);
+            cppFolderContext = await folderInRootWorkspace("diagnosticsCpp", workspaceContext);
+            mainUri = vscode.Uri.file(`${workspaceFolder.uri.path}/Sources/main.swift`);
+            funcUri = vscode.Uri.file(`${workspaceFolder.uri.path}/Sources/func.swift`);
+            cUri = vscode.Uri.file(`${cWorkspaceFolder.uri.path}/Sources/MyPoint/MyPoint.c`);
+            cppUri = vscode.Uri.file(`${cppWorkspaceFolder.uri.path}/Sources/MyPoint/MyPoint.cpp`);
+            cppHeaderUri = vscode.Uri.file(
+                `${cppWorkspaceFolder.uri.path}/Sources/MyPoint/include/MyPoint.h`
+            );
+        },
     });
 
     suite("Parse diagnostics", async () => {

--- a/test/integration-tests/ExtensionActivation.test.ts
+++ b/test/integration-tests/ExtensionActivation.test.ts
@@ -15,7 +15,13 @@
 import * as vscode from "vscode";
 import * as assert from "assert";
 import { afterEach } from "mocha";
-import { activateExtension, deactivateExtension } from "./utilities/testutilities";
+import {
+    activateExtension,
+    activateExtensionForSuite,
+    activateExtensionForTest,
+    deactivateExtension,
+} from "./utilities/testutilities";
+import { WorkspaceContext } from "../../src/WorkspaceContext";
 
 suite("Extension Activation/Deactivation Tests", () => {
     suite("Extension Activation", () => {
@@ -52,5 +58,43 @@ suite("Extension Activation/Deactivation Tests", () => {
         const ext = vscode.extensions.getExtension("sswg.swift-lang");
         assert(ext);
         assert.equal(workspaceContext.subscriptions.length, 0);
+    });
+
+    suite("Extension Activation per suite", () => {
+        let workspaceContext: WorkspaceContext | undefined;
+        let capturedWorkspaceContext: WorkspaceContext | undefined;
+        activateExtensionForSuite({
+            async setup(ctx) {
+                workspaceContext = ctx;
+            },
+        });
+
+        test("Assert workspace context is created", () => {
+            assert.ok(workspaceContext);
+            capturedWorkspaceContext = workspaceContext;
+        });
+
+        test("Assert workspace context is not recreated", () => {
+            assert.strictEqual(workspaceContext, capturedWorkspaceContext);
+        });
+    });
+
+    suite("Extension activation per test", () => {
+        let workspaceContext: WorkspaceContext | undefined;
+        let capturedWorkspaceContext: WorkspaceContext | undefined;
+        activateExtensionForTest({
+            async setup(ctx) {
+                workspaceContext = ctx;
+            },
+        });
+
+        test("Assert workspace context is created", () => {
+            assert.ok(workspaceContext);
+            capturedWorkspaceContext = workspaceContext;
+        });
+
+        test("Assert workspace context is recreated per test", () => {
+            assert.notStrictEqual(workspaceContext, capturedWorkspaceContext);
+        });
     });
 });

--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -19,18 +19,16 @@ import { FolderOperation, WorkspaceContext } from "../../src/WorkspaceContext";
 import { createBuildAllTask } from "../../src/tasks/SwiftTaskProvider";
 import { Version } from "../../src/utilities/version";
 import { SwiftExecution } from "../../src/tasks/SwiftExecution";
-import { activateExtension, deactivateExtension } from "./utilities/testutilities";
+import { activateExtensionForSuite } from "./utilities/testutilities";
 
 suite("WorkspaceContext Test Suite", () => {
     let workspaceContext: WorkspaceContext;
     const packageFolder: vscode.Uri = testAssetUri("defaultPackage");
 
-    suiteSetup(async function () {
-        workspaceContext = await activateExtension();
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+        },
     });
 
     suite("Folder Events", () => {

--- a/test/integration-tests/commands/runTestMultipleTimes.test.ts
+++ b/test/integration-tests/commands/runTestMultipleTimes.test.ts
@@ -18,11 +18,7 @@ import { runTestMultipleTimes } from "../../../src/commands/testMultipleTimes";
 import { mockGlobalObject } from "../../MockUtils";
 import { FolderContext } from "../../../src/FolderContext";
 import { TestRunProxy } from "../../../src/TestExplorer/TestRunner";
-import {
-    activateExtension,
-    deactivateExtension,
-    folderInRootWorkspace,
-} from "../utilities/testutilities";
+import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
 
 suite("Test Multiple Times Command Test Suite", () => {
     const windowMock = mockGlobalObject(vscode, "window");
@@ -30,22 +26,19 @@ suite("Test Multiple Times Command Test Suite", () => {
     let folderContext: FolderContext;
     let testItem: vscode.TestItem;
 
-    suiteSetup(async () => {
-        const workspaceContext = await activateExtension();
-        folderContext = await folderInRootWorkspace("diagnostics", workspaceContext);
-        folderContext.addTestExplorer();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            folderContext = await folderInRootWorkspace("diagnostics", ctx);
+            folderContext.addTestExplorer();
 
-        const item = folderContext.testExplorer?.controller.createTestItem(
-            "testId",
-            "Test Item For Testing"
-        );
+            const item = folderContext.testExplorer?.controller.createTestItem(
+                "testId",
+                "Test Item For Testing"
+            );
 
-        expect(item).to.not.be.undefined;
-        testItem = item!;
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+            expect(item).to.not.be.undefined;
+            testItem = item!;
+        },
     });
 
     test("Runs successfully after testing 0 times", async () => {

--- a/test/integration-tests/debugger/lldb.test.ts
+++ b/test/integration-tests/debugger/lldb.test.ts
@@ -15,17 +15,15 @@
 import { expect } from "chai";
 import { getLLDBLibPath, getLldbProcess } from "../../../src/debugger/lldb";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
-import { activateExtension, deactivateExtension } from "../utilities/testutilities";
+import { activateExtensionForSuite } from "../utilities/testutilities";
 
 suite("lldb contract test suite", () => {
     let workspaceContext: WorkspaceContext;
 
-    suiteSetup(async () => {
-        workspaceContext = await activateExtension();
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+        },
     });
 
     test("getLldbProcess Contract Test, make sure the command returns", async () => {

--- a/test/integration-tests/extension.test.ts
+++ b/test/integration-tests/extension.test.ts
@@ -13,21 +13,18 @@
 //===----------------------------------------------------------------------===//
 
 import * as assert from "assert";
-import { beforeEach, afterEach } from "mocha";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { getBuildAllTask } from "../../src/tasks/SwiftTaskProvider";
 import { SwiftExecution } from "../../src/tasks/SwiftExecution";
-import { activateExtension, deactivateExtension } from "./utilities/testutilities";
+import { activateExtensionForTest } from "./utilities/testutilities";
 
 suite("Extension Test Suite", () => {
     let workspaceContext: WorkspaceContext;
 
-    beforeEach(async function () {
-        workspaceContext = await activateExtension(this.currentTest);
-    });
-
-    afterEach(async () => {
-        await deactivateExtension();
+    activateExtensionForTest({
+        async setup(ctx) {
+            workspaceContext = ctx;
+        },
     });
 
     suite("Temporary Folder Test Suite", () => {

--- a/test/integration-tests/tasks/SwiftExecution.test.ts
+++ b/test/integration-tests/tasks/SwiftExecution.test.ts
@@ -18,22 +18,20 @@ import { testSwiftTask } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
-import { activateExtension, deactivateExtension } from "../utilities/testutilities";
+import { activateExtensionForSuite } from "../utilities/testutilities";
 
 suite("SwiftExecution Tests Suite", () => {
     let workspaceContext: WorkspaceContext;
     let toolchain: SwiftToolchain;
     let workspaceFolder: vscode.WorkspaceFolder;
 
-    suiteSetup(async () => {
-        workspaceContext = await activateExtension();
-        toolchain = await SwiftToolchain.create();
-        assert.notEqual(workspaceContext.folders.length, 0);
-        workspaceFolder = workspaceContext.folders[0].workspaceFolder;
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+            toolchain = await SwiftToolchain.create();
+            assert.notEqual(workspaceContext.folders.length, 0);
+            workspaceFolder = workspaceContext.folders[0].workspaceFolder;
+        },
     });
 
     setup(async () => {

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -17,27 +17,22 @@ import * as assert from "assert";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftPluginTaskProvider } from "../../../src/tasks/SwiftPluginTaskProvider";
 import { FolderContext } from "../../../src/FolderContext";
+import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
 import { executeTaskAndWaitForResult, mutable, waitForEndTaskProcess } from "../../utilities";
-import {
-    activateExtension,
-    deactivateExtension,
-    folderInRootWorkspace,
-} from "../utilities/testutilities";
+import { expect } from "chai";
 
 suite("SwiftPluginTaskProvider Test Suite", () => {
     let workspaceContext: WorkspaceContext;
     let folderContext: FolderContext;
 
-    suiteSetup(async () => {
-        workspaceContext = await activateExtension();
-        folderContext = await folderInRootWorkspace("command-plugin", workspaceContext);
-        assert.notEqual(workspaceContext.folders.length, 0);
-        await folderContext.loadSwiftPlugins();
-        assert.notEqual(folderContext.swiftPackage.plugins.length, 0);
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+            folderContext = await folderInRootWorkspace("command-plugin", workspaceContext);
+            expect(workspaceContext.folders).to.not.have.lengthOf(0);
+            await folderContext.loadSwiftPlugins();
+            expect(workspaceContext.folders).to.not.have.lengthOf(0);
+        },
     });
 
     suite("createSwiftPluginTask", () => {

--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -30,11 +30,8 @@ import {
 import { Version } from "../../../src/utilities/version";
 import { FolderContext } from "../../../src/FolderContext";
 import { mockGlobalObject } from "../../MockUtils";
-import {
-    activateExtension,
-    deactivateExtension,
-    folderInRootWorkspace,
-} from "../utilities/testutilities";
+import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
+import { expect } from "chai";
 
 suite("SwiftTaskProvider Test Suite", () => {
     let workspaceContext: WorkspaceContext;
@@ -42,18 +39,16 @@ suite("SwiftTaskProvider Test Suite", () => {
     let workspaceFolder: vscode.WorkspaceFolder;
     let folderContext: FolderContext;
 
-    suiteSetup(async () => {
-        workspaceContext = await activateExtension();
-        toolchain = workspaceContext.toolchain;
-        assert.notEqual(workspaceContext.folders.length, 0);
-        workspaceFolder = workspaceContext.folders[0].workspaceFolder;
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+            toolchain = workspaceContext.toolchain;
+            expect(workspaceContext.folders).to.not.have.lengthOf(0);
+            workspaceFolder = workspaceContext.folders[0].workspaceFolder;
 
-        // Make sure have another folder
-        folderContext = await folderInRootWorkspace("diagnostics", workspaceContext);
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+            // Make sure have another folder
+            folderContext = await folderInRootWorkspace("diagnostics", workspaceContext);
+        },
     });
 
     suite("createSwiftTask", () => {

--- a/test/integration-tests/tasks/TaskManager.test.ts
+++ b/test/integration-tests/tasks/TaskManager.test.ts
@@ -17,20 +17,18 @@ import * as assert from "assert";
 import { TaskManager } from "../../../src/tasks/TaskManager";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { waitForNoRunningTasks } from "../../utilities";
-import { activateExtension, deactivateExtension } from "../utilities/testutilities";
+import { activateExtensionForSuite } from "../utilities/testutilities";
 
 suite("TaskManager Test Suite", () => {
     let workspaceContext: WorkspaceContext;
     let taskManager: TaskManager;
 
-    suiteSetup(async () => {
-        workspaceContext = await activateExtension();
-        taskManager = workspaceContext.tasks;
-        assert.notEqual(workspaceContext.folders.length, 0);
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+            taskManager = workspaceContext.tasks;
+            assert.notEqual(workspaceContext.folders.length, 0);
+        },
     });
 
     setup(async () => {

--- a/test/integration-tests/tasks/TaskQueue.test.ts
+++ b/test/integration-tests/tasks/TaskQueue.test.ts
@@ -18,20 +18,18 @@ import { testAssetPath } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftExecOperation, TaskOperation, TaskQueue } from "../../../src/tasks/TaskQueue";
 import { waitForNoRunningTasks } from "../../utilities";
-import { activateExtension, deactivateExtension } from "../utilities/testutilities";
+import { activateExtensionForSuite } from "../utilities/testutilities";
 
 suite("TaskQueue Test Suite", () => {
     let workspaceContext: WorkspaceContext;
     let taskQueue: TaskQueue;
 
-    suiteSetup(async () => {
-        workspaceContext = await activateExtension();
-        assert.notEqual(workspaceContext.folders.length, 0);
-        taskQueue = workspaceContext.folders[0].taskQueue;
-    });
-
-    suiteTeardown(async () => {
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            workspaceContext = ctx;
+            assert.notEqual(workspaceContext.folders.length, 0);
+            taskQueue = workspaceContext.folders[0].taskQueue;
+        },
     });
 
     setup(async () => {

--- a/test/integration-tests/testexplorer/utilities.ts
+++ b/test/integration-tests/testexplorer/utilities.ts
@@ -63,7 +63,7 @@ export async function setupTestExplorerTest(settings: SettingsMap = {}) {
  * @param packageFolder The package folder within the workspace
  * @returns The TestExplorer for the package
  */
-function testExplorerFor(
+export function testExplorerFor(
     workspaceContext: WorkspaceContext,
     packageFolder: vscode.Uri
 ): TestExplorer {

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -20,28 +20,24 @@ import {
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities";
 import { getBuildAllTask, SwiftTask } from "../../../src/tasks/SwiftTaskProvider";
 import { testAssetPath } from "../../fixtures";
-import {
-    activateExtension,
-    deactivateExtension,
-    folderInRootWorkspace,
-} from "../utilities/testutilities";
+import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
 
 suite("PackageDependencyProvider Test Suite", function () {
     let treeProvider: PackageDependenciesProvider;
     this.timeout(2 * 60 * 1000); // Allow up to 2 minutes to build
 
-    suiteSetup(async function () {
-        const workspaceContext = await activateExtension();
-        await waitForNoRunningTasks();
-        const folderContext = await folderInRootWorkspace("dependencies", workspaceContext);
-        await executeTaskAndWaitForResult((await getBuildAllTask(folderContext)) as SwiftTask);
-        await workspaceContext.focusFolder(folderContext);
-        treeProvider = new PackageDependenciesProvider(workspaceContext);
-    });
-
-    suiteTeardown(async () => {
-        treeProvider.dispose();
-        await deactivateExtension();
+    activateExtensionForSuite({
+        async setup(ctx) {
+            const workspaceContext = ctx;
+            await waitForNoRunningTasks();
+            const folderContext = await folderInRootWorkspace("dependencies", workspaceContext);
+            await executeTaskAndWaitForResult((await getBuildAllTask(folderContext)) as SwiftTask);
+            await workspaceContext.focusFolder(folderContext);
+            treeProvider = new PackageDependenciesProvider(workspaceContext);
+        },
+        async teardown() {
+            treeProvider.dispose();
+        },
     });
 
     test("Includes remote dependency", async () => {


### PR DESCRIPTION
Favour using the new `activateExtensionForSuite` and `activateExtensionForTest` methods, which automatically deactivate the extension when the suite or test completes.

These methods take optional setup/teardown methods that run on suite/test setup/teardown. If the setup method returns a promise, this is run automatically on teardown. This is useful for setup methods that modify settings, as they can now return the promise directly from `updateSettings` and any modified settings will be reverted automatically.

This also prints any logs captured to the output channel if a suite/test setup/teardown method fails with an error, which was being silently lost before.