### PR TITLE
Address some issues found when running test locally

### DIFF
--- a/assets/test/.vscode/settings.json
+++ b/assets/test/.vscode/settings.json
@@ -6,5 +6,6 @@
         "-Xswiftc",
         "-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
     ],
-    "lldb.verboseLogging": true
+    "lldb.verboseLogging": true,
+    "swift.backgroundCompilation": false
 }

--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -32,6 +32,9 @@ import {
 import { pathExists } from "../../../src/utilities/filesystem";
 
 suite("Build Commands", function () {
+    // Default timeout is a bit too short, give it a little bit more time
+    this.timeout(30 * 1000);
+
     let folderContext: FolderContext;
     let workspaceContext: WorkspaceContext;
     let buildPath: string;

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -120,7 +120,7 @@ suite("Dependency Commmands Test Suite", function () {
 
             // This will now pass as we have the required library
             const { exitCode, output } = await executeTaskAndWaitForResult(tasks);
-            expect(exitCode, `Exit code non zero, command output:\n${output}`).to.equal(0);
+            expect(exitCode, `${output}`).to.equal(0);
             expect(output).to.include("defaultpackage");
             expect(output).to.include("not used by any target");
         }

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -100,10 +100,7 @@ suite("Dependency Commmands Test Suite", function () {
 
             // This will now pass as we have the required library
             const { exitCode, output } = await executeTaskAndWaitForResult(tasks);
-            if (exitCode !== 0) {
-                console.warn("Exit code non zero, command output:\n", output);
-            }
-            expect(exitCode).to.equal(0);
+            expect(exitCode, `Exit code non zero, command output:\n${output}`).to.equal(0);
             expect(output).to.include("defaultpackage");
             expect(output).to.include("not used by any target");
         }

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -134,15 +134,11 @@ suite("Dependency Commmands Test Suite", function () {
         });
 
         test("Contract: spm update", async function () {
-            // This test is flaky, test in CI setting when the below change get merged in and find
-            // out exactly where the command fails.
-            // https://github.com/swiftlang/vscode-swift/pull/1194
-            this.skip();
-            await useLocalDependencyTest();
-
             // Contract: spm update
             let result = await vscode.commands.executeCommand(Commands.UPDATE_DEPENDENCIES);
             expect(result).to.be.true;
+
+            await useLocalDependencyTest();
 
             // Clean up
             result = await vscode.commands.executeCommand(Commands.UNEDIT_DEPENDENCY, item);

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -36,7 +36,27 @@ suite("Dependency Commmands Test Suite", function () {
     // 15 seconds for each test should be more than enough
     this.timeout(15 * 1000);
 
-    suite("spm Resolve Update Contract Tests", function () {
+    suite("spm Update Contract Tests", function () {
+        let folderContext: FolderContext;
+        let workspaceContext: WorkspaceContext;
+
+        activateExtensionForSuite({
+            async setup(ctx) {
+                workspaceContext = ctx;
+                await waitForNoRunningTasks();
+                folderContext = await folderInRootWorkspace("defaultPackage", workspaceContext);
+                await workspaceContext.focusFolder(folderContext);
+            },
+        });
+
+        test("Contract: spm update", async function () {
+            // Contract: spm update
+            const result = await vscode.commands.executeCommand(Commands.UPDATE_DEPENDENCIES);
+            expect(result).to.be.true;
+        });
+    });
+
+    suite("spm Resolve Contract Tests", function () {
         let folderContext: FolderContext;
         let workspaceContext: WorkspaceContext;
 
@@ -128,20 +148,6 @@ suite("Dependency Commmands Test Suite", function () {
 
             // Contract: spm unedit
             const result = await vscode.commands.executeCommand(Commands.UNEDIT_DEPENDENCY, item);
-            expect(result).to.be.true;
-
-            await assertDependencyNoLongerExists();
-        });
-
-        test("Contract: spm update", async function () {
-            // Contract: spm update
-            let result = await vscode.commands.executeCommand(Commands.UPDATE_DEPENDENCIES);
-            expect(result).to.be.true;
-
-            await useLocalDependencyTest();
-
-            // Clean up
-            result = await vscode.commands.executeCommand(Commands.UNEDIT_DEPENDENCY, item);
             expect(result).to.be.true;
 
             await assertDependencyNoLongerExists();


### PR DESCRIPTION
- The build command output is not logged properly in dependency test
- The build command test teardown is not needed and it adds unnecessary run time in the CI
- Check in the default setting for background compilation since updateSettings cannot reset to undefined, this way running locally will not cause git status to show unstaged changes even on test pass