### PR TITLE
Fixup newly uncovered lint error

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -670,12 +670,7 @@ export class TestRunner {
                 outputStream.write(replaced);
             });
 
-            let cancellation: vscode.Disposable;
             task.execution.onDidClose(code => {
-                if (cancellation) {
-                    cancellation.dispose();
-                }
-
                 // undefined or 0 are viewed as success
                 if (!code) {
                     resolve();


### PR DESCRIPTION
The eslint-plugin version bump in #1222 uncovered some dead code that has no effect. Remove it so that we can rebase the @dependabot patch and update eslint-plugin.