### PR TITLE
Format JSON files in the .vscode directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,9 @@
 !*.json
 !*.ts
 
+# Directories ignored by default that actually should be formatted
+!.vscode/
+
 # NodeJS
 node_modules/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,5 @@
 {
-	// See http://go.microsoft.com/fwlink/?LinkId=827846
-	// for the documentation about the extensions.json format
-	"recommendations": [
-		"dbaeumer.vscode-eslint",
-		"esbenp.prettier-vscode"
-	]
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,51 +3,41 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
-	"configurations": [
-		{
-			"name": "Run Extension",
-			"type": "extensionHost",
-			"request": "launch",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}"
-			],
-			"env": {
-				"VSCODE_DEBUG": "1"
-			},
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "build"
-		},
-		{
-			"name": "Extension Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"testConfiguration": "${workspaceFolder}/.vscode-test.js",
-			"testConfigurationLabel": "integrationTests",
-			"args": [
-				"--profile=testing-debug"
-			],
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"env": {
-				"VSCODE_DEBUG": "1",
-				"VSCODE_TEST": "1"
-			},
-			"preLaunchTask": "compile-tests"
-		},
-		{
-			"name": "Unit Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"testConfiguration": "${workspaceFolder}/.vscode-test.js",
-			"testConfigurationLabel": "unitTests",
-			"outFiles": [
-				"${workspaceFolder}/dist/**/*.js"
-			],
-			"preLaunchTask": "compile-tests"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "env": {
+        "VSCODE_DEBUG": "1"
+      },
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "build"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "testConfiguration": "${workspaceFolder}/.vscode-test.js",
+      "testConfigurationLabel": "integrationTests",
+      "args": ["--profile=testing-debug"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "VSCODE_DEBUG": "1",
+        "VSCODE_TEST": "1"
+      },
+      "preLaunchTask": "compile-tests"
+    },
+    {
+      "name": "Unit Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "testConfiguration": "${workspaceFolder}/.vscode-test.js",
+      "testConfigurationLabel": "unitTests",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "compile-tests"
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,15 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "dist": false // set this to true to hide the "dist" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "dist": true // set this to false to include "dist" folder in search results
-    },
-    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off",
+  "files.exclude": {
+    "dist": false // set this to true to hide the "dist" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "dist": true // set this to false to include "dist" folder in search results
+  },
+  // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+  "typescript.tsc.autoDetect": "off",
 
-    // Configure Prettier
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // Configure Prettier
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,30 +1,30 @@
 // See https://go.microsoft.com/fwlink/?LinkId=733558
 // for the documentation about the tasks.json format
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"label": "build",
-			"type": "npm",
-			"script": "watch",
-			"problemMatcher": "$tsc-watch",
-			"presentation": {
-				"reveal": "never"
-			},
-			"isBackground": true,
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			}
-		},
-		{
-			"label": "compile-tests",
-			"type": "npm",
-			"script": "compile-tests",
-			"problemMatcher": "$tsc",
-			"presentation": {
-				"reveal": "never"
-			}
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "reveal": "never"
+      },
+      "isBackground": true,
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "compile-tests",
+      "type": "npm",
+      "script": "compile-tests",
+      "problemMatcher": "$tsc",
+      "presentation": {
+        "reveal": "never"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Prettier was ignoring files in the .vscode directory by default since it's considered hidden. However, we actually want these files to have the same formatting with all of our other JSON files.