### PR TITLE
Add integration test for swift.runPluginTask command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -72,6 +72,7 @@ export enum Commands {
     UPDATE_DEPENDENCIES = "swift.updateDependencies",
     RUN_TESTS_MULTIPLE_TIMES = "swift.runTestsMultipleTimes",
     RESET_PACKAGE = "swift.resetPackage",
+    RUN_PLUGIN_TASK = "swift.runPluginTask",
     USE_LOCAL_DEPENDENCY = "swift.useLocalDependency",
     UNEDIT_DEPENDENCY = "swift.uneditDependency",
 }
@@ -112,7 +113,7 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         }),
         vscode.commands.registerCommand("swift.runSnippet", () => runSnippet(ctx)),
         vscode.commands.registerCommand("swift.debugSnippet", () => debugSnippet(ctx)),
-        vscode.commands.registerCommand("swift.runPluginTask", () => runPluginTask()),
+        vscode.commands.registerCommand(Commands.RUN_PLUGIN_TASK, () => runPluginTask()),
         vscode.commands.registerCommand("swift.restartLSPServer", () =>
             ctx.languageClientManager.restart()
         ),

--- a/src/commands/runPluginTask.ts
+++ b/src/commands/runPluginTask.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 
 export async function runPluginTask() {
-    vscode.commands.executeCommand("workbench.action.tasks.runTask", {
-        type: "swift-plugin",
-    });
+    const args = { type: "swift-plugin" };
+    await vscode.commands.executeCommand("workbench.action.tasks.runTask", args);
+    return args;
 }

--- a/test/integration-tests/BackgroundCompilation.test.ts
+++ b/test/integration-tests/BackgroundCompilation.test.ts
@@ -17,7 +17,6 @@ import * as vscode from "vscode";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { testAssetUri } from "../fixtures";
 import { waitForNoRunningTasks } from "../utilities";
-import { Workbench } from "../../src/utilities/commands";
 import { activateExtensionForTest, updateSettings } from "./utilities/testutilities";
 
 suite("BackgroundCompilation Test Suite", () => {
@@ -32,10 +31,6 @@ suite("BackgroundCompilation Test Suite", () => {
                 "swift.backgroundCompilation": true,
             });
         },
-    });
-
-    suiteTeardown(async () => {
-        await vscode.commands.executeCommand(Workbench.ACTION_CLOSEALLEDITORS);
     });
 
     test("build all on save @slow", async () => {

--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -22,7 +22,6 @@ import { FolderContext } from "../../../src/FolderContext";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { Commands } from "../../../src/commands";
 import { makeDebugConfigurations } from "../../../src/debugger/launch";
-import { Workbench } from "../../../src/utilities/commands";
 import { continueSession, waitForDebugAdapterCommand } from "../../utilities/debug";
 import {
     activateExtensionForSuite,

--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -61,9 +61,6 @@ suite("Build Commands", function () {
             await makeDebugConfigurations(folderContext, undefined, true);
             return settingsTeardown;
         },
-        async teardown() {
-            await vscode.commands.executeCommand(Workbench.ACTION_CLOSEALLEDITORS);
-        },
     });
 
     test("Swift: Run Build", async () => {

--- a/test/integration-tests/commands/runPluginTask.test.ts
+++ b/test/integration-tests/commands/runPluginTask.test.ts
@@ -54,10 +54,7 @@ suite("Build Commands", function () {
 
         // Check if both tasks have the and names
         const taskLabels = tasks.map(task => task.name);
-        const expectedLabels = [
-            "swift-plugin: command-plugin",
-            "swift: command-plugin from tasks.json",
-        ];
+        const expectedLabels = ["command-plugin", "swift: command-plugin from tasks.json"];
         expect(taskLabels).to.deep.equal(expectedLabels);
     });
 });

--- a/test/integration-tests/commands/runPluginTask.test.ts
+++ b/test/integration-tests/commands/runPluginTask.test.ts
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { expect } from "chai";
+import { testAssetUri } from "../../fixtures";
+import { FolderContext } from "../../../src/FolderContext";
+import { WorkspaceContext } from "../../../src/WorkspaceContext";
+import { Commands } from "../../../src/commands";
+import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
+
+suite("Build Commands", function () {
+    let folderContext: FolderContext;
+    let workspaceContext: WorkspaceContext;
+    const uri = testAssetUri("command-plugin/Plugins/command-plugin/command-plugin.swift");
+
+    activateExtensionForSuite({
+        async setup(ctx) {
+            // Open fixture and set focus to the plugin file under test
+            workspaceContext = ctx;
+            folderContext = await folderInRootWorkspace("command-plugin", workspaceContext);
+            await workspaceContext.focusFolder(folderContext);
+            await vscode.window.showTextDocument(uri);
+
+            // These calls are needed for the command plugin command to show up.
+            // Otherwise will need to modified swift.disableAutoResolve config and a extension reload,
+            // which is not ideal.
+            await folderContext.loadSwiftPlugins();
+            workspaceContext.updatePluginContextKey();
+        },
+        testAssets: ["command-plugin"],
+    });
+
+    test("Tasks: Run Task, swift-plugin", async () => {
+        // This will show a quick pick and is difficult to mock, since the tasks are already tested
+        // in the SwiftPluginTaskProvider integration test, just validate the arguments are valid.
+        const args = await vscode.commands.executeCommand(Commands.RUN_PLUGIN_TASK);
+        const tasks = await vscode.tasks.fetchTasks(args as vscode.TaskFilter);
+
+        // Assert that there are exactly two tasks fetched
+        // One from tasks.json, another from the SwiftPluginTaskProvider
+        expect(tasks.length).to.equal(2);
+
+        // Check if both tasks have the and names
+        const taskLabels = tasks.map(task => task.name);
+        const expectedLabels = [
+            "swift-plugin: command-plugin",
+            "swift: command-plugin from tasks.json",
+        ];
+        expect(taskLabels).to.deep.equal(expectedLabels);
+    });
+});

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -47,7 +47,7 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "swift-markdown") as PackageNode;
-        expect(dep).to.not.be.undefined;
+        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
         expect(dep?.location).to.equal("https://github.com/swiftlang/swift-markdown.git");
         assertPathsEqual(
             dep?.path,

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -47,7 +47,7 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "swift-markdown") as PackageNode;
-        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
+        expect(dep).to.not.be.undefined;
         expect(dep?.location).to.equal("https://github.com/swiftlang/swift-markdown.git");
         assertPathsEqual(
             dep?.path,

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -20,6 +20,7 @@ import { testAssetUri } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { FolderContext } from "../../../src/FolderContext";
 import { waitForNoRunningTasks } from "../../utilities";
+import { Workbench } from "../../../src/utilities/commands";
 
 function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     const result = vscode.workspace.workspaceFolders?.at(0);
@@ -175,7 +176,7 @@ const extensionBootstrapper = (() => {
             await waitForNoRunningTasks({ timeout: 10000 });
 
             // Close all editors before deactivating the extension.
-            await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+            await vscode.commands.executeCommand(Workbench.ACTION_CLOSEALLEDITORS);
 
             await activatedAPI.workspaceContext?.removeWorkspaceFolder(getRootWorkspaceFolder());
             await activatedAPI.deactivate();


### PR DESCRIPTION
- Change runPluginTask to return the argument filter for better testability
- Given SwiftPluginTaskProvider integration test already test the tasks, assert the command arguments are valid and return the right tasks for picking.

Issue: #1230