### PR TITLE
Add "auto" mode to sourcekit-lsp backgroundIndexing setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -477,12 +477,12 @@
           "swift.sourcekit-lsp.backgroundIndexing": {
             "type": "string",
             "enum": [
-              "true",
-              "false",
+              "on",
+              "off",
               "auto"
             ],
             "default": "auto",
-            "markdownDescription": "Enable or disable background indexing. `auto` will enable background indexing if the Swift version is >= 6.1. This option has no effect in Swift versions prior to 6.0.",
+            "markdownDescription": "Turns background indexing `on` or `off`. `auto` will enable background indexing if the Swift version is >= 6.1. This option has no effect in Swift versions prior to 6.0.",
             "order": 4
           },
           "swift.sourcekit-lsp.trace.server": {

--- a/package.json
+++ b/package.json
@@ -475,9 +475,14 @@
             "order": 3
           },
           "swift.sourcekit-lsp.backgroundIndexing": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "**Experimental**: Enable or disable background indexing. This option has no effect in Swift versions prior to 6.0.",
+            "type": "string",
+            "enum": [
+              "true",
+              "false",
+              "auto"
+            ],
+            "default": "auto",
+            "markdownDescription": "Enable or disable background indexing. `auto` will enable background indexing if the Swift version is >= 6.1. This option has no effect in Swift versions prior to 6.0.",
             "order": 4
           },
           "swift.sourcekit-lsp.trace.server": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -242,10 +242,17 @@ const configuration = {
             .get<boolean>("backgroundCompilation", false);
     },
     /** background indexing */
-    get backgroundIndexing(): boolean {
-        return vscode.workspace
+    get backgroundIndexing(): "true" | "false" | "auto" {
+        const value = vscode.workspace
             .getConfiguration("swift.sourcekit-lsp")
-            .get("backgroundIndexing", false);
+            .get("backgroundIndexing", "auto");
+
+        // Legacy versions of this setting were a boolean, convert to the new string version.
+        if (typeof value === "boolean") {
+            return value ? "true" : "false";
+        } else {
+            return value;
+        }
     },
     /** focus on problems view whenever there is a build error */
     get actionAfterBuildError(): ActionAfterBuildError {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -242,14 +242,14 @@ const configuration = {
             .get<boolean>("backgroundCompilation", false);
     },
     /** background indexing */
-    get backgroundIndexing(): "true" | "false" | "auto" {
+    get backgroundIndexing(): "on" | "off" | "auto" {
         const value = vscode.workspace
             .getConfiguration("swift.sourcekit-lsp")
             .get("backgroundIndexing", "auto");
 
         // Legacy versions of this setting were a boolean, convert to the new string version.
         if (typeof value === "boolean") {
-            return value ? "true" : "false";
+            return value ? "on" : "off";
         } else {
             return value;
         }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -129,6 +129,8 @@ export class LanguageClientManager {
     // that are not at the root of their workspace
     public subFolderWorkspaces: vscode.Uri[];
     private namedOutputChannels: Map<string, LSPOutputChannel> = new Map();
+    private swiftVersion: Version;
+
     /** Get the current state of the underlying LanguageClient */
     public get state(): langclient.State {
         if (!this.languageClient) {
@@ -142,9 +144,8 @@ export class LanguageClientManager {
             LanguageClientManager.indexingLogName,
             new LSPOutputChannel(LanguageClientManager.indexingLogName, false, true)
         );
-        this.singleServerSupport = workspaceContext.swiftVersion.isGreaterThanOrEqual(
-            new Version(5, 7, 0)
-        );
+        this.swiftVersion = workspaceContext.swiftVersion;
+        this.singleServerSupport = this.swiftVersion.isGreaterThanOrEqual(new Version(5, 7, 0));
         this.subscriptions = [];
         this.subFolderWorkspaces = [];
         if (this.singleServerSupport) {
@@ -613,10 +614,18 @@ export class LanguageClientManager {
             },
         };
 
-        if (configuration.backgroundIndexing) {
+        // Swift 6.0.0 and later supports background indexing.
+        // In 6.0.0 it is experimental so only "true" enables it.
+        // In 6.0.1 it is no longer experimental, and so "auto" or "true" enables it.
+        if (
+            this.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0)) &&
+            (configuration.backgroundIndexing === "true" ||
+                (configuration.backgroundIndexing === "auto" &&
+                    this.swiftVersion.isGreaterThanOrEqual(new Version(6, 1, 0))))
+        ) {
             options = {
                 ...options,
-                backgroundIndexing: configuration.backgroundIndexing,
+                backgroundIndexing: true,
                 backgroundPreparationMode: "enabled",
             };
         }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -616,7 +616,7 @@ export class LanguageClientManager {
 
         // Swift 6.0.0 and later supports background indexing.
         // In 6.0.0 it is experimental so only "true" enables it.
-        // In 6.0.1 it is no longer experimental, and so "auto" or "true" enables it.
+        // In 6.1.0 it is no longer experimental, and so "auto" or "true" enables it.
         if (
             this.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0)) &&
             (configuration.backgroundIndexing === "on" ||

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -619,7 +619,7 @@ export class LanguageClientManager {
         // In 6.0.1 it is no longer experimental, and so "auto" or "true" enables it.
         if (
             this.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0)) &&
-            (configuration.backgroundIndexing === "true" ||
+            (configuration.backgroundIndexing === "on" ||
                 (configuration.backgroundIndexing === "auto" &&
                     this.swiftVersion.isGreaterThanOrEqual(new Version(6, 1, 0))))
         ) {

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -161,7 +161,7 @@ suite("LanguageClientManager Suite", () => {
         // LSP configuration defaults
         mockedConfig.path = "";
         mockedConfig.buildArguments = [];
-        mockedConfig.backgroundIndexing = "false";
+        mockedConfig.backgroundIndexing = "off";
         mockedConfig.swiftEnvironmentVariables = {};
         mockedLspConfig.supportCFamily = "cpptools-inactive";
         mockedLspConfig.disable = false;
@@ -216,7 +216,7 @@ suite("LanguageClientManager Suite", () => {
 
     test("chooses the correct backgroundIndexing value is true, swift version if 6.0.0", async () => {
         mockedWorkspace.swiftVersion = new Version(6, 0, 0);
-        mockedConfig.backgroundIndexing = "true";
+        mockedConfig.backgroundIndexing = "on";
 
         new LanguageClientManager(instance(mockedWorkspace));
         await waitForReturnedPromises(languageClientMock.start);

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -65,6 +65,14 @@ suite("LanguageClientManager Suite", () => {
     let createFilesEmitter: AsyncEventEmitter<vscode.FileCreateEvent>;
     let deleteFilesEmitter: AsyncEventEmitter<vscode.FileDeleteEvent>;
 
+    const doesNotHave = (prop: any) =>
+        match(function (actual) {
+            if (typeof actual === "object") {
+                return !(prop in actual);
+            }
+            return actual[prop] === undefined;
+        }, "doesNotHave");
+
     setup(async () => {
         // Mock pieces of the VSCode API
         mockedVSCodeWindow.activeTextEditor = undefined;
@@ -153,7 +161,7 @@ suite("LanguageClientManager Suite", () => {
         // LSP configuration defaults
         mockedConfig.path = "";
         mockedConfig.buildArguments = [];
-        mockedConfig.backgroundIndexing = false;
+        mockedConfig.backgroundIndexing = "false";
         mockedConfig.swiftEnvironmentVariables = {};
         mockedLspConfig.supportCFamily = "cpptools-inactive";
         mockedLspConfig.disable = false;
@@ -175,6 +183,50 @@ suite("LanguageClientManager Suite", () => {
             /* clientOptions */ match.object
         );
         expect(languageClientMock.start).to.have.been.calledOnce;
+    });
+
+    test("chooses the correct backgroundIndexing value is auto, swift version if 6.0.0", async () => {
+        mockedWorkspace.swiftVersion = new Version(6, 0, 0);
+        mockedConfig.backgroundIndexing = "auto";
+        new LanguageClientManager(instance(mockedWorkspace));
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(mockedLangClientModule.LanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions", doesNotHave("backgroundIndexing"))
+        );
+    });
+
+    test("chooses the correct backgroundIndexing value is auto, swift version if 6.1.0", async () => {
+        mockedWorkspace.swiftVersion = new Version(6, 1, 0);
+        mockedConfig.backgroundIndexing = "auto";
+
+        new LanguageClientManager(instance(mockedWorkspace));
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(mockedLangClientModule.LanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions.backgroundIndexing", match.truthy)
+        );
+    });
+
+    test("chooses the correct backgroundIndexing value is true, swift version if 6.0.0", async () => {
+        mockedWorkspace.swiftVersion = new Version(6, 0, 0);
+        mockedConfig.backgroundIndexing = "true";
+
+        new LanguageClientManager(instance(mockedWorkspace));
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(mockedLangClientModule.LanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions.backgroundIndexing", match.truthy)
+        );
     });
 
     test("notifies SourceKit-LSP of WorkspaceFolder changes", async () => {


### PR DESCRIPTION
Now that backgroundIndexing is no longer experimental it can be enabled by default in Swift 6.1.

This patch evolves the `sourcekit-lsp.backgroundIndexing` setting to be an enum with three possible values, `true`, `false` or `auto`.

The `true` and `false` options function as they did previously. The new `auto` setting will enable background indexing on Swift >= 6.1. To enable background indexing on Swift 6.0 the user must still set this setting to `true`, as this feature is experimental in 6.0.