### PR TITLE
Fix location for diagnostics generated from macros via swiftc

### DIFF
--- a/assets/test/.vscode/settings.json
+++ b/assets/test/.vscode/settings.json
@@ -7,5 +7,4 @@
         "-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
     ],
     "lldb.verboseLogging": true
-
 }

--- a/assets/test/diagnostics/Sources/main.swift
+++ b/assets/test/diagnostics/Sources/main.swift
@@ -12,3 +12,6 @@ repeat {
   line = readLine()
   print(line ?? "nil")
 } while line != nil;
+
+import Testing
+#expect(try myFunc() != 0)

--- a/assets/test/diagnostics/Sources/main.swift
+++ b/assets/test/diagnostics/Sources/main.swift
@@ -13,5 +13,7 @@ repeat {
   print(line ?? "nil")
 } while line != nil;
 
+#if canImport(Testing)
 import Testing
 #expect(try myFunc() != 0)
+#endif

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -56,7 +56,7 @@ function assertHasDiagnostic(uri: vscode.Uri, expected: vscode.Diagnostic): vsco
     assert.notEqual(
         diagnostic,
         undefined,
-        `Could not find diagnostic matching:\n${JSON.stringify(expected)}`
+        `Could not find diagnostic matching:\n${JSON.stringify(expected)}\nDiagnostics:\n${JSON.stringify(diagnostics)}`
     );
     return diagnostic!;
 }
@@ -66,7 +66,7 @@ function assertWithoutDiagnostic(uri: vscode.Uri, expected: vscode.Diagnostic) {
     assert.equal(
         diagnostics.find(findDiagnostic(expected)),
         undefined,
-        `Unexpected diagnostic matching:\n${JSON.stringify(expected)}`
+        `Unexpected diagnostic matching:\n${JSON.stringify(expected)}\nDiagnostics:\n${JSON.stringify(diagnostics)}`
     );
 }
 
@@ -136,6 +136,23 @@ suite("DiagnosticsManager Test Suite", async function () {
             );
             expectedFuncErrorDiagnostic.source = "swiftc";
 
+            const expectedMacroDiagnostic = new vscode.Diagnostic(
+                new vscode.Range(new vscode.Position(16, 26), new vscode.Position(16, 26)),
+                "No calls to throwing functions occur within 'try' expression",
+                vscode.DiagnosticSeverity.Warning
+            );
+
+            expectedMacroDiagnostic.source = "swiftc";
+            expectedMacroDiagnostic.relatedInformation = [
+                {
+                    location: {
+                        uri: mainUri,
+                        range: expectedMacroDiagnostic.range,
+                    },
+                    message: "Expanded code originates here",
+                },
+            ];
+
             // SourceKit-LSP sometimes sends diagnostics
             // after first build and can cause intermittent
             // failure if `swiftc` diagnostic is fixed
@@ -161,6 +178,7 @@ suite("DiagnosticsManager Test Suite", async function () {
                 // Should have parsed correct severity
                 assertHasDiagnostic(mainUri, expectedWarningDiagnostic);
                 assertHasDiagnostic(mainUri, expectedMainErrorDiagnostic);
+                assertHasDiagnostic(mainUri, expectedMacroDiagnostic);
                 // Check parsed for other file
                 assertHasDiagnostic(funcUri, expectedFuncErrorDiagnostic);
             }).timeout(2 * 60 * 1000); // Allow 2 minutes to build
@@ -183,6 +201,7 @@ suite("DiagnosticsManager Test Suite", async function () {
                 // Should have parsed severity
                 assertHasDiagnostic(mainUri, expectedWarningDiagnostic);
                 assertHasDiagnostic(mainUri, expectedMainErrorDiagnostic);
+                assertHasDiagnostic(mainUri, expectedMacroDiagnostic);
                 // Check parsed for other file
                 assertHasDiagnostic(funcUri, expectedFuncErrorDiagnostic);
             }).timeout(2 * 60 * 1000); // Allow 2 minutes to build
@@ -198,6 +217,9 @@ suite("DiagnosticsManager Test Suite", async function () {
 
                 // Should have parsed severity
                 assertHasDiagnostic(mainUri, expectedWarningDiagnostic);
+
+                // llvm style doesn't do macro diagnostics
+                assertWithoutDiagnostic(mainUri, expectedMacroDiagnostic);
                 const diagnostic = assertHasDiagnostic(mainUri, expectedMainErrorDiagnostic);
                 // Should have parsed related note
                 assert.equal(diagnostic.relatedInformation?.length, 1);

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -137,7 +137,7 @@ suite("DiagnosticsManager Test Suite", async function () {
             expectedFuncErrorDiagnostic.source = "swiftc";
 
             const expectedMacroDiagnostic = new vscode.Diagnostic(
-                new vscode.Range(new vscode.Position(16, 26), new vscode.Position(16, 26)),
+                new vscode.Range(new vscode.Position(17, 26), new vscode.Position(17, 26)),
                 "No calls to throwing functions occur within 'try' expression",
                 vscode.DiagnosticSeverity.Warning
             );
@@ -178,7 +178,9 @@ suite("DiagnosticsManager Test Suite", async function () {
                 // Should have parsed correct severity
                 assertHasDiagnostic(mainUri, expectedWarningDiagnostic);
                 assertHasDiagnostic(mainUri, expectedMainErrorDiagnostic);
-                assertHasDiagnostic(mainUri, expectedMacroDiagnostic);
+                if (workspaceContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))) {
+                    assertHasDiagnostic(mainUri, expectedMacroDiagnostic);
+                }
                 // Check parsed for other file
                 assertHasDiagnostic(funcUri, expectedFuncErrorDiagnostic);
             }).timeout(2 * 60 * 1000); // Allow 2 minutes to build
@@ -201,7 +203,9 @@ suite("DiagnosticsManager Test Suite", async function () {
                 // Should have parsed severity
                 assertHasDiagnostic(mainUri, expectedWarningDiagnostic);
                 assertHasDiagnostic(mainUri, expectedMainErrorDiagnostic);
-                assertHasDiagnostic(mainUri, expectedMacroDiagnostic);
+                if (workspaceContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))) {
+                    assertHasDiagnostic(mainUri, expectedMacroDiagnostic);
+                }
                 // Check parsed for other file
                 assertHasDiagnostic(funcUri, expectedFuncErrorDiagnostic);
             }).timeout(2 * 60 * 1000); // Allow 2 minutes to build


### PR DESCRIPTION
The format of messages generated from macro errors/warnings is different than those generated normally. The parsing regex would capture the location for the related info diagnostic with a backtick. The location for the parent regex would be "#macro expansion" which when clicked would open an error window in a VS Code tab stating that the file "#macro expansion" could not be found.

This patch tweaks two things:
1. Makes the regex for capturing the filepaths of warnings/errors account for leading trivia
2. If the path for a diagnostic is invalid, wait until we parse the related information and use the URI from there.

Issue #1224