### PR TITLE
Fix LanguageClientManager unit tests

### DIFF
--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as fs from "fs";
+import * as fs from "fs/promises";
 import * as path from "path";
 import { expect } from "chai";
 import { waitForNoRunningTasks } from "../../utilities";
@@ -29,6 +29,7 @@ import {
     folderInRootWorkspace,
     updateSettings,
 } from "../utilities/testutilities";
+import { pathExists } from "../../../src/utilities/filesystem";
 
 suite("Build Commands", function () {
     let folderContext: FolderContext;
@@ -60,8 +61,8 @@ suite("Build Commands", function () {
 
     teardown(async () => {
         // Remove the build directory after each test case
-        if (fs.existsSync(buildPath)) {
-            fs.rmSync(buildPath, { recursive: true, force: true });
+        if (await pathExists(buildPath)) {
+            await fs.rm(buildPath, { recursive: true, force: true });
         }
     });
 
@@ -79,12 +80,12 @@ suite("Build Commands", function () {
         let result = await vscode.commands.executeCommand(Commands.RUN);
         expect(result).to.be.true;
 
-        const beforeItemCount = fs.readdirSync(buildPath).length;
+        const beforeItemCount = (await fs.readdir(buildPath)).length;
 
         result = await vscode.commands.executeCommand(Commands.CLEAN_BUILD);
         expect(result).to.be.true;
 
-        const afterItemCount = fs.readdirSync(buildPath).length;
+        const afterItemCount = (await fs.readdir(buildPath)).length;
         // This test will run in order after the Swift: Run Build test,
         // where .build folder is going to be filled with built artifacts.
         // After executing the clean command the build directory is guranteed to have less entry.

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -190,10 +190,11 @@ suite("LanguageClientManager Suite", () => {
     test("chooses the correct backgroundIndexing value is auto, swift version if 6.0.0", async () => {
         mockedWorkspace.swiftVersion = new Version(6, 0, 0);
         mockedConfig.backgroundIndexing = "auto";
-        new LanguageClientManager(instance(mockedWorkspace));
+
+        new LanguageClientManager(instance(mockedWorkspace), languageClientFactoryMock);
         await waitForReturnedPromises(languageClientMock.start);
 
-        expect(mockedLangClientModule.LanguageClient).to.have.been.calledOnceWith(
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
             match.string,
             match.string,
             match.object,
@@ -205,10 +206,10 @@ suite("LanguageClientManager Suite", () => {
         mockedWorkspace.swiftVersion = new Version(6, 1, 0);
         mockedConfig.backgroundIndexing = "auto";
 
-        new LanguageClientManager(instance(mockedWorkspace));
+        new LanguageClientManager(instance(mockedWorkspace), languageClientFactoryMock);
         await waitForReturnedPromises(languageClientMock.start);
 
-        expect(mockedLangClientModule.LanguageClient).to.have.been.calledOnceWith(
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
             match.string,
             match.string,
             match.object,
@@ -220,10 +221,10 @@ suite("LanguageClientManager Suite", () => {
         mockedWorkspace.swiftVersion = new Version(6, 0, 0);
         mockedConfig.backgroundIndexing = "on";
 
-        new LanguageClientManager(instance(mockedWorkspace));
+        new LanguageClientManager(instance(mockedWorkspace), languageClientFactoryMock);
         await waitForReturnedPromises(languageClientMock.start);
 
-        expect(mockedLangClientModule.LanguageClient).to.have.been.calledOnceWith(
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
             match.string,
             match.string,
             match.object,


### PR DESCRIPTION
Two PRs that touched the LanguageClientManager unit tests were merged at the same time and broke the unit tests.