### PR TITLE
Improve the debugging on expect statement in test

### DIFF
--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -211,8 +211,9 @@ suite("DiagnosticsManager Test Suite", async function () {
             suiteSetup(async function () {
                 this.timeout(2 * 60 * 1000); // Allow 2 minutes to build
                 const task = createBuildAllTask(folderContext);
-                const { exitCode, output } = await executeTaskAndWaitForResult(task);
-                assert.equal(exitCode, 0, `${output}`);
+                // This return exit code and output for the task but we will omit it here
+                // because the failures are expected and we just want the task to build
+                await executeTaskAndWaitForResult(task);
             });
 
             suiteTeardown(async () => {
@@ -996,8 +997,7 @@ suite("DiagnosticsManager Test Suite", async function () {
         test("Provides swift diagnostics", async () => {
             // Build for indexing
             let task = createBuildAllTask(folderContext);
-            let { exitCode, output } = await executeTaskAndWaitForResult(task);
-            assert.equal(exitCode, 0, `${output}`);
+            await executeTaskAndWaitForResult(task);
 
             // Open file
             const promise = Promise.resolve(); // waitForDiagnostics([mainUri], false);
@@ -1006,8 +1006,7 @@ suite("DiagnosticsManager Test Suite", async function () {
             await vscode.window.showTextDocument(document);
 
             task = createBuildAllTask(folderContext);
-            ({ exitCode, output } = await executeTaskAndWaitForResult(task));
-            assert.equal(exitCode, 0, `${output}`);
+            await executeTaskAndWaitForResult(task);
 
             // Retrigger diagnostics
             await workspaceContext.focusFolder(folderContext);
@@ -1039,8 +1038,7 @@ suite("DiagnosticsManager Test Suite", async function () {
         test("Provides clang diagnostics", async () => {
             // Build for indexing
             const task = createBuildAllTask(cFolderContext);
-            const { exitCode, output } = await executeTaskAndWaitForResult(task);
-            assert.equal(exitCode, 0, `${output}`);
+            await executeTaskAndWaitForResult(task);
 
             // Open file
             const promise = Promise.resolve(); //  waitForDiagnostics([cUri], false);

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -211,7 +211,8 @@ suite("DiagnosticsManager Test Suite", async function () {
             suiteSetup(async function () {
                 this.timeout(2 * 60 * 1000); // Allow 2 minutes to build
                 const task = createBuildAllTask(folderContext);
-                await executeTaskAndWaitForResult(task);
+                const { exitCode, output } = await executeTaskAndWaitForResult(task);
+                assert.equal(exitCode, 0, `${output}`);
             });
 
             suiteTeardown(async () => {
@@ -995,7 +996,8 @@ suite("DiagnosticsManager Test Suite", async function () {
         test("Provides swift diagnostics", async () => {
             // Build for indexing
             let task = createBuildAllTask(folderContext);
-            await executeTaskAndWaitForResult(task);
+            let { exitCode, output } = await executeTaskAndWaitForResult(task);
+            assert.equal(exitCode, 0, `${output}`);
 
             // Open file
             const promise = Promise.resolve(); // waitForDiagnostics([mainUri], false);
@@ -1004,7 +1006,8 @@ suite("DiagnosticsManager Test Suite", async function () {
             await vscode.window.showTextDocument(document);
 
             task = createBuildAllTask(folderContext);
-            await executeTaskAndWaitForResult(task);
+            ({ exitCode, output } = await executeTaskAndWaitForResult(task));
+            assert.equal(exitCode, 0, `${output}`);
 
             // Retrigger diagnostics
             await workspaceContext.focusFolder(folderContext);
@@ -1036,7 +1039,8 @@ suite("DiagnosticsManager Test Suite", async function () {
         test("Provides clang diagnostics", async () => {
             // Build for indexing
             const task = createBuildAllTask(cFolderContext);
-            await executeTaskAndWaitForResult(task);
+            const { exitCode, output } = await executeTaskAndWaitForResult(task);
+            assert.equal(exitCode, 0, `${output}`);
 
             // Open file
             const promise = Promise.resolve(); //  waitForDiagnostics([cUri], false);

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -93,7 +93,7 @@ suite("Dependency Commmands Test Suite", function () {
 
                 tasks = (await getBuildAllTask(folderContext)) as SwiftTask;
                 const { exitCode, output } = await executeTaskAndWaitForResult(tasks);
-                expect(exitCode).to.not.equal(0);
+                expect(exitCode, `${output}`).to.not.equal(0);
                 expect(output).to.include("PackageLib");
                 expect(output).to.include("required");
 
@@ -128,7 +128,7 @@ suite("Dependency Commmands Test Suite", function () {
         async function assertDependencyNoLongerExists() {
             // Expect to fail again now dependency is missing
             const { exitCode, output } = await executeTaskAndWaitForResult(tasks);
-            expect(exitCode).to.not.equal(0);
+            expect(exitCode, `${output}`).to.not.equal(0);
             expect(output).to.include("PackageLib");
             expect(output).to.include("required");
         }

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -69,8 +69,8 @@ suite("SwiftPluginTaskProvider Test Suite", () => {
                 }
             );
             mutable(task.execution).command = "/definitely/not/swift";
-            const { exitCode } = await executeTaskAndWaitForResult(task);
-            expect(exitCode).to.not.equal(0);
+            const { exitCode, output } = await executeTaskAndWaitForResult(task);
+            expect(exitCode, `${output}`).to.not.equal(0);
         }).timeout(10000);
     });
 

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -33,7 +33,10 @@ suite("PackageDependencyProvider Test Suite", function () {
             const workspaceContext = ctx;
             await waitForNoRunningTasks();
             const folderContext = await folderInRootWorkspace("dependencies", workspaceContext);
-            await executeTaskAndWaitForResult((await getBuildAllTask(folderContext)) as SwiftTask);
+            const { exitCode, output } = await executeTaskAndWaitForResult(
+                (await getBuildAllTask(folderContext)) as SwiftTask
+            );
+            expect(exitCode, `${output}`).to.be.equals(0);
             await workspaceContext.focusFolder(folderContext);
             treeProvider = new PackageDependenciesProvider(workspaceContext);
         },
@@ -47,7 +50,7 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "swift-markdown") as PackageNode;
-        expect(dep).to.not.be.undefined;
+        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
         expect(dep?.location).to.equal("https://github.com/swiftlang/swift-markdown.git");
         assertPathsEqual(
             dep?.path,
@@ -59,6 +62,9 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "defaultpackage") as PackageNode;
+        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
+        expect(dep?.location).to.equal(testAssetPath("defaultPackage"));
+        expect(dep?.path).to.equal(testAssetPath("defaultPackage"));
         expect(
             dep,
             `Expected to find defaultPackage, but instead items were ${items.map(n => n.name)}`
@@ -71,6 +77,7 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "defaultpackage") as PackageNode;
+        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
         expect(
             dep,
             `Expected to find defaultPackage, but instead items were ${items.map(n => n.name)}`
@@ -105,7 +112,7 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "swift-markdown") as PackageNode;
-        expect(dep).to.not.be.undefined;
+        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
 
         const folders = await treeProvider.getChildren(dep);
         const folder = folders.find(n => n.name === "Sources");

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -33,10 +33,7 @@ suite("PackageDependencyProvider Test Suite", function () {
             const workspaceContext = ctx;
             await waitForNoRunningTasks();
             const folderContext = await folderInRootWorkspace("dependencies", workspaceContext);
-            const { exitCode, output } = await executeTaskAndWaitForResult(
-                (await getBuildAllTask(folderContext)) as SwiftTask
-            );
-            expect(exitCode, `${output}`).to.be.equals(0);
+            await executeTaskAndWaitForResult((await getBuildAllTask(folderContext)) as SwiftTask);
             await workspaceContext.focusFolder(folderContext);
             treeProvider = new PackageDependenciesProvider(workspaceContext);
         },

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -59,9 +59,6 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "defaultpackage") as PackageNode;
-        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
-        expect(dep?.location).to.equal(testAssetPath("defaultPackage"));
-        expect(dep?.path).to.equal(testAssetPath("defaultPackage"));
         expect(
             dep,
             `Expected to find defaultPackage, but instead items were ${items.map(n => n.name)}`
@@ -74,7 +71,6 @@ suite("PackageDependencyProvider Test Suite", function () {
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "defaultpackage") as PackageNode;
-        expect(dep, `${JSON.stringify(items, null, 2)}`).to.not.be.undefined;
         expect(
             dep,
             `Expected to find defaultPackage, but instead items were ${items.map(n => n.name)}`


### PR DESCRIPTION
- This is true especially on flaky test, sometimes we check for the exit code but not print out the output from the command on failure.
- Fix it for a bunch of asserts where sporadic failures were observed to better understand what went wrong.