### PR TITLE
Activate extension when compile_flags.txt or buildServer.json is present

### DIFF
--- a/assets/test/cmake-compile-flags/CMakeLists.txt
+++ b/assets/test/cmake-compile-flags/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.4)
+
+project(hello_world)
+
+add_executable(app main.cpp)

--- a/assets/test/cmake-compile-flags/compile_flags.txt
+++ b/assets/test/cmake-compile-flags/compile_flags.txt
@@ -1,0 +1,8 @@
+/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
+-isysroot
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk
+-mmacosx-version-min=13.0
+-o
+CMakeFiles/app.dir/main.o
+-c
+main.cpp

--- a/assets/test/cmake-compile-flags/main.cpp
+++ b/assets/test/cmake-compile-flags/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello World!\n";
+    return 0;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "onLanguage:swift",
     "workspaceContains:Package.swift",
     "workspaceContains:compile_commands.json",
+    "workspaceContains:compile_flags.txt",
+    "workspaceContains:buildServer.json",
     "onDebugResolve:swift-lldb"
   ],
   "main": "./dist/src/extension.js",

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -349,7 +349,7 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     async searchForPackages(folder: vscode.Uri, workspaceFolder: vscode.WorkspaceFolder) {
-        // add folder if Package.swift/compile_commands.json exists
+        // add folder if Package.swift/compile_commands.json/compile_flags.txt/buildServer.json exists
         if (await this.isValidWorkspaceFolder(folder.fsPath)) {
             await this.addPackageFolder(folder, workspaceFolder);
             return;
@@ -614,13 +614,15 @@ export class WorkspaceContext implements vscode.Disposable {
 
     /**
      * Return if folder is considered a valid root folder ie does it contain a SwiftPM
-     * Package.swift or a CMake compile_commands.json
+     * Package.swift or a CMake compile_commands.json, compile_flags.txt, or a BSP buildServer.json.
      */
     async isValidWorkspaceFolder(folder: string): Promise<boolean> {
         return (
             ((await pathExists(folder, "Package.swift")) &&
                 !configuration.disableSwiftPMIntegration) ||
-            (await pathExists(folder, "compile_commands.json"))
+            (await pathExists(folder, "compile_commands.json")) ||
+            (await pathExists(folder, "compile_flags.txt")) ||
+            (await pathExists(folder, "buildServer.json"))
         );
     }
 

--- a/test/integration-tests/ExtensionActivation.test.ts
+++ b/test/integration-tests/ExtensionActivation.test.ts
@@ -22,6 +22,8 @@ import {
     deactivateExtension,
 } from "./utilities/testutilities";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
+import { testAssetUri } from "../fixtures";
+import { assertContains } from "./testexplorer/utilities";
 
 suite("Extension Activation/Deactivation Tests", () => {
     suite("Extension Activation", () => {
@@ -95,6 +97,31 @@ suite("Extension Activation/Deactivation Tests", () => {
 
         test("Assert workspace context is recreated per test", () => {
             assert.notStrictEqual(workspaceContext, capturedWorkspaceContext);
+        });
+    });
+
+    suite("Activates for cmake projects", () => {
+        let workspaceContext: WorkspaceContext;
+
+        activateExtensionForTest({
+            async setup(ctx) {
+                workspaceContext = ctx;
+            },
+            testAssets: ["cmake", "cmake-compile-flags"],
+        });
+
+        test("compile_commands.json", async () => {
+            const lspWorkspaces = workspaceContext.languageClientManager.subFolderWorkspaces.map(
+                ({ fsPath }) => fsPath
+            );
+            assertContains(lspWorkspaces, testAssetUri("cmake").fsPath);
+        });
+
+        test("compile_flags.txt", async () => {
+            const lspWorkspaces = workspaceContext.languageClientManager.subFolderWorkspaces.map(
+                ({ fsPath }) => fsPath
+            );
+            assertContains(lspWorkspaces, testAssetUri("cmake-compile-flags").fsPath);
         });
     });
 });


### PR DESCRIPTION
SourceKit-LSP can handle projects configured with the paired down clang `compile_flags.txt` configuration file, as well as projects configured with the Build Server Protocol's `buildServer.json`.

Activate the extension if the folder added to the workspace contains either of these files in the root.

Issue: #1087