### PR TITLE
Warn when using `console` logging methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "no-throw-literal": "warn",
     // TODO "@typescript-eslint/semi" rule moved to https://eslint.style
     "semi": "error",
+    "no-console": "warn",
     // Mostly fails tests, ex. expect(...).to.be.true returns a Chai.Assertion
     "@typescript-eslint/no-unused-expressions": "off",
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -733,7 +733,11 @@ export class TestRunner {
             const xUnitParser = new TestXUnitParser(
                 this.folderContext.workspaceContext.toolchain.hasMultiLineParallelTestOutput
             );
-            const results = await xUnitParser.parse(buffer, runState);
+            const results = await xUnitParser.parse(
+                buffer,
+                runState,
+                this.workspaceContext.outputChannel
+            );
             if (results) {
                 this.testRun.appendOutput(
                     `\r\nExecuted ${results.tests} tests, with ${results.failures} failures and ${results.errors} errors.\r\n`
@@ -863,9 +867,13 @@ export class TestRunner {
                             );
 
                             const outputHandler = this.testOutputHandler(config.testType, runState);
-                            LoggingDebugAdapterTracker.setDebugSessionCallback(session, output => {
-                                outputHandler(output);
-                            });
+                            LoggingDebugAdapterTracker.setDebugSessionCallback(
+                                session,
+                                this.workspaceContext.outputChannel,
+                                output => {
+                                    outputHandler(output);
+                                }
+                            );
 
                             const cancellation = this.testRun.token.onCancellationRequested(() => {
                                 this.workspaceContext.outputChannel.logDiagnostic(

--- a/src/TestExplorer/TestXUnitParser.ts
+++ b/src/TestExplorer/TestXUnitParser.ts
@@ -14,6 +14,7 @@
 
 import * as xml2js from "xml2js";
 import { TestRunnerTestRunState } from "./TestRunner";
+import { OutputChannel } from "vscode";
 
 export interface TestResults {
     tests: number;
@@ -48,14 +49,15 @@ export class TestXUnitParser {
 
     async parse(
         buffer: string,
-        runState: TestRunnerTestRunState
+        runState: TestRunnerTestRunState,
+        outputChannel: OutputChannel
     ): Promise<TestResults | undefined> {
         const xml = await xml2js.parseStringPromise(buffer);
         try {
             return await this.parseXUnit(xml, runState);
         } catch (error) {
             // ignore error
-            console.log(error);
+            outputChannel.appendLine(`Error parsing xUnit output: ${error}`);
             return undefined;
         }
     }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -253,6 +253,7 @@ export class WorkspaceContext implements vscode.Disposable {
         // add event listener for when a workspace folder is added/removed
         const onWorkspaceChange = vscode.workspace.onDidChangeWorkspaceFolders(event => {
             if (this === undefined) {
+                // eslint-disable-next-line no-console
                 console.log("Trying to run onDidChangeWorkspaceFolders on deleted context");
                 return;
             }
@@ -261,6 +262,7 @@ export class WorkspaceContext implements vscode.Disposable {
         // add event listener for when the active edited text document changes
         const onDidChangeActiveWindow = vscode.window.onDidChangeActiveTextEditor(async editor => {
             if (this === undefined) {
+                // eslint-disable-next-line no-console
                 console.log("Trying to run onDidChangeWorkspaceFolders on deleted context");
                 return;
             }

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -15,6 +15,7 @@
 import * as vscode from "vscode";
 import { DebugAdapter } from "./debugAdapter";
 import { Version } from "../utilities/version";
+import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
 
 /**
  * Factory class for building LoggingDebugAdapterTracker
@@ -82,12 +83,16 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
         LoggingDebugAdapterTracker.debugSessionIdMap[id] = this;
     }
 
-    static setDebugSessionCallback(session: vscode.DebugSession, cb: (log: string) => void) {
+    static setDebugSessionCallback(
+        session: vscode.DebugSession,
+        outputChannel: SwiftOutputChannel,
+        cb: (log: string) => void
+    ) {
         const loggingDebugAdapter = this.debugSessionIdMap[session.id];
         if (loggingDebugAdapter) {
             loggingDebugAdapter.cb = cb;
         } else {
-            console.error("Could not find debug adapter for session:", session.id);
+            outputChannel.appendLine("Could not find debug adapter for session: " + session.id);
         }
     }
 

--- a/src/tasks/TaskManager.ts
+++ b/src/tasks/TaskManager.ts
@@ -104,7 +104,9 @@ export class TaskManager implements vscode.Disposable {
         });
         // setup startingTaskPromise to be resolved one task has started
         if (this.startingTaskPromise !== undefined) {
-            console.warn("TaskManager: Starting promise should be undefined if we reach here.");
+            this.workspaceContext.outputChannel.appendLine(
+                "TaskManager: Starting promise should be undefined if we reach here."
+            );
         }
         this.startingTaskPromise = new Promise<void>(resolve => {
             this.taskStartObserver = () => {
@@ -122,7 +124,7 @@ export class TaskManager implements vscode.Disposable {
                 });
             },
             error => {
-                console.log(error);
+                this.workspaceContext.outputChannel.appendLine(`Error executing task: ${error}`);
                 disposable.dispose();
                 this.startingTaskPromise = undefined;
                 reject(error);

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -39,6 +39,7 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
         this.logStore.append(value);
 
         if (this.logToConsole) {
+            // eslint-disable-next-line no-console
             console.log(value);
         }
     }
@@ -48,6 +49,7 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
         this.logStore.appendLine(value);
 
         if (this.logToConsole) {
+            // eslint-disable-next-line no-console
             console.log(value);
         }
     }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "no-console": "off",
     "@typescript-eslint/no-explicit-any": "off"
   }
 }


### PR DESCRIPTION
Add an ESLint warning when using methods like console.log in the extension code. It is preferable to use the `SwiftOutputChannel` so that these logs are captured by the extension diagnostics mechanism, and so that they are all grouped together in the same place when debugging.

Sources under the tests directory do not have this restriction.