### PR TITLE
Disable dependency integration test

### DIFF
--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -80,6 +80,12 @@ suite("Dependency Commmands Test Suite", function () {
 
         activateExtensionForSuite({
             async setup(ctx) {
+                // FIXME: Disable this test suite as this is dependent on external git dependency
+                // and introduces flakinesss when run in the CI setting. The spm command only
+                // runs if the dependency is remote, which make faking difficult.
+                // For enabling the test in the future, we would need to set up the environment
+                // into a pre-resolved state, so spm does not need to visit remote git url.
+                this.skip();
                 // Check before each test case start:
                 // Expect to fail without setting up local version
                 workspaceContext = ctx;


### PR DESCRIPTION
- Disable this test suite until we have a good way to set up the test to not dependent on external components that can fail. (remote git)
- This will need to be revisited when project panel is introduced.