### PR TITLE
Lower dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 5
     allow:
       - dependency-type: direct


### PR DESCRIPTION
Since update rules are more permissive now, we get spammed when daily. I propose weekly is sufficient.