### PR TITLE
Fix XCTest - Run Multiple Times test

### DIFF
--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -449,7 +449,7 @@ suite("Test Explorer Suite", function () {
                 test("@slow runs an XCTest multiple times", async function () {
                     const testItems = await gatherTests(
                         testExplorer.controller,
-                        "PackageTests.topLevelTestPassing()"
+                        "PackageTests.PassingXCTestSuite/testPassing"
                     );
 
                     await testExplorer.folderContext.workspaceContext.focusFolder(
@@ -466,7 +466,10 @@ suite("Test Explorer Suite", function () {
                     await eventPromise(testRun.onTestRunComplete);
 
                     assertTestResults(testRun, {
-                        passed: ["PackageTests.topLevelTestPassing()"],
+                        passed: [
+                            "PackageTests.PassingXCTestSuite",
+                            "PackageTests.PassingXCTestSuite/testPassing",
+                        ],
                     });
                 });
             });


### PR DESCRIPTION
This test was copied from the swift-testing version, but the names of the expected tests were not changed. This would pass on 6.0 since it would do the same thing that the swift-testing test did, but because swift-testing isn't supported on < Swift 6.0 this test would fail on 5.10 and earlier.

Issue: #1262