### PR TITLE
Allow manually triggering of nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: Nightly
 on:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   tests_release:


### PR DESCRIPTION
Documentation says the user must have write access to trigger this