### PR TITLE
Increase timeout for build tests

### DIFF
--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -32,7 +32,7 @@ import {
 
 suite("Build Commands", function () {
     // Default timeout is a bit too short, give it a little bit more time
-    this.timeout(30 * 1000);
+    this.timeout(120 * 1000);
 
     let folderContext: FolderContext;
     let workspaceContext: WorkspaceContext;
@@ -106,7 +106,9 @@ suite("Build Commands", function () {
         const result = vscode.commands.executeCommand(Commands.DEBUG);
         expect(result).to.eventually.be.true;
 
-        await bpPromise.then(() => continueSession());
+        await bpPromise;
+        await continueSession();
+
         vscode.debug.removeBreakpoints(breakpoints);
     });
 });


### PR DESCRIPTION
30 seconds often wasn't enough to complete the build.

Issue: #1269