### PR TITLE
Allow triggering nightly build from PR label

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,6 +30,30 @@ jobs:
       windows_build_command: docker\test-windows.ps1
       enable_windows_docker: false
 
+  full_test_run:
+    name: Full Test Run
+    if: contains(github.event.pull_request.labels.*.name, 'full-test-run')
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    with:
+      # Linux
+      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly-main"}]'
+      linux_env_vars: |
+        NODE_VERSION=v18.19.0
+        NODE_PATH=/usr/local/nvm/versions/node/v18.19.0/bin
+        NVM_DIR=/usr/local/nvm
+        CI=1
+        VSCODE_TEST=1
+      linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
+      linux_build_command: ./docker/test.sh
+      # Windows
+      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly"}]'
+      windows_env_vars: |
+        CI=1
+        VSCODE_TEST=1
+      windows_pre_build_command: .github\workflows\scripts\windows\install-nodejs.ps1
+      windows_build_command: docker\test-windows.ps1
+      enable_windows_docker: false
+
   soundness:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,7 @@ jobs:
   tests:
     name: Test
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'full-test-run') }}
     with:
       # Linux
       linux_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly-main"}]'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,34 +6,7 @@ on:
 
 jobs:
   tests:
-    name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'full-test-run') }}
-    with:
-      # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly-main"}]'
-      linux_env_vars: |
-        NODE_VERSION=v18.19.0
-        NODE_PATH=/usr/local/nvm/versions/node/v18.19.0/bin
-        NVM_DIR=/usr/local/nvm
-        CI=1
-        VSCODE_TEST=1
-        FAST_TEST_RUN=1
-      linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
-      linux_build_command: ./docker/test.sh
-      # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly"}]'
-      windows_env_vars: |
-        CI=1
-        VSCODE_TEST=1
-        FAST_TEST_RUN=1
-      windows_pre_build_command: .github\workflows\scripts\windows\install-nodejs.ps1
-      windows_build_command: docker\test-windows.ps1
-      enable_windows_docker: false
-
-  full_test_run:
-    name: Full Test Run
-    if: contains(github.event.pull_request.labels.*.name, 'full-test-run')
+    name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       # Linux
@@ -44,6 +17,7 @@ jobs:
         NVM_DIR=/usr/local/nvm
         CI=1
         VSCODE_TEST=1
+        FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./docker/test.sh
       # Windows
@@ -51,6 +25,7 @@ jobs:
       windows_env_vars: |
         CI=1
         VSCODE_TEST=1
+        FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}
       windows_pre_build_command: .github\workflows\scripts\windows\install-nodejs.ps1
       windows_build_command: docker\test-windows.ps1
       enable_windows_docker: false


### PR DESCRIPTION
Adding the `full-test-run` label to a PR before creating it will trigger the same workflow as the nightly job.