### PR TITLE
Fix SourceKit-LSP symbol info request

### DIFF
--- a/src/sourcekit-lsp/extensions/SymbolInfoRequest.ts
+++ b/src/sourcekit-lsp/extensions/SymbolInfoRequest.ts
@@ -150,7 +150,7 @@ export interface SymbolDetails {
  * any additional client or server capabilities to use.
  */
 export namespace SymbolInfoRequest {
-    export const method = "textDocument/documentSymbol" as const;
+    export const method = "textDocument/symbolInfo" as const;
     export const messageDirection: MessageDirection = MessageDirection.clientToServer;
-    export const type = new RequestType<SymbolInfoParams, SymbolDetails, never>(method);
+    export const type = new RequestType<SymbolInfoParams, SymbolDetails[], never>(method);
 }


### PR DESCRIPTION
The `textDocument/symbolInfo` request was created with an incorrect method name and response type.