### PR TITLE
Only change scheme of `.swiftinterface` files to `readonly` if old scheme was `file`

### DIFF
--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -518,7 +518,8 @@ export class LanguageClientManager {
                     const definitions = result as vscode.Location[];
                     if (
                         definitions &&
-                        path.extname(definitions[0].uri.path) === ".swiftinterface"
+                        path.extname(definitions[0].uri.path) === ".swiftinterface" &&
+                        definitions[0].uri.scheme === "file"
                     ) {
                         const uri = definitions[0].uri.with({ scheme: "readonly" });
                         return new vscode.Location(uri, definitions[0].range);


### PR DESCRIPTION
I’m working on adding semantic functionality to generated interfaces in SourceKit-LSP and this will generate reference documents with a `sourcekit-lsp:` scheme and a `.swiftinterface` file. We shouldn’t change those URIs to a `readonly` scheme.