### PR TITLE
Fix typo in description for swift.buildArguments setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Additional arguments to pass to `swift` commands such as `swift build`, `swift package`, `swift test`, etc... Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propogated to that task."
+            "markdownDescription": "Additional arguments to pass to `swift` commands such as `swift build`, `swift package`, `swift test`, etc... Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propagated to that task."
           },
           "swift.additionalTestArguments": {
             "type": "array",


### PR DESCRIPTION
I noticed this small typo while browsing the extension settings in VS Code.