### PR TITLE
Clean up live preview VS Code event handlers

### DIFF
--- a/src/documentation/DocumentationManager.ts
+++ b/src/documentation/DocumentationManager.ts
@@ -42,7 +42,10 @@ export class DocumentationManager implements vscode.Disposable {
                 return false;
             }
 
-            this.previewEditor = new DocumentationPreviewEditor(this.extension, this.context);
+            this.previewEditor = await DocumentationPreviewEditor.create(
+                this.extension,
+                this.context
+            );
             const subscriptions: vscode.Disposable[] = [
                 this.previewEditor.onDidUpdateContent(content => {
                     this.editorUpdatedContentEmitter.fire(content);

--- a/src/documentation/DocumentationPreviewEditor.ts
+++ b/src/documentation/DocumentationPreviewEditor.ts
@@ -22,10 +22,12 @@ import { ConvertDocumentationRequest } from "../sourcekit-lsp/extensions/Convert
 export enum PreviewEditorConstant {
     VIEW_TYPE = "swift.previewDocumentationEditor",
     TITLE = "Preview Swift Documentation",
+    UNSUPPORTED_EDITOR_ERROR_MESSAGE = "The active text editor does not support Swift Documentation Live Preview",
 }
 
 export class DocumentationPreviewEditor implements vscode.Disposable {
     private readonly webviewPanel: vscode.WebviewPanel;
+    private activeTextEditor?: vscode.TextEditor;
     private subscriptions: vscode.Disposable[] = [];
 
     private disposeEmitter = new vscode.EventEmitter<void>();
@@ -36,6 +38,7 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
         private readonly extension: vscode.ExtensionContext,
         private readonly context: WorkspaceContext
     ) {
+        this.activeTextEditor = vscode.window.activeTextEditor;
         const swiftDoccRenderPath = this.extension.asAbsolutePath(
             path.join("assets", "swift-docc-render")
         );
@@ -65,26 +68,20 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
                 )
             )
         );
-        fs.readFile(path.join(swiftDoccRenderPath, "index.html"), "utf-8").then(
-            documentationHTML => {
-                documentationHTML = documentationHTML
-                    .replaceAll("{{BASE_PATH}}", webviewBaseURI.toString())
-                    .replace("</body>", `<script src="${scriptURI.toString()}"></script></body>`);
-                this.webviewPanel.webview.html = documentationHTML;
-                this.subscriptions.push(
-                    this.webviewPanel.webview.onDidReceiveMessage(this.receiveMessage.bind(this)),
-                    vscode.window.onDidChangeActiveTextEditor(editor => {
-                        this.convertDocumentation(editor);
-                    }),
-                    vscode.window.onDidChangeTextEditorSelection(event => {
-                        this.convertDocumentation(event.textEditor);
-                    }),
-                    this.webviewPanel.onDidDispose(this.dispose.bind(this))
-                );
-                // Reveal the editor, but don't change the focus of the active text editor
-                this.webviewPanel.reveal(undefined, true);
-            }
-        );
+        fs.readFile(path.join(swiftDoccRenderPath, "index.html"), "utf-8").then(doccRenderHTML => {
+            doccRenderHTML = doccRenderHTML
+                .replaceAll("{{BASE_PATH}}", webviewBaseURI.toString())
+                .replace("</body>", `<script src="${scriptURI.toString()}"></script></body>`);
+            this.webviewPanel.webview.html = doccRenderHTML;
+            this.subscriptions.push(
+                this.webviewPanel.webview.onDidReceiveMessage(this.receiveMessage, this),
+                vscode.window.onDidChangeActiveTextEditor(this.handleActiveTextEditorChange, this),
+                vscode.workspace.onDidChangeTextDocument(this.handleDocumentChange, this),
+                this.webviewPanel.onDidDispose(this.dispose, this)
+            );
+            // Reveal the editor, but don't change the focus of the active text editor
+            this.webviewPanel.reveal(undefined, true);
+        });
     }
 
     /** An event that is fired when the Documentation Preview Editor is disposed */
@@ -117,7 +114,10 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
     private receiveMessage(message: WebviewMessage) {
         switch (message.type) {
             case "loaded":
-                this.convertDocumentation(vscode.window.activeTextEditor);
+                if (!this.activeTextEditor) {
+                    break;
+                }
+                this.convertDocumentation(this.activeTextEditor);
                 break;
             case "rendered":
                 this.renderEmitter.fire();
@@ -125,10 +125,34 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
         }
     }
 
-    private async convertDocumentation(editor: vscode.TextEditor | undefined): Promise<void> {
-        const document = editor?.document;
-        if (!document || document.uri.scheme !== "file") {
-            return undefined;
+    private handleActiveTextEditorChange(activeTextEditor: vscode.TextEditor | undefined) {
+        if (this.activeTextEditor === activeTextEditor || activeTextEditor === undefined) {
+            return;
+        }
+        this.activeTextEditor = activeTextEditor;
+        this.convertDocumentation(activeTextEditor);
+    }
+
+    private handleDocumentChange(event: vscode.TextDocumentChangeEvent) {
+        if (this.activeTextEditor?.document === event.document) {
+            this.convertDocumentation(this.activeTextEditor);
+        }
+    }
+
+    private async convertDocumentation(textEditor: vscode.TextEditor): Promise<void> {
+        const document = textEditor.document;
+        if (
+            document.uri.scheme !== "file" ||
+            !["markdown", "tutorial", "swift"].includes(document.languageId)
+        ) {
+            this.postMessage({
+                type: "update-content",
+                content: {
+                    type: "error",
+                    errorMessage: PreviewEditorConstant.UNSUPPORTED_EDITOR_ERROR_MESSAGE,
+                },
+            });
+            return;
         }
 
         const response = await this.context.languageClientManager.useLanguageClient(
@@ -137,7 +161,7 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
                     textDocument: {
                         uri: document.uri.toString(),
                     },
-                    position: editor.selection.start,
+                    position: textEditor.selection.start,
                 });
             }
         );

--- a/src/documentation/DocumentationPreviewEditor.ts
+++ b/src/documentation/DocumentationPreviewEditor.ts
@@ -33,7 +33,6 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
         const swiftDoccRenderPath = extension.asAbsolutePath(
             path.join("assets", "swift-docc-render")
         );
-        // Create and hook up events for the WebviewPanel
         const webviewPanel = vscode.window.createWebviewPanel(
             PreviewEditorConstant.VIEW_TYPE,
             PreviewEditorConstant.TITLE,
@@ -65,8 +64,6 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
             .replaceAll("{{BASE_PATH}}", webviewBaseURI.toString())
             .replace("</body>", `<script src="${scriptURI.toString()}"></script></body>`);
         webviewPanel.webview.html = doccRenderHTML;
-        // Reveal the editor, but don't change the focus of the active text editor
-        webviewPanel.reveal(undefined, true);
         return new DocumentationPreviewEditor(context, webviewPanel);
     }
 
@@ -88,6 +85,8 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
             vscode.workspace.onDidChangeTextDocument(this.handleDocumentChange, this),
             this.webviewPanel.onDidDispose(this.dispose, this)
         );
+        // Reveal the editor, but don't change the focus of the active text editor
+        webviewPanel.reveal(undefined, true);
     }
 
     /** An event that is fired when the Documentation Preview Editor is disposed */


### PR DESCRIPTION
Switch to using `vscode.workspace.onDidChangeTextDocument()` instead of listening for text editor selection changes. This reduces the number of unnecessary requests made to SourceKit-LSP. Additionally, check the language of the editor before we send a request as SourceKit-LSP can only handle Markdown, Tutorial, and Swift files. Anything else we can safely assume will not succeed.