### PR TITLE
Fix debug command test

### DIFF
--- a/assets/test/.vscode/launch.json
+++ b/assets/test/.vscode/launch.json
@@ -7,7 +7,9 @@
             "program": "${workspaceFolder:test}/defaultPackage/.build/debug/PackageExe",
             "args": [],
             "cwd": "${workspaceFolder:test}/defaultPackage",
-            "preLaunchTask": "swift: Build Debug PackageExe (defaultPackage)"
+            "preLaunchTask": "swift: Build Debug PackageExe (defaultPackage)",
+            "disableASLR": false,
+            "initCommands": ["settings set target.disable-aslr false"],
         },
         {
             "type": "swift-lldb",
@@ -16,7 +18,9 @@
             "program": "${workspaceFolder:test}/defaultPackage/.build/release/PackageExe",
             "args": [],
             "cwd": "${workspaceFolder:test}/defaultPackage",
-            "preLaunchTask": "swift: Build Release PackageExe (defaultPackage)"
+            "preLaunchTask": "swift: Build Release PackageExe (defaultPackage)",
+            "disableASLR": false,
+            "initCommands": ["settings set target.disable-aslr false"],
         }
     ]
 }

--- a/test/integration-tests/SwiftSnippet.test.ts
+++ b/test/integration-tests/SwiftSnippet.test.ts
@@ -50,7 +50,7 @@ suite("SwiftSnippet Test Suite @slow", function () {
             workspaceContext = ctx;
 
             const folder = await folderInRootWorkspace("defaultPackage", workspaceContext);
-            if (folder.workspaceContext.toolchain.swiftVersion.isLessThan(new Version(6, 0, 0))) {
+            if (folder.workspaceContext.toolchain.swiftVersion.isLessThan(new Version(5, 9, 0))) {
                 this.skip();
             }
             await waitForNoRunningTasks();
@@ -83,7 +83,11 @@ suite("SwiftSnippet Test Suite @slow", function () {
     });
 
     test("Run `Swift: Debug Swift Snippet` command for snippet file", async () => {
-        const bpPromise = waitForDebugAdapterRequest("Run hello", "stackTrace");
+        const bpPromise = waitForDebugAdapterRequest(
+            "Run hello",
+            workspaceContext.toolchain.swiftVersion,
+            "stackTrace"
+        );
         const sessionPromise = waitUntilDebugSessionTerminates("Run hello");
 
         const succeeded = vscode.commands.executeCommand("swift.debugSnippet");


### PR DESCRIPTION
* Timing issue waiting for the debug configuration to be created, but we should not have to do this
* Using existing launch config, the  adapter tracker was waiting for "swift-lldb" but we fallback to the "lldb" type for swift versions < 6.0

Issue: #1269