### PR TITLE
Fix flaky package dependency tests

### DIFF
--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -42,7 +42,7 @@ suite("Build Commands @slow", function () {
             // The description of this package is crashing on Windows with Swift 5.9.x and below
             if (
                 process.platform === "win32" &&
-                ctx.toolchain.swiftVersion.isLessThan(new Version(6, 0, 0))
+                ctx.toolchain.swiftVersion.isLessThanOrEqual(new Version(5, 9, 0))
             ) {
                 this.skip();
             }

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -32,10 +32,11 @@ suite("PackageDependencyProvider Test Suite", function () {
         async setup(ctx) {
             const workspaceContext = ctx;
             await waitForNoRunningTasks();
+            await folderInRootWorkspace("defaultPackage", workspaceContext);
             const folderContext = await folderInRootWorkspace("dependencies", workspaceContext);
             await executeTaskAndWaitForResult((await getBuildAllTask(folderContext)) as SwiftTask);
-            await workspaceContext.focusFolder(folderContext);
             treeProvider = new PackageDependenciesProvider(workspaceContext);
+            await workspaceContext.focusFolder(folderContext);
         },
         async teardown() {
             treeProvider.dispose();


### PR DESCRIPTION
* Seem to be intermittent failures if defaultPackage was not in the the workspace context as a package folder so lets be explicit

Issue: #1258