### PR TITLE
Configurable Command Plugin Permissions

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,6 +4,45 @@ The Visual Studio Code Swift extension comes with a number of settings you can u
 
 This document outlines useful configuration options not covered by the settings descriptions in the extension settings page.
 
+## Command Plugins
+
+Swift packages can define [command plugins](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Plugins.md) that can perform arbitrary tasks. For example, the [swift-format](https://github.com/swiftlang/swift-format) package exposes a `format-source-code` command which will use swift-format to format source code in a folder. These plugin commands can be invoked from VS Code using `> Swift: Run Command Plugin`. 
+
+A plugin may require permissions to perform tasks like writing to the file system or using the network. If a plugin command requires one of these permissions, you will be prompted in the integrated terminal to accept them. If you trust the command and wish to apply permissions on every command execution, you can configure a setting in your `settings.json`.
+
+```json
+{
+  "swift.pluginPermissions": {
+    "PluginName:command": {
+      "allowWritingToPackageDirectory": true,
+      "allowWritingToDirectory": "/some/path/",
+      "allowNetworkConnections": "all",
+      "disableSandbox": true
+    }
+  }
+}
+```
+
+A key of `PluginName:command` will set permissions for a specific command. A key of `PluginName` will set permissions for all commands in the plugin.
+
+Alternatively, you can define a task in your tasks.json and define permissions directly on the task. This will create a new entry in the list shown by `> Swift: Run Command Plugin`.
+
+```json
+{
+  "type": "swift-plugin",
+  "command": "command_plugin",
+  "args": ["--foo"],
+  "cwd": "command-plugin",
+  "problemMatcher": ["$swiftc"],
+  "label": "swift: command-plugin from tasks.json",
+
+  "allowWritingToPackageDirectory": true,
+  "allowWritingToDirectory": "/some/path/",
+  "allowNetworkConnections": "all",
+  "disableSandbox": true
+}
+```
+
 ## SourceKit-LSP
 
 [SourceKit-LSP](https://github.com/apple/sourcekit-lsp) is the language server used by the the Swift extension to provide symbol completion, jump to definition etc. It is developed by Apple to provide Swift and C language support for any editor that supports the Language Server Protocol.

--- a/package.json
+++ b/package.json
@@ -394,6 +394,12 @@
             "type": "boolean",
             "default": true,
             "markdownDescription": "Controls whether or not the extension will contribute environment variables defined in `Swift: Environment Variables` to the integrated terminal. If this is set to `true` and a custom `Swift: Path` is also set then the swift path is appended to the terminal's `PATH`."
+          },
+          "swift.pluginPermissions": {
+            "type": "object",
+            "default": {},
+            "markdownDescription": "TODO: Document",
+            "scope": "machine-overridable"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -398,8 +398,42 @@
           "swift.pluginPermissions": {
             "type": "object",
             "default": {},
-            "markdownDescription": "TODO: Document",
-            "scope": "machine-overridable"
+            "markdownDescription": "Configures a list of permissions to be used when running a command plugins.\n\nPermissions objects are defined in the form:\n\n`{ \"PluginName:command\": { \"allowWritingToPackageDirectory\": true } }`.\n\nA key of `PluginName:command` will set permissions for a specific command. A key of `PluginName` will set permissions for all commands in the plugin.",
+            "scope": "machine-overridable",
+            "patternProperties": {
+              "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)?)$": {
+                "type": "object",
+                "properties": {
+                  "disableSandbox": {
+                    "type": "boolean",
+                    "description": "Disable using the sandbox when executing plugins"
+                  },
+                  "allowWritingToPackageDirectory": {
+                    "type": "boolean",
+                    "description": "Allow the plugin to write to the package directory"
+                  },
+                  "allowWritingToDirectory": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "description": "Allow the plugin to write to an additional directory"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Allow the plugin to write to additional directories"
+                      }
+                    ]
+                  },
+                  "allowNetworkConnections": {
+                    "type": "string",
+                    "description": "Allow the plugin to make network connections"
+                  }
+                }
+              }
+            }
           }
         }
       },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -65,6 +65,23 @@ export interface FolderConfiguration {
     readonly autoGenerateLaunchConfigurations: boolean;
     /** disable automatic running of swift package resolve */
     readonly disableAutoResolve: boolean;
+    /** look up saved permissions for the supplied plugin */
+    pluginPermissions(pluginId: string): PluginPermissionConfiguration;
+}
+
+export interface PluginPermissionConfiguration {
+    /** Disable using the sandbox when executing plugins */
+    disableSandbox?: boolean;
+    /** Allow the plugin to write to the package directory */
+    allowWritingToPackageDirectory?: boolean;
+    /** Allow the plugin to write to an additional directory or directories  */
+    allowWritingToDirectory?: string | string[];
+    /**
+     * Allow the plugin to make network connections
+     * For a list of valid options see:
+     * https://github.com/swiftlang/swift-package-manager/blob/0401a2ae55077cfd1f4c0acd43ae0a1a56ab21ef/Sources/Commands/PackageCommands/PluginCommand.swift#L62
+     */
+    allowNetworkConnections?: string;
 }
 
 /**
@@ -144,6 +161,13 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift", workspaceFolder)
                     .get<boolean>("searchSubfoldersForPackages", false);
+            },
+            pluginPermissions(pluginId: string): PluginPermissionConfiguration {
+                return (
+                    vscode.workspace.getConfiguration("swift", workspaceFolder).get<{
+                        [key: string]: PluginPermissionConfiguration;
+                    }>("pluginPermissions", {})[pluginId] ?? {}
+                );
             },
         };
     },

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -76,7 +76,12 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         // We need to create a new Task object here.
         // Reusing the task parameter doesn't seem to work.
         const swift = this.workspaceContext.toolchain.getToolchainExecutable("swift");
-        let swiftArgs = ["package", task.definition.command, ...task.definition.args];
+        let swiftArgs = [
+            "package",
+            ...this.pluginArguments(task.definition as PluginPermissionConfiguration),
+            task.definition.command,
+            ...task.definition.args,
+        ];
         swiftArgs = this.workspaceContext.toolchain.buildFlags.withSwiftSDKFlags(swiftArgs);
 
         const cwd = resolveTaskCwd(task, task.definition.cwd);
@@ -228,6 +233,9 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
 
     private pluginArguments(config: PluginPermissionConfiguration): string[] {
         const args = [];
+        if (config.disableSandbox) {
+            args.push("--disable-sandbox");
+        }
         if (config.allowWritingToPackageDirectory) {
             args.push("--allow-writing-to-package-directory");
         }

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -223,11 +223,19 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         if (taskDefinition.allowWritingToPackageDirectory) {
             taskDefinitionConfiguration.allowWritingToPackageDirectory = true;
         }
+        if (taskDefinition.allowWritingToDirectory) {
+            taskDefinitionConfiguration.allowWritingToDirectory =
+                taskDefinition.allowWritingToDirectory;
+        }
+        if (taskDefinition.allowNetworkConnections) {
+            taskDefinitionConfiguration.allowNetworkConnections =
+                taskDefinition.allowNetworkConnections;
+        }
 
         return this.pluginArguments({
-            ...taskDefinitionConfiguration,
             ...packageConfig,
             ...commandConfig,
+            ...taskDefinitionConfiguration,
         });
     }
 

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -240,7 +240,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
             args.push("--allow-writing-to-package-directory");
         }
         if (config.allowWritingToDirectory) {
-            if (Array.isArray(config.allowWritingToPackageDirectory)) {
+            if (Array.isArray(config.allowWritingToDirectory)) {
                 args.push("--allow-writing-to-directory", ...config.allowWritingToDirectory);
             } else {
                 args.push("--allow-writing-to-directory");

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -18,103 +18,151 @@ import { expect } from "chai";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftPluginTaskProvider } from "../../../src/tasks/SwiftPluginTaskProvider";
 import { FolderContext } from "../../../src/FolderContext";
-import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
+import {
+    activateExtensionForSuite,
+    folderInRootWorkspace,
+    updateSettings,
+} from "../utilities/testutilities";
 import {
     cleanOutput,
     executeTaskAndWaitForResult,
     waitForEndTaskProcess,
 } from "../../utilities/tasks";
 import { mutable } from "../../utilities/types";
+import { SwiftExecution } from "../../../src/tasks/SwiftExecution";
 
 suite("SwiftPluginTaskProvider Test Suite", () => {
     let workspaceContext: WorkspaceContext;
     let folderContext: FolderContext;
 
-    activateExtensionForSuite({
-        async setup(ctx) {
-            workspaceContext = ctx;
-            folderContext = await folderInRootWorkspace("command-plugin", workspaceContext);
-            await folderContext.loadSwiftPlugins();
-            expect(workspaceContext.folders).to.not.have.lengthOf(0);
-        },
-    });
-
-    suite("createSwiftPluginTask", () => {
-        let taskProvider: SwiftPluginTaskProvider;
-
-        setup(() => {
-            taskProvider = new SwiftPluginTaskProvider(workspaceContext);
+    suite("settings plugin arguments", () => {
+        activateExtensionForSuite({
+            async setup(ctx) {
+                workspaceContext = ctx;
+                folderContext = await folderInRootWorkspace("command-plugin", workspaceContext);
+                await folderContext.loadSwiftPlugins();
+                expect(workspaceContext.folders).to.not.have.lengthOf(0);
+                return await updateSettings({
+                    "swift.pluginPermissions": {
+                        "command-plugin:command_plugin": {
+                            disableSandbox: true,
+                            allowWritingToPackageDirectory: true,
+                            allowWritingToDirectory: ["/foo", "/bar"],
+                            allowNetworkConnections: "all",
+                        },
+                    },
+                });
+            },
         });
 
-        test("Exit code on success", async () => {
-            const task = taskProvider.createSwiftPluginTask(folderContext.swiftPackage.plugins[0], {
-                cwd: folderContext.folder,
-                scope: folderContext.workspaceFolder,
-            });
-            const { exitCode, output } = await executeTaskAndWaitForResult(task);
-            expect(exitCode).to.equal(0);
-            expect(cleanOutput(output)).to.include("Hello, World!");
-        }).timeout(60000);
-
-        test("Exit code on failure", async () => {
-            const task = taskProvider.createSwiftPluginTask(
-                {
-                    command: "not_a_command",
-                    name: "not_a_command",
-                    package: "command-plugin",
-                },
-                {
-                    cwd: folderContext.folder,
-                    scope: folderContext.workspaceFolder,
-                }
-            );
-            mutable(task.execution).command = "/definitely/not/swift";
-            const { exitCode, output } = await executeTaskAndWaitForResult(task);
-            expect(exitCode, `${output}`).to.not.equal(0);
-        }).timeout(10000);
+        test("provides a task with permissions set via settings", async () => {
+            const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
+            const task = tasks.find(t => t.name === "command-plugin");
+            const swiftExecution = task?.execution as SwiftExecution;
+            assert.deepEqual(swiftExecution.args, [
+                "package",
+                "--disable-sandbox",
+                "--allow-writing-to-package-directory",
+                "--allow-writing-to-directory",
+                "/foo",
+                "/bar",
+                "--allow-network-connections",
+                "all",
+                "command_plugin",
+            ]);
+        });
     });
 
-    suite("provideTasks", () => {
-        suite("includes command plugin provided by the extension", async () => {
-            let task: vscode.Task | undefined;
-
-            setup(async () => {
-                const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
-                task = tasks.find(t => t.name === "command-plugin");
-            });
-
-            test("provides", () => {
-                expect(task?.detail).to.equal("swift package command_plugin");
-            });
-
-            test("executes", async () => {
-                assert(task);
-                const exitPromise = waitForEndTaskProcess(task);
-                await vscode.tasks.executeTask(task);
-                const exitCode = await exitPromise;
-                expect(exitCode).to.equal(0);
-            }).timeout(30000); // 30 seconds to run
+    suite("execution", () => {
+        activateExtensionForSuite({
+            async setup(ctx) {
+                workspaceContext = ctx;
+                folderContext = await folderInRootWorkspace("command-plugin", workspaceContext);
+                await folderContext.loadSwiftPlugins();
+                expect(workspaceContext.folders).to.not.have.lengthOf(0);
+            },
         });
 
-        suite("includes command plugin provided by tasks.json", async () => {
-            let task: vscode.Task | undefined;
+        suite("createSwiftPluginTask", () => {
+            let taskProvider: SwiftPluginTaskProvider;
 
-            setup(async () => {
-                const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
-                task = tasks.find(t => t.name === "swift: command-plugin from tasks.json");
+            setup(() => {
+                taskProvider = new SwiftPluginTaskProvider(workspaceContext);
             });
 
-            test("provides", () => {
-                expect(task?.detail).to.equal("swift package command_plugin --foo");
-            });
-
-            test("executes", async () => {
-                assert(task);
-                const exitPromise = waitForEndTaskProcess(task);
-                await vscode.tasks.executeTask(task);
-                const exitCode = await exitPromise;
+            test("Exit code on success", async () => {
+                const task = taskProvider.createSwiftPluginTask(
+                    folderContext.swiftPackage.plugins[0],
+                    {
+                        cwd: folderContext.folder,
+                        scope: folderContext.workspaceFolder,
+                    }
+                );
+                const { exitCode, output } = await executeTaskAndWaitForResult(task);
                 expect(exitCode).to.equal(0);
-            }).timeout(30000); // 30 seconds to run
+                expect(cleanOutput(output)).to.include("Hello, World!");
+            }).timeout(60000);
+
+            test("Exit code on failure", async () => {
+                const task = taskProvider.createSwiftPluginTask(
+                    {
+                        command: "not_a_command",
+                        name: "not_a_command",
+                        package: "command-plugin",
+                    },
+                    {
+                        cwd: folderContext.folder,
+                        scope: folderContext.workspaceFolder,
+                    }
+                );
+                mutable(task.execution).command = "/definitely/not/swift";
+                const { exitCode, output } = await executeTaskAndWaitForResult(task);
+                expect(exitCode, `${output}`).to.not.equal(0);
+            }).timeout(10000);
+        });
+
+        suite("provideTasks", () => {
+            suite("includes command plugin provided by the extension", async () => {
+                let task: vscode.Task | undefined;
+
+                setup(async () => {
+                    const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
+                    task = tasks.find(t => t.name === "command-plugin");
+                });
+
+                test("provides", () => {
+                    expect(task?.detail).to.equal("swift package command_plugin");
+                });
+
+                test("executes", async () => {
+                    assert(task);
+                    const exitPromise = waitForEndTaskProcess(task);
+                    await vscode.tasks.executeTask(task);
+                    const exitCode = await exitPromise;
+                    expect(exitCode).to.equal(0);
+                }).timeout(30000); // 30 seconds to run
+            });
+
+            suite("includes command plugin provided by tasks.json", async () => {
+                let task: vscode.Task | undefined;
+
+                setup(async () => {
+                    const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
+                    task = tasks.find(t => t.name === "swift: command-plugin from tasks.json");
+                });
+
+                test("provides", () => {
+                    expect(task?.detail).to.equal("swift package command_plugin --foo");
+                });
+
+                test("executes", async () => {
+                    assert(task);
+                    const exitPromise = waitForEndTaskProcess(task);
+                    await vscode.tasks.executeTask(task);
+                    const exitCode = await exitPromise;
+                    expect(exitCode).to.equal(0);
+                }).timeout(30000); // 30 seconds to run
+            });
         });
     });
 });

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -21,6 +21,7 @@ import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { FolderContext } from "../../../src/FolderContext";
 import { waitForNoRunningTasks } from "../../utilities/tasks";
 import { closeAllEditors } from "../../utilities/commands";
+import { isDeepStrictEqual } from "util";
 
 function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     const result = vscode.workspace.workspaceFolders?.at(0);
@@ -296,8 +297,10 @@ export async function updateSettings(settings: SettingsMap): Promise<() => Promi
         for (const setting of Object.keys(settings)) {
             const { section, name } = decomposeSettingName(setting);
             while (
-                vscode.workspace.getConfiguration(section, { languageId: "swift" }).get(name) !==
-                settings[setting]
+                isDeepStrictEqual(
+                    vscode.workspace.getConfiguration(section, { languageId: "swift" }).get(name),
+                    settings[setting]
+                ) === false
             ) {
                 // Not yet, wait a bit and try again.
                 await new Promise(resolve => setTimeout(resolve, 30));


### PR DESCRIPTION
Packages can define their own plugins either directly or through their dependencies. These plugins define commands, and the extension exposes a list of these when you use `> Swift: Run Command Plugin`.

If a command requires special permissions to write to disk or use the network the user is prompted in the integrated terminal to type "yes". This can be bypassed by passing a permission flag to the command such as `--allow-writing-to-package-directory`. The extension does supply permission flags for a small list of well known package plugins, however if the user creates their own or uses one not on this list they must enter "yes" every time they run the command plugin.

This patch introduces a new setting that can be specified globally or on a per workspace folder basis that allows users to configure which permission flags should be used when running the command.

The setting is defined under `swift.pluginPermissions`, and is specified as an object in the following form:

```
{
	"PluginCommandName:intent-name": {
		"allowWritingToPackageDirectory": true,
		"allowWritingToDirectory: "/some/path",
		"allowNetworkConnections: "all",
		"disableSandbox": true,
	}
}
```

- The top level string key is the command id in the form `PluginCommandName:intent-name`. For instance, swift-format's format-source-code command would be specified as `swift-format:format-source-code`
- Each permission in the permissions lookup is optional.
- `allowWritingToDirectory` can also be specified as an array of paths.
- The valid values for `allowNetworkConnections` can be found here: https://github.com/swiftlang/swift-package-manager/blob/0401a2ae55077cfd1f4c0acd43ae0a1a56ab21ef/Sources/Commands/PackageCommands/PluginCommand.swift#L62

Issue: #1277