### PR TITLE
Display error messages in the Documentation Live Preview Editor

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,4 +8,7 @@
 !dist/**
 !images/**
 !snippets/**
-!assets/icon-font.woff
+!assets/icons/**
+!assets/documentation-webview/**
+!assets/swift-docc-render/**
+!node_modules/@vscode/codicons/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.11.4",
       "hasInstallScript": true,
       "dependencies": {
+        "@vscode/codicons": "^0.0.36",
         "lcov-parse": "^1.0.0",
         "plist": "^3.1.0",
         "vscode-languageclient": "^9.0.1",
@@ -1383,6 +1384,12 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
+      "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ==",
+      "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/debugprotocol": {
       "version": "1.68.0",
@@ -7365,6 +7372,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "@vscode/codicons": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
+      "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ=="
     },
     "@vscode/debugprotocol": {
       "version": "1.68.0",

--- a/package.json
+++ b/package.json
@@ -1423,6 +1423,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
+    "@vscode/codicons": "^0.0.36",
     "lcov-parse": "^1.0.0",
     "plist": "^3.1.0",
     "vscode-languageclient": "^9.0.1",

--- a/src/documentation/DocumentationPreviewEditor.ts
+++ b/src/documentation/DocumentationPreviewEditor.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2024-2025 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -41,6 +41,11 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
                 enableScripts: true,
                 localResourceRoots: [
                     vscode.Uri.file(
+                        extension.asAbsolutePath(
+                            path.join("node_modules", "@vscode/codicons", "dist")
+                        )
+                    ),
+                    vscode.Uri.file(
                         extension.asAbsolutePath(path.join("assets", "documentation-webview"))
                     ),
                     vscode.Uri.file(swiftDoccRenderPath),
@@ -72,8 +77,16 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
             path.join(swiftDoccRenderPath, "index.html"),
             "utf-8"
         );
+        const codiconsUri = webviewPanel.webview.asWebviewUri(
+            vscode.Uri.file(
+                extension.asAbsolutePath(
+                    path.join("node_modules", "@vscode/codicons", "dist", "codicon.css")
+                )
+            )
+        );
         doccRenderHTML = doccRenderHTML
             .replaceAll("{{BASE_PATH}}", webviewBaseURI.toString())
+            .replace("</head>", `<link href="${codiconsUri}" rel="stylesheet" /></head>`)
             .replace("</body>", `<script src="${scriptURI.toString()}"></script></body>`);
         webviewPanel.webview.html = doccRenderHTML;
         return new DocumentationPreviewEditor(context, webviewPanel);

--- a/src/documentation/webview/ErrorMessage.ts
+++ b/src/documentation/webview/ErrorMessage.ts
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+export class ErrorMessage {
+    private readonly containerElement: HTMLDivElement;
+    private readonly iconElement: HTMLSpanElement;
+    private readonly messageElement: HTMLSpanElement;
+
+    constructor() {
+        this.containerElement = createContainer();
+        this.iconElement = createIcon();
+        this.messageElement = createMessage();
+        this.containerElement.appendChild(this.iconElement);
+        this.containerElement.appendChild(this.messageElement);
+        window.document.body.appendChild(this.containerElement);
+    }
+
+    show(message: string) {
+        this.messageElement.textContent = message;
+        this.containerElement.style.display = "flex";
+    }
+
+    hide() {
+        this.containerElement.style.display = "none";
+    }
+}
+
+function createContainer(): HTMLDivElement {
+    const containerElement = document.createElement("div");
+    containerElement.style.width = "100%";
+    containerElement.style.height = "100%";
+    containerElement.style.display = "none";
+    containerElement.style.gap = "10px";
+    containerElement.style.flexDirection = "column";
+    containerElement.style.alignItems = "center";
+    containerElement.style.justifyContent = "center";
+    containerElement.style.position = "absolute";
+    containerElement.style.top = "0";
+    containerElement.style.left = "0";
+    return containerElement;
+}
+
+function createIcon(): HTMLSpanElement {
+    const iconElement = document.createElement("span");
+    iconElement.className = "codicon codicon-error";
+    iconElement.style.color = "var(--vscode-editorError-foreground)";
+    iconElement.style.fontSize = "48px";
+    return iconElement;
+}
+
+function createMessage(): HTMLSpanElement {
+    const messageElement = document.createElement("span");
+    messageElement.style.color = "var(--vscode-foreground)";
+    messageElement.style.fontSize = "14px";
+    return messageElement;
+}

--- a/src/documentation/webview/ErrorMessage.ts
+++ b/src/documentation/webview/ErrorMessage.ts
@@ -38,6 +38,10 @@ export class ErrorMessage {
 
 function createContainer(): HTMLDivElement {
     const containerElement = document.createElement("div");
+    containerElement.style.backgroundColor = "var(--vscode-editor-background)";
+    containerElement.style.color = "var(--vscode-foreground)";
+    containerElement.style.fontFamily = "var(--vscode-font-family)";
+    containerElement.style.fontWeight = "var(--vscode-font-weight)";
     containerElement.style.width = "100%";
     containerElement.style.height = "100%";
     containerElement.style.display = "none";
@@ -61,7 +65,6 @@ function createIcon(): HTMLSpanElement {
 
 function createMessage(): HTMLSpanElement {
     const messageElement = document.createElement("span");
-    messageElement.style.color = "var(--vscode-foreground)";
     messageElement.style.fontSize = "14px";
     return messageElement;
 }


### PR DESCRIPTION
SourceKit-LSP has the capability of returning error messages for live preview that should be displayed to the user. Show an error message in this case that matches the style of errors shown in VSCode text editors.