### PR TITLE
Improve user feedback if SourceKit-LSP is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -570,7 +570,7 @@
           "swift.sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Disable SourceKit-LSP. This will turn off features like code completion, error diagnostics and jump-to-definition. Certain features like swift-testing tests may not work correctly.",
+            "markdownDescription": "Disable SourceKit-LSP. This will turn off features like code completion, error diagnostics and jump-to-definition. Features like swift-testing test discovery will not work correctly.",
             "order": 6
           },
           "sourcekit-lsp.inlayHints.enabled": {

--- a/package.json
+++ b/package.json
@@ -570,7 +570,7 @@
           "swift.sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "Disable SourceKit-LSP",
+            "markdownDescription": "Disable SourceKit-LSP. This will turn off features like code completion, error diagnostics and jump-to-definition. Certain features like swift-testing tests may not work correctly.",
             "order": 6
           },
           "sourcekit-lsp.inlayHints.enabled": {

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -261,6 +261,14 @@ export class TestExplorer {
     async discoverTestsInWorkspaceSPM(token: vscode.CancellationToken) {
         async function runDiscover(explorer: TestExplorer, firstTry: boolean) {
             try {
+                // we depend on sourcekit-lsp to detect swift-testing tests so let the user know
+                // that things won't work properly if sourcekit-lsp has been disabled for some reason
+                if (firstTry === true && configuration.lsp.disable === true) {
+                    vscode.window.showInformationMessage(
+                        `swift-testing tests may not be detected correctly since SourceKit-LSP
+                        has been disabled for this workspace.`
+                    );
+                }
                 const toolchain = explorer.folderContext.workspaceContext.toolchain;
                 // get build options before build is run so we can be sure they aren't changed
                 // mid-build

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -263,11 +263,31 @@ export class TestExplorer {
             try {
                 // we depend on sourcekit-lsp to detect swift-testing tests so let the user know
                 // that things won't work properly if sourcekit-lsp has been disabled for some reason
-                if (firstTry === true && configuration.lsp.disable === true) {
-                    vscode.window.showInformationMessage(
-                        `swift-testing tests may not be detected correctly since SourceKit-LSP
-                        has been disabled for this workspace.`
-                    );
+                // and provide an option to enable sourcekit-lsp again
+                const ok = "OK";
+                const enable = "Enable SourceKit-LSP";
+                if (firstTry && configuration.lsp.disable === true) {
+                    vscode.window
+                        .showInformationMessage(
+                            `swift-testing tests will not be detected since SourceKit-LSP
+                            has been disabled for this workspace.`,
+                            enable,
+                            ok
+                        )
+                        .then(selected => {
+                            if (selected === enable) {
+                                explorer.folderContext.workspaceContext.outputChannel.log(
+                                    `Enabling SourceKit-LSP after swift-testing message`
+                                );
+                                vscode.workspace
+                                    .getConfiguration("swift")
+                                    .update("sourcekit-lsp.disable", false);
+                            } else if (selected === ok) {
+                                explorer.folderContext.workspaceContext.outputChannel.log(
+                                    `User acknowledged that SourceKit-LSP is disabled`
+                                );
+                            }
+                        });
                 }
                 const toolchain = explorer.folderContext.workspaceContext.toolchain;
                 // get build options before build is run so we can be sure they aren't changed

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -225,10 +225,8 @@ export class LanguageClientManager implements vscode.Disposable {
                         // Language client is already stopped
                         return;
                     }
-                    message =
-                        `You have disabled the Swift language server, but it is still running. Would you like to stop it now?
-                        This will turn off code completion, error diagnostics and jump-to-definition.
-                        Certain features like swift-testing tests may not work correctly.`;
+                    message = `You have disabled the Swift language server, but it is still running. Would you like to stop it now?
+                        This will turn off features such as code completion, error diagnostics, jump-to-definition, and test discovery.`;
                     restartLSPButton = "Stop Language Server";
                 } else {
                     if (this.state !== State.Stopped) {

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -226,7 +226,9 @@ export class LanguageClientManager implements vscode.Disposable {
                         return;
                     }
                     message =
-                        "You have disabled the Swift language server, but it is still running. Would you like to stop it now?";
+                        `You have disabled the Swift language server, but it is still running. Would you like to stop it now?
+                        This will turn off code completion, error diagnostics and jump-to-definition.
+                        Certain features like swift-testing tests may not work correctly.`;
                     restartLSPButton = "Stop Language Server";
                 } else {
                     if (this.state !== State.Stopped) {


### PR DESCRIPTION
Add some notifications to let users know that several things won't work as expected if SourceKit-LSP is disabled.

Issue: #892