### PR TITLE
Fix empty folder in dependencies view for registry deps

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -148,7 +148,7 @@ export interface CheckoutState {
 
 export interface WorkspaceStateDependency {
     packageRef: { identity: string; kind: string; location: string; name: string };
-    state: { name: string; path?: string; checkoutState?: CheckoutState };
+    state: { name: string; path?: string; checkoutState?: CheckoutState; version?: string };
     subpath: string;
 }
 

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -358,6 +358,7 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
                 dependency.state.checkoutState?.version ??
                 dependency.state.checkoutState?.branch ??
                 dependency.state.checkoutState?.revision.substring(0, 7) ??
+                dependency.state.version ??
                 "unknown"
             );
         }
@@ -389,7 +390,11 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
                 workspaceFolder,
                 true
             );
-            return path.join(buildDirectory, "checkouts", dependency.subpath);
+            if (dependency.packageRef.kind === "registry") {
+                return path.join(buildDirectory, "registry", "downloads", dependency.subpath);
+            } else {
+                return path.join(buildDirectory, "checkouts", dependency.subpath);
+            }
         }
     }
 }


### PR DESCRIPTION
Registry dependencies are stored in a different location than those checked out from source control.

Issue: #1307