### PR TITLE
Handle typed throws when generating comment completions

### DIFF
--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -179,6 +179,9 @@ class FunctionDocumentationCompletionProvider implements vscode.CompletionItemPr
             }
             if (mark[0] === "throws") {
                 throws = true;
+
+                // Check for a type annotation on the throw i.e. throws(MyError)
+                parser.match(/^\s*(\(.*\))/);
             }
         }
         // if we find a `->` then function returns a value

--- a/test/integration-tests/editor/CommentCompletion.test.ts
+++ b/test/integration-tests/editor/CommentCompletion.test.ts
@@ -164,6 +164,27 @@ suite("CommentCompletion Test Suite", () => {
         ]);
     });
 
+    test("Comment completion on complex typed throwing function", async () => {
+        const { document, positions } = await openDocument(`
+            /// 1️⃣
+            func foo(bar: Int, baz: String) -> Data throws(MyError) { return Data() }`);
+        const position = positions["1️⃣"];
+
+        const items = await provider.functionCommentCompletion.provideCompletionItems(
+            document,
+            position
+        );
+        assert.deepEqual(items, [
+            expectedCompletionItem(
+                ` $1
+/// - Parameters:
+///   - bar: $2
+///   - baz: $3
+/// - Returns: $4`
+            ),
+        ]);
+    });
+
     test("Comment Insertion", async () => {
         const { document, positions } = await openDocument(`
             /// 1️⃣


### PR DESCRIPTION
The comment completion parser was stumbling over the type declaration for typed throws, causing it to stop parsing the function declaration before it got to the return type.

Issue: #1313