### PR TITLE
Notify build is preparing before progress starts

### DIFF
--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -82,7 +82,6 @@ export async function debugSnippetWithOptions(
             presentationOptions: {
                 reveal: vscode.TaskRevealKind.Always,
             },
-            showBuildStatus: configuration.showBuildStatus,
         },
         ctx.toolchain
     );

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -19,7 +19,6 @@ import { createSwiftTask } from "./tasks/SwiftTaskProvider";
 import { WorkspaceContext } from "./WorkspaceContext";
 import { createSnippetConfiguration, debugLaunchConfig } from "./debugger/launch";
 import { TaskOperation } from "./tasks/TaskQueue";
-import configuration from "./configuration";
 
 /**
  * Set context key indicating whether current file is a Swift Snippet

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -155,7 +155,6 @@ export function createBuildAllTask(
                 reveal: getBuildRevealOption(),
             },
             disableTaskQueue: true,
-            showBuildStatus: configuration.showBuildStatus,
         },
         folderContext.workspaceContext.toolchain
     );
@@ -239,7 +238,6 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 },
                 disableTaskQueue: true,
                 dontTriggerTestDiscovery: true,
-                showBuildStatus: configuration.showBuildStatus,
             },
             folderContext.workspaceContext.toolchain
         );
@@ -268,7 +266,6 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
                 },
                 disableTaskQueue: true,
                 dontTriggerTestDiscovery: true,
-                showBuildStatus: configuration.showBuildStatus,
             },
             folderContext.workspaceContext.toolchain
         );
@@ -314,9 +311,15 @@ export function createSwiftTask(
             args: args,
             env: env,
             cwd: cwd,
-            showBuildStatus: config.showBuildStatus,
-            disableTaskQueue: config.disableTaskQueue,
-            dontTriggerTestDiscovery: config.dontTriggerTestDiscovery,
+            ...(config.showBuildStatus !== undefined
+                ? { showBuildStatus: config.showBuildStatus }
+                : {}),
+            ...(config.disableTaskQueue !== undefined
+                ? { disableTaskQueue: config.disableTaskQueue }
+                : {}),
+            ...(config.dontTriggerTestDiscovery !== undefined
+                ? { dontTriggerTestDiscovery: config.dontTriggerTestDiscovery }
+                : {}),
         },
         config?.scope ?? vscode.TaskScope.Workspace,
         name,

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -132,7 +132,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
             }
             if (this.checkIfFetching(line)) {
                 // this.statusItem.update(task, `Fetching dependencies "${task.name}"`);
-                update(`${name}: fetching dependencies`);
+                update(`${name} fetching dependencies`);
                 state.started = true;
                 return false;
             }

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -71,28 +71,14 @@ export class SwiftBuildStatus implements vscode.Disposable {
                     disposables.forEach(d => d.dispose());
                     res();
                 };
-                let started = false;
                 disposables.push(
-                    execution.onDidWrite(data => {
-                        const name = new RunningTask(task).name;
-
-                        // If we've found nothing that matches a known state then put up a temporary
-                        // message that we're preparing the build, as there is sometimes a delay before
-                        // building starts while the build system is preparing, especially in large projects.
-                        // The status bar has a message immediately, so only show this when using a
-                        // notification to show progress.
-                        if (
-                            !started &&
-                            (showBuildStatus === "notification" || showBuildStatus === "progress")
-                        ) {
-                            update(`${name}: Preparing...`);
-                        }
-
-                        started = true;
-                        if (this.parseEvents(name, data, update)) {
-                            done();
-                        }
-                    }),
+                    this.outputParser(
+                        new RunningTask(task).name,
+                        execution,
+                        showBuildStatus,
+                        update,
+                        done
+                    ),
                     execution.onDidClose(done),
                     vscode.tasks.onDidEndTask(e => {
                         if (e.execution.task === task) {
@@ -118,32 +104,57 @@ export class SwiftBuildStatus implements vscode.Disposable {
         }
     }
 
-    /**
-     * @param data
-     * @returns true if done, false otherwise
-     */
-    private parseEvents(name: string, data: string, update: (message: string) => void): boolean {
-        const sanitizedData = stripAnsi(data);
-        // We'll process data one line at a time, in reverse order
-        // since the latest interesting message is all we need to
-        // be concerned with
-        const lines = sanitizedData.split(/\r\n|\n|\r/gm).reverse();
-        for (const line of lines) {
-            if (checkIfBuildComplete(line)) {
-                return true;
+    private outputParser(
+        name: string,
+        execution: SwiftExecution,
+        showBuildStatus: ShowBuildStatusOptions,
+        update: (message: string) => void,
+        done: () => void
+    ): vscode.Disposable {
+        let started = false;
+
+        const parseEvents = (data: string) => {
+            const sanitizedData = stripAnsi(data);
+            // We'll process data one line at a time, in reverse order
+            // since the latest interesting message is all we need to
+            // be concerned with
+            const lines = sanitizedData.split(/\r\n|\n|\r/gm).reverse();
+            for (const line of lines) {
+                if (checkIfBuildComplete(line)) {
+                    return true;
+                }
+                const progress = this.findBuildProgress(line);
+                if (progress) {
+                    update(`${name}: [${progress.completed}/${progress.total}]`);
+                    started = true;
+                    return false;
+                }
+                if (this.checkIfFetching(line)) {
+                    // this.statusItem.update(task, `Fetching dependencies "${task.name}"`);
+                    update(`${name}: Fetching Dependencies`);
+                    started = true;
+                    return false;
+                }
             }
-            const progress = this.findBuildProgress(line);
-            if (progress) {
-                update(`${name}: [${progress.completed}/${progress.total}]`);
-                return false;
+            // If we've found nothing that matches a known state then put up a temporary
+            // message that we're preparing the build, as there is sometimes a delay before
+            // building starts while the build system is preparing, especially in large projects.
+            // The status bar has a message immediately, so only show this when using a
+            // notification to show progress.
+            if (
+                !started &&
+                (showBuildStatus === "notification" || showBuildStatus === "progress")
+            ) {
+                update(`${name}: Preparing...`);
             }
-            if (this.checkIfFetching(line)) {
-                // this.statusItem.update(task, `Fetching dependencies "${task.name}"`);
-                update(`${name}: Fetching Dependencies`);
-                return false;
+            return false;
+        };
+
+        return execution.onDidWrite(data => {
+            if (parseEvents(data)) {
+                done();
             }
-        }
-        return false;
+        });
     }
 
     private checkIfFetching(line: string): boolean {

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -126,13 +126,13 @@ export class SwiftBuildStatus implements vscode.Disposable {
             }
             const progress = this.findBuildProgress(line);
             if (progress) {
-                update(`${name} [${progress.completed}/${progress.total}]`);
+                update(`${name}: [${progress.completed}/${progress.total}]`);
                 state.started = true;
                 return false;
             }
             if (this.checkIfFetching(line)) {
                 // this.statusItem.update(task, `Fetching dependencies "${task.name}"`);
-                update(`${name} fetching dependencies`);
+                update(`${name}: Fetching Dependencies`);
                 state.started = true;
                 return false;
             }
@@ -146,7 +146,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
             !state.started &&
             (showBuildStatus === "notification" || showBuildStatus === "progress")
         ) {
-            update(`Preparing ${name}`);
+            update(`${name}: Preparing...`);
         }
         return false;
     }

--- a/test/unit-tests/ui/SwiftBuildStatus.test.ts
+++ b/test/unit-tests/ui/SwiftBuildStatus.test.ts
@@ -164,7 +164,7 @@ suite("SwiftBuildStatus Unit Test Suite", async function () {
                 "Fetched https://github.com/apple/swift-testing.git from cache (0.77s)\n"
         );
 
-        const expected = "My Task fetching dependencies";
+        const expected = "My Task: Fetching Dependencies";
         expect(mockedProgress.report).to.have.been.calledWith({ message: expected });
         expect(mockedStatusItem.update).to.have.been.calledWith(mockedTaskExecution.task, expected);
     });
@@ -186,7 +186,7 @@ suite("SwiftBuildStatus Unit Test Suite", async function () {
                 "[7/7] Applying MyCLI\n"
         );
 
-        const expected = "My Task [7/7]";
+        const expected = "My Task: [7/7]";
         expect(mockedProgress.report).to.have.been.calledWith({ message: expected });
         expect(mockedStatusItem.update).to.have.been.calledWith(mockedTaskExecution.task, expected);
 

--- a/test/unit-tests/ui/SwiftBuildStatus.test.ts
+++ b/test/unit-tests/ui/SwiftBuildStatus.test.ts
@@ -192,9 +192,9 @@ suite("SwiftBuildStatus Unit Test Suite", async function () {
 
         // Ignore old stuff
         expect(mockedProgress.report).to.not.have.been.calledWith({
-            message: "My Task fetching dependencies",
+            message: "My Task: Fetching Dependencies",
         });
-        expect(mockedProgress.report).to.not.have.been.calledWith({ message: "My Task [6/7]" });
+        expect(mockedProgress.report).to.not.have.been.calledWith({ message: "My Task: [6/7]" });
     });
 
     test("Build complete", async () => {


### PR DESCRIPTION
The build progress notification would only appear once the progress values were shown in the output, i.e. [12/122]. Until progress values appear, show a "Preparing <task>" notification. This only needs to apply when the `showBuildStatus` value is `notification` or `progress`, since `swiftStatus` already shows a message in the bar immediately.

This patch also only sets the `showBuildStatus` setting on a Task if it is coming from a user defined task. Previously it was being set on synthetic tasks which were being cached, so when the user updated the `showBuildStatus` setting it wouldn't take effect until they restarted the extension.

Issue: #1322