### PR TITLE
Show build preparing status immediately

### DIFF
--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -136,19 +136,16 @@ export class SwiftBuildStatus implements vscode.Disposable {
                     return false;
                 }
             }
-            // If we've found nothing that matches a known state then put up a temporary
-            // message that we're preparing the build, as there is sometimes a delay before
-            // building starts while the build system is preparing, especially in large projects.
-            // The status bar has a message immediately, so only show this when using a
-            // notification to show progress.
-            if (
-                !started &&
-                (showBuildStatus === "notification" || showBuildStatus === "progress")
-            ) {
-                update(`${name}: Preparing...`);
-            }
             return false;
         };
+
+        // Begin by showing a message that the build is preparing, as there is sometimes
+        // a delay before building starts, especially in large projects.
+        // The status bar has a message immediately, so only show this when using a
+        // notification to show progress.
+        if (!started && (showBuildStatus === "notification" || showBuildStatus === "progress")) {
+            update(`${name}: Preparing...`);
+        }
 
         return execution.onDidWrite(data => {
             if (parseEvents(data)) {

--- a/test/unit-tests/ui/SwiftBuildStatus.test.ts
+++ b/test/unit-tests/ui/SwiftBuildStatus.test.ts
@@ -215,8 +215,7 @@ suite("SwiftBuildStatus Unit Test Suite", async function () {
                 "Build complete!"
         );
 
-        // Report nothing
-        expect(mockedProgress.report).to.not.have.been.called;
-        expect(mockedStatusItem.update).to.not.have.been.called;
+        // Report only the preparing message
+        expect(mockedProgress.report).to.have.been.calledWith({ message: "My Task: Preparing..." });
     });
 });


### PR DESCRIPTION
Previously we were waiting for output from the build, which could be several seconds.

Issue: #1323