### PR TITLE
Move CodeLLDB XCTest case to nightly

### DIFF
--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -162,7 +162,7 @@ suite("Test Explorer Suite", function () {
                 }
             });
 
-            test("Debugs specified XCTest test", async function () {
+            test("Debugs specified XCTest test @slow", async function () {
                 // CodeLLDB tests stall out on 5.9 and below.
                 if (workspaceContext.swiftVersion.isLessThan(new Version(5, 10, 0))) {
                     this.skip();


### PR DESCRIPTION
This test case seems to get stuck frequently on Swift 5.10 now. Move it to nightly for now so that we can avoid creating false positives.

Issue: #1317