### PR TITLE
Show project dependencies hierarchically

### DIFF
--- a/assets/test/dependencies/Package.swift
+++ b/assets/test/dependencies/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "dependencies",
-            dependencies: [.product(name: "MarkdownLib", package: "swift-markdown")],
+            dependencies: [.product(name: "Markdown", package: "swift-markdown")],
             path: "Sources"),
     ]
 )

--- a/assets/test/dependencies/Sources/main.swift
+++ b/assets/test/dependencies/Sources/main.swift
@@ -1,4 +1,4 @@
-import MarkdownLib
+import Markdown
 
 print("Test Asset:(dependencies)")
 print(a)

--- a/assets/test/identity-different/Package.resolved
+++ b/assets/test/identity-different/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "cmark-gfm",
-        "repositoryURL": "https://github.com/apple/swift-cmark.git",
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
-          "branch": "gfm",
-          "revision": "bfdc057b5a02fc65af20771a7ba08f9c944eb117",
-          "version": null
+          "branch": null,
+          "revision": "96a2f8a0fa41e9e09af4585e2724c4e825410b91",
+          "version": "1.6.2"
         }
       }
     ]

--- a/assets/test/identity-different/Package.swift
+++ b/assets/test/identity-different/Package.swift
@@ -13,13 +13,13 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(name: "cmark", url: "https://github.com/apple/swift-cmark.git", .branch("gfm")),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "identity-different",
-            dependencies: ["cmark"]),
+            dependencies: [.product(name: "Logging", package: "swift-log")]),
     ]
 )

--- a/package.json
+++ b/package.json
@@ -129,6 +129,18 @@
         "category": "Swift"
       },
       {
+        "command": "swift.flatDependenciesList",
+        "title": "Flat Dependencies List View",
+        "icon": "$(list-flat)",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.nestedDependenciesList",
+        "title": "Nested Dependencies List View",
+        "icon": "$(list-tree)",
+        "category": "Swift"
+      },
+      {
         "command": "swift.cleanBuild",
         "title": "Clean Build Folder",
         "category": "Swift"
@@ -785,6 +797,14 @@
           "when": "swift.hasPackage"
         },
         {
+          "command": "swift.flatDependenciesList",
+          "when": "false"
+        },
+        {
+          "command": "swift.nestedDependenciesList",
+          "when": "false"
+        },
+        {
           "command": "swift.useLocalDependency",
           "when": "false"
         },
@@ -889,17 +909,27 @@
         {
           "command": "swift.updateDependencies",
           "when": "view == packageDependencies",
-          "group": "navigation"
+          "group": "navigation@1"
         },
         {
           "command": "swift.resolveDependencies",
           "when": "view == packageDependencies",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
           "command": "swift.resetPackage",
           "when": "view == packageDependencies",
-          "group": "navigation"
+          "group": "navigation@3"
+        },
+        {
+          "command": "swift.flatDependenciesList",
+          "when": "view == packageDependencies && !swift.flatDependenciesList",
+          "group": "navigation@4"
+        },
+        {
+          "command": "swift.nestedDependenciesList",
+          "when": "view == packageDependencies && swift.flatDependenciesList",
+          "group": "navigation@5"
         }
       ],
       "view/item/context": [

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -128,13 +128,14 @@ export class FolderContext implements vscode.Disposable {
         await this.swiftPackage.reloadPackageResolved();
     }
 
+    /** reload workspace-state.json for this folder */
+    async reloadWorkspaceState() {
+        await this.swiftPackage.reloadWorkspaceState();
+    }
+
     /** Load Swift Plugins and store in Package */
     async loadSwiftPlugins() {
-        const plugins = await SwiftPackage.loadPlugins(
-            this.folder,
-            this.workspaceContext.toolchain
-        );
-        this.swiftPackage.plugins = plugins;
+        await this.swiftPackage.loadSwiftPlugins(this.workspaceContext.toolchain);
     }
 
     /**

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -54,7 +54,7 @@ export interface Dependency {
     dependencies: Dependency[];
 }
 
-export interface ResolvedDependency extends Omit<Omit<Dependency, "type">, "path"> {
+export interface ResolvedDependency extends Dependency {
     version: string;
     type: string;
     path: string;

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -385,7 +385,7 @@ export class SwiftPackage implements PackageContents {
         };
     }
 
-    public async childDependencies(dependency: Dependency): Promise<ResolvedDependency[]> {
+    public childDependencies(dependency: Dependency): ResolvedDependency[] {
         return dependency.dependencies.map(dep => this.resolveDependencyAgainstWorkspaceState(dep));
     }
 

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -680,6 +680,8 @@ export enum FolderOperation {
     packageUpdated = "packageUpdated",
     // Package.resolved has been updated
     resolvedUpdated = "resolvedUpdated",
+    // .build/workspace-state.json has been updated
+    workspaceStateUpdated = "workspaceStateUpdated",
 }
 
 /** Workspace Folder Event */

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -682,6 +682,8 @@ export enum FolderOperation {
     resolvedUpdated = "resolvedUpdated",
     // .build/workspace-state.json has been updated
     workspaceStateUpdated = "workspaceStateUpdated",
+    // .build/workspace-state.json has been updated
+    packageViewUpdated = "packageViewUpdated",
 }
 
 /** Workspace Folder Event */

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,6 +39,7 @@ import { runPluginTask } from "./commands/runPluginTask";
 import { runTestMultipleTimes } from "./commands/testMultipleTimes";
 import { newSwiftFile } from "./commands/newFile";
 import { runAllTestsParallel } from "./commands/runParallelTests";
+import { updateDependenciesViewList } from "./commands/dependencies/updateDepViewList";
 
 /**
  * References:
@@ -69,6 +70,8 @@ export enum Commands {
     DEBUG = "swift.debug",
     CLEAN_BUILD = "swift.cleanBuild",
     RESOLVE_DEPENDENCIES = "swift.resolveDependencies",
+    SHOW_FLAT_DEPENDENCIES_LIST = "swift.flatDependenciesList",
+    SHOW_NESTED_DEPENDENCIES_LIST = "swift.nestedDependenciesList",
     UPDATE_DEPENDENCIES = "swift.updateDependencies",
     RUN_TESTS_MULTIPLE_TIMES = "swift.runTestsMultipleTimes",
     RESET_PACKAGE = "swift.resetPackage",
@@ -159,6 +162,12 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         vscode.commands.registerCommand(
             Commands.PREVIEW_DOCUMENTATION,
             async () => await ctx.documentation.launchDocumentationPreview()
+        ),
+        vscode.commands.registerCommand(Commands.SHOW_FLAT_DEPENDENCIES_LIST, () =>
+            updateDependenciesViewList(ctx, true)
+        ),
+        vscode.commands.registerCommand(Commands.SHOW_NESTED_DEPENDENCIES_LIST, () =>
+            updateDependenciesViewList(ctx, false)
         ),
     ];
 }

--- a/src/commands/dependencies/updateDepViewList.ts
+++ b/src/commands/dependencies/updateDepViewList.ts
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2021-2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import contextKeys from "../../contextKeys";
+import { FolderOperation, WorkspaceContext } from "../../WorkspaceContext";
+
+export function updateDependenciesViewList(ctx: WorkspaceContext, flatList: boolean) {
+    if (ctx.currentFolder) {
+        contextKeys.flatDependenciesList = flatList;
+        ctx.fireEvent(ctx.currentFolder, FolderOperation.packageViewUpdated);
+    }
+}

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -39,6 +39,11 @@ interface ContextKeys {
     packageHasDependencies: boolean;
 
     /**
+     * Whether the dependencies list is displayed in a nested or flat view.
+     */
+    flatDependenciesList: boolean;
+
+    /**
      * Whether the Swift package has any plugins.
      */
     packageHasPlugins: boolean;
@@ -78,6 +83,7 @@ interface ContextKeys {
 function createContextKeys(): ContextKeys {
     let isActivated: boolean = false;
     let hasPackage: boolean = false;
+    let flatDependenciesList: boolean = false;
     let packageHasDependencies: boolean = false;
     let packageHasPlugins: boolean = false;
     let currentTargetType: string | undefined = undefined;
@@ -113,6 +119,15 @@ function createContextKeys(): ContextKeys {
         set packageHasDependencies(value: boolean) {
             packageHasDependencies = value;
             vscode.commands.executeCommand("setContext", "swift.packageHasDependencies", value);
+        },
+
+        get flatDependenciesList() {
+            return flatDependenciesList;
+        },
+
+        set flatDependenciesList(value: boolean) {
+            flatDependenciesList = value;
+            vscode.commands.executeCommand("setContext", "swift.flatDependenciesList", value);
         },
 
         get packageHasPlugins() {

--- a/src/ui/PackageDependencyProvider.ts
+++ b/src/ui/PackageDependencyProvider.ts
@@ -18,16 +18,8 @@ import * as path from "path";
 import configuration from "../configuration";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { FolderOperation } from "../WorkspaceContext";
-import { FolderContext } from "../FolderContext";
 import contextKeys from "../contextKeys";
-import {
-    Dependency,
-    PackageContents,
-    SwiftPackage,
-    WorkspaceState,
-    WorkspaceStateDependency,
-} from "../SwiftPackage";
-import { BuildFlags } from "../toolchain/BuildFlags";
+import { Dependency, ResolvedDependency } from "../SwiftPackage";
 
 /**
  * References:
@@ -41,28 +33,89 @@ import { BuildFlags } from "../toolchain/BuildFlags";
  */
 
 /**
+ * Returns a {@link FileNode} for every file or subdirectory
+ * in the given directory.
+ */
+async function getChildren(directoryPath: string, parentId?: string): Promise<FileNode[]> {
+    const contents = await fs.readdir(directoryPath);
+    const results: FileNode[] = [];
+    const excludes = configuration.excludePathsFromPackageDependencies;
+    for (const fileName of contents) {
+        if (excludes.includes(fileName)) {
+            continue;
+        }
+        const filePath = path.join(directoryPath, fileName);
+        const stats = await fs.stat(filePath);
+        results.push(new FileNode(fileName, filePath, stats.isDirectory(), parentId));
+    }
+    return results.sort((first, second) => {
+        if (first.isDirectory === second.isDirectory) {
+            // If both nodes are of the same type, sort them by name.
+            return first.name.localeCompare(second.name);
+        } else {
+            // Otherwise, sort directories first.
+            return first.isDirectory ? -1 : 1;
+        }
+    });
+}
+
+/**
  * A package in the Package Dependencies {@link vscode.TreeView TreeView}.
  */
 export class PackageNode {
+    private id: string;
+
     constructor(
-        public name: string,
-        public path: string,
-        public location: string,
-        public version: string,
-        public type: "local" | "remote" | "editing"
-    ) {}
+        private dependency: ResolvedDependency,
+        private childDependencies: (dependency: Dependency) => Promise<ResolvedDependency[]>,
+        private parentId?: string
+    ) {
+        this.id =
+            (this.parentId ? `${this.parentId}->` : "") +
+            `${this.name}-${this.dependency.version ?? ""}`;
+    }
+
+    get name(): string {
+        return this.dependency.identity;
+    }
+
+    get location(): string {
+        return this.dependency.location;
+    }
+
+    get type(): string {
+        return this.dependency.type;
+    }
+
+    get path(): string {
+        return this.dependency.path ?? "";
+    }
 
     toTreeItem(): vscode.TreeItem {
         const item = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
-        item.id = this.path;
-        item.description = this.version;
+        item.id = this.id;
+        item.description = this.dependency.version;
         item.iconPath =
-            this.type === "editing"
+            this.dependency.type === "editing"
                 ? new vscode.ThemeIcon("edit")
                 : new vscode.ThemeIcon("package");
-        item.contextValue = this.type;
+        item.contextValue = this.dependency.type;
         item.accessibilityInformation = { label: `Package ${this.name}` };
+        item.tooltip = this.path;
         return item;
+    }
+
+    async getChildren(): Promise<TreeNode[]> {
+        const [childDeps, files] = await Promise.all([
+            this.childDependencies(this.dependency),
+            getChildren(this.dependency.path, this.id),
+        ]);
+        const childNodes = childDeps.map(
+            dep => new PackageNode(dep, this.childDependencies, this.id)
+        );
+
+        // Show dependencies first, then files.
+        return [...childNodes, ...files];
     }
 }
 
@@ -70,11 +123,16 @@ export class PackageNode {
  * A file or directory in the Package Dependencies {@link vscode.TreeView TreeView}.
  */
 export class FileNode {
+    private id: string;
+
     constructor(
         public name: string,
         public path: string,
-        public isDirectory: boolean
-    ) {}
+        public isDirectory: boolean,
+        private parentId?: string
+    ) {
+        this.id = (this.parentId ? `${this.parentId}->` : "") + `${this.path}`;
+    }
 
     toTreeItem(): vscode.TreeItem {
         const item = new vscode.TreeItem(
@@ -83,8 +141,9 @@ export class FileNode {
                 ? vscode.TreeItemCollapsibleState.Collapsed
                 : vscode.TreeItemCollapsibleState.None
         );
-        item.id = this.path;
+        item.id = this.id;
         item.resourceUri = vscode.Uri.file(this.path);
+        item.tooltip = this.path;
         if (!this.isDirectory) {
             item.command = {
                 command: "vscode.open",
@@ -96,6 +155,10 @@ export class FileNode {
             item.accessibilityInformation = { label: `Folder ${this.name}` };
         }
         return item;
+    }
+
+    async getChildren(): Promise<FileNode[]> {
+        return await getChildren(this.path, this.id);
     }
 }
 
@@ -142,6 +205,7 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
                         treeView.title = `Package Dependencies`;
                         this.didChangeTreeDataEmitter.fire();
                         break;
+                    case FolderOperation.workspaceStateUpdated:
                     case FolderOperation.resolvedUpdated:
                         if (!folder) {
                             return;
@@ -164,237 +228,19 @@ export class PackageDependenciesProvider implements vscode.TreeDataProvider<Tree
             return [];
         }
         if (!element) {
-            const workspaceState = await folderContext.swiftPackage.loadWorkspaceState();
-            return await this.getDependencyGraph(workspaceState, folderContext);
-        }
-
-        return this.getNodesInDirectory(element.path);
-    }
-
-    private async getDependencyGraph(
-        workspaceState: WorkspaceState | undefined,
-        folderContext: FolderContext
-    ): Promise<PackageNode[]> {
-        if (!workspaceState) {
-            return [];
-        }
-        const inUseDependencies = await this.getInUseDependencies(workspaceState, folderContext);
-        return (
-            workspaceState?.object.dependencies
-                .filter(dependency =>
-                    inUseDependencies.has(dependency.packageRef.identity.toLowerCase())
-                )
-                .map(dependency => {
-                    const type = this.dependencyType(dependency);
-                    const version = this.dependencyDisplayVersion(dependency);
-                    const packagePath = this.dependencyPackagePath(
-                        dependency,
-                        folderContext.folder.fsPath
-                    );
-                    const location = dependency.packageRef.location;
-                    return new PackageNode(
-                        dependency.packageRef.identity,
-                        packagePath,
-                        location,
-                        version,
-                        type
-                    );
-                }) ?? []
-        );
-    }
-
-    /**
-     * * Returns a set of all dependencies that are in use in the workspace.
-     * Why tranverse is necessary here?
-     *  * If we have an implicit local dependency of a dependency, you may not be able to see it in either `Package.swift` or `Package.resolved` unless tranversing from root Package.swift.
-     * Why not using `swift package show-dependencies`?
-     *  * it costs more time and it triggers the file change of `workspace-state.json` which is not necessary
-     * Why not using `workspace-state.json` directly?
-     *  * `workspace-state.json` contains all necessary dependencies but it also contains dependencies that are not in use.
-     * Here is the implementation details:
-     * 1. local/remote/edited dependency has remote/edited dependencies, Package.resolved covers them
-     * 2. remote/edited dependency has a local dependency, the local dependency must have been declared in root Package.swift
-     * 3. local dependency has a local dependency, traverse it and find the local dependencies only recursively
-     * 4. pins include all remote and edited packages for 1, 2
-     */
-    private async getInUseDependencies(
-        workspaceState: WorkspaceState,
-        folderContext: FolderContext
-    ): Promise<Set<string>> {
-        const localDependencies = await this.getLocalDependencySet(workspaceState, folderContext);
-        const remoteDependencies = this.getRemoteDependencySet(folderContext);
-        const editedDependencies = this.getEditedDependencySet(workspaceState);
-        return new Set<string>([
-            ...localDependencies,
-            ...remoteDependencies,
-            ...editedDependencies,
-        ]);
-    }
-
-    private getRemoteDependencySet(folderContext: FolderContext | undefined): Set<string> {
-        return new Set<string>(folderContext?.swiftPackage.resolved?.pins.map(pin => pin.identity));
-    }
-
-    private getEditedDependencySet(workspaceState: WorkspaceState): Set<string> {
-        return new Set<string>(
-            workspaceState.object.dependencies
-                .filter(dependency => this.dependencyType(dependency) === "editing")
-                .map(dependency => dependency.packageRef.identity)
-        );
-    }
-
-    /**
-     * @param workspaceState the workspace state read from `Workspace-state.json`
-     * @param folderContext the folder context of the current folder
-     * @returns all local in-use dependencies
-     */
-    private async getLocalDependencySet(
-        workspaceState: WorkspaceState,
-        folderContext: FolderContext
-    ): Promise<Set<string>> {
-        const rootDependencies = folderContext.swiftPackage.dependencies ?? [];
-        const workspaceStateDependencies = workspaceState.object.dependencies ?? [];
-        const workspacePath = folderContext.folder.fsPath;
-
-        const showingDependencies: Set<string> = new Set<string>();
-        const stack: Dependency[] = rootDependencies.slice();
-
-        while (stack.length > 0) {
-            const top = stack.pop();
-            if (!top) {
-                continue;
-            }
-
-            if (showingDependencies.has(top.identity)) {
-                continue;
-            }
-
-            if (top.type !== "local" && top.type !== "fileSystem") {
-                continue;
-            }
-
-            showingDependencies.add(top.identity);
-            const workspaceStateDependency = workspaceStateDependencies.find(
-                workspaceStateDependency =>
-                    workspaceStateDependency.packageRef.identity === top.identity
-            );
-            if (!workspaceStateDependency) {
-                continue;
-            }
-
-            const packagePath = this.dependencyPackagePath(workspaceStateDependency, workspacePath);
-            const childDependencyContents = (await SwiftPackage.loadPackage(
-                vscode.Uri.file(packagePath),
-                folderContext.workspaceContext.toolchain
-            )) as PackageContents;
-
-            stack.push(...childDependencyContents.dependencies);
-        }
-        return showingDependencies;
-    }
-
-    /**
-     * Returns a {@link FileNode} for every file or subdirectory
-     * in the given directory.
-     */
-    private async getNodesInDirectory(directoryPath: string): Promise<FileNode[]> {
-        const contents = await fs.readdir(directoryPath);
-        const results: FileNode[] = [];
-        const excludes = configuration.excludePathsFromPackageDependencies;
-        for (const fileName of contents) {
-            if (excludes.includes(fileName)) {
-                continue;
-            }
-            const filePath = path.join(directoryPath, fileName);
-            const stats = await fs.stat(filePath);
-            results.push(new FileNode(fileName, filePath, stats.isDirectory()));
-        }
-        return results.sort((first, second) => {
-            if (first.isDirectory === second.isDirectory) {
-                // If both nodes are of the same type, sort them by name.
-                return first.name.localeCompare(second.name);
-            } else {
-                // Otherwise, sort directories first.
-                return first.isDirectory ? -1 : 1;
-            }
-        });
-    }
-
-    /// - Dependency display helpers
-
-    /**
-     * Get type of WorkspaceStateDependency for displaying in the tree: real version | edited | local
-     * @param dependency
-     * @return "local" | "remote" | "editing"
-     */
-    private dependencyType(dependency: WorkspaceStateDependency): "local" | "remote" | "editing" {
-        if (dependency.state.name === "edited") {
-            return "editing";
-        } else if (
-            dependency.packageRef.kind === "local" ||
-            dependency.packageRef.kind === "fileSystem"
-        ) {
-            // need to check for both "local" and "fileSystem" as swift 5.5 and earlier
-            // use "local" while 5.6 and later use "fileSystem"
-            return "local";
+            return folderContext.swiftPackage
+                .rootDependencies()
+                .map(
+                    dependency =>
+                        new PackageNode(
+                            dependency,
+                            folderContext.swiftPackage.childDependencies.bind(
+                                folderContext.swiftPackage
+                            )
+                        )
+                );
         } else {
-            return "remote";
-        }
-    }
-
-    /**
-     * Get version of WorkspaceStateDependency for displaying in the tree
-     * @param dependency
-     * @return real version | editing | local
-     */
-    private dependencyDisplayVersion(dependency: WorkspaceStateDependency): string {
-        const type = this.dependencyType(dependency);
-        if (type === "editing") {
-            return "editing";
-        } else if (type === "local") {
-            return "local";
-        } else {
-            return (
-                dependency.state.checkoutState?.version ??
-                dependency.state.checkoutState?.branch ??
-                dependency.state.checkoutState?.revision.substring(0, 7) ??
-                dependency.state.version ??
-                "unknown"
-            );
-        }
-    }
-
-    /**
-     *  * Get package source path of dependency
-     * `editing`: dependency.state.path ?? workspacePath + Packages/ + dependency.subpath
-     * `local`: dependency.packageRef.location
-     * `remote`: buildDirectory + checkouts + dependency.packageRef.location
-     * @param dependency
-     * @param workspaceFolder
-     * @return the package path based on the type
-     */
-    private dependencyPackagePath(
-        dependency: WorkspaceStateDependency,
-        workspaceFolder: string
-    ): string {
-        const type = this.dependencyType(dependency);
-        if (type === "editing") {
-            return (
-                dependency.state.path ?? path.join(workspaceFolder, "Packages", dependency.subpath)
-            );
-        } else if (type === "local") {
-            return dependency.state.path ?? dependency.packageRef.location;
-        } else {
-            // remote
-            const buildDirectory = BuildFlags.buildDirectoryFromWorkspacePath(
-                workspaceFolder,
-                true
-            );
-            if (dependency.packageRef.kind === "registry") {
-                return path.join(buildDirectory, "registry", "downloads", dependency.subpath);
-            } else {
-                return path.join(buildDirectory, "checkouts", dependency.subpath);
-            }
+            return await element.getChildren();
         }
     }
 }

--- a/test/integration-tests/SwiftPackage.test.ts
+++ b/test/integration-tests/SwiftPackage.test.ts
@@ -69,6 +69,6 @@ suite("SwiftPackage Test Suite", () => {
         assert.strictEqual(spmPackage.dependencies.length, 1);
         assert(spmPackage.resolved !== undefined);
         assert.strictEqual(spmPackage.resolved.pins.length, 1);
-        assert.strictEqual(spmPackage.resolved.pins[0].identity, "swift-cmark");
+        assert.strictEqual(spmPackage.resolved.pins[0].identity, "swift-log");
     }).timeout(10000);
 });

--- a/test/integration-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/integration-tests/ui/PackageDependencyProvider.test.ts
@@ -23,6 +23,7 @@ import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilit
 import { getBuildAllTask, SwiftTask } from "../../../src/tasks/SwiftTaskProvider";
 import { testAssetPath } from "../../fixtures";
 import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
+import contextKeys from "../../../src/contextKeys";
 
 suite("PackageDependencyProvider Test Suite", function () {
     let treeProvider: PackageDependenciesProvider;
@@ -39,12 +40,14 @@ suite("PackageDependencyProvider Test Suite", function () {
             await workspaceContext.focusFolder(folderContext);
         },
         async teardown() {
+            contextKeys.flatDependenciesList = false;
             treeProvider.dispose();
         },
         testAssets: ["dependencies"],
     });
 
     test("Includes remote dependency", async () => {
+        contextKeys.flatDependenciesList = false;
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "swift-markdown") as PackageNode;
@@ -69,6 +72,7 @@ suite("PackageDependencyProvider Test Suite", function () {
     });
 
     test("Lists local dependency file structure", async () => {
+        contextKeys.flatDependenciesList = false;
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "defaultpackage") as PackageNode;
@@ -103,6 +107,7 @@ suite("PackageDependencyProvider Test Suite", function () {
     });
 
     test("Lists remote dependency file structure", async () => {
+        contextKeys.flatDependenciesList = false;
         const items = await treeProvider.getChildren();
 
         const dep = items.find(n => n.name === "swift-markdown") as PackageNode;
@@ -126,6 +131,23 @@ suite("PackageDependencyProvider Test Suite", function () {
         expect(file).to.not.be.undefined;
 
         assertPathsEqual(file?.path, path.join(depPath, "Sources/CAtomic/CAtomic.c"));
+    });
+
+    test("Shows a flat dependency list", async () => {
+        contextKeys.flatDependenciesList = true;
+        const items = await treeProvider.getChildren();
+        expect(items.length).to.equal(3);
+        expect(items.find(n => n.name === "swift-markdown")).to.not.be.undefined;
+        expect(items.find(n => n.name === "swift-cmark")).to.not.be.undefined;
+        expect(items.find(n => n.name === "defaultpackage")).to.not.be.undefined;
+    });
+
+    test("Shows a nested dependency list", async () => {
+        contextKeys.flatDependenciesList = false;
+        const items = await treeProvider.getChildren();
+        expect(items.length).to.equal(2);
+        expect(items.find(n => n.name === "swift-markdown")).to.not.be.undefined;
+        expect(items.find(n => n.name === "defaultpackage")).to.not.be.undefined;
     });
 
     function assertPathsEqual(path1: string | undefined, path2: string | undefined) {

--- a/test/unit-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/unit-tests/ui/PackageDependencyProvider.test.ts
@@ -56,7 +56,7 @@ suite("PackageDependencyProvider Unit Test Suite", function () {
                     version: "1.2.3",
                     type: "remote",
                 },
-                () => Promise.resolve([])
+                () => []
             );
             const item = node.toTreeItem();
 
@@ -80,17 +80,16 @@ suite("PackageDependencyProvider Unit Test Suite", function () {
                     version: "1.2.3",
                     type: "remote",
                 },
-                () =>
-                    Promise.resolve([
-                        {
-                            identity: "SomeChildDependency",
-                            path: "/path/to/.build/child-dependency",
-                            location: "https://github.com/swiftlang/some-child-dependency.git",
-                            dependencies: [],
-                            version: "1.2.4",
-                            type: "remote",
-                        },
-                    ])
+                () => [
+                    {
+                        identity: "SomeChildDependency",
+                        path: "/path/to/.build/child-dependency",
+                        location: "https://github.com/swiftlang/some-child-dependency.git",
+                        dependencies: [],
+                        version: "1.2.4",
+                        type: "remote",
+                    },
+                ]
             );
 
             const children = await node.getChildren();

--- a/test/unit-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/unit-tests/ui/PackageDependencyProvider.test.ts
@@ -67,7 +67,7 @@ suite("PackageDependencyProvider Unit Test Suite", function () {
 
         const fsMock = mockGlobalModule(fs);
 
-        test("enumeates child dependencies and files", async () => {
+        test("enumerates child dependencies and files", async () => {
             fsMock.readdir.resolves(["file1", "file2"] as any);
             fsMock.stat.resolves({ isFile: () => true, isDirectory: () => false } as any);
 

--- a/test/unit-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/unit-tests/ui/PackageDependencyProvider.test.ts
@@ -14,7 +14,9 @@
 
 import { expect } from "chai";
 import * as vscode from "vscode";
+import * as fs from "fs/promises";
 import { FileNode, PackageNode } from "../../../src/ui/PackageDependencyProvider";
+import { mockGlobalModule } from "../../MockUtils";
 
 suite("PackageDependencyProvider Unit Test Suite", function () {
     suite("FileNode", () => {
@@ -46,17 +48,70 @@ suite("PackageDependencyProvider Unit Test Suite", function () {
     suite("PackageNode", () => {
         test("can create a VSCode TreeItem that represents a Swift package", () => {
             const node = new PackageNode(
-                "SwiftMarkdown",
-                "/path/to/.build/swift-markdown",
-                "https://github.com/swiftlang/swift-markdown.git",
-                "1.2.3",
-                "remote"
+                {
+                    identity: "SwiftMarkdown",
+                    path: "/path/to/.build/swift-markdown",
+                    location: "https://github.com/swiftlang/swift-markdown.git",
+                    dependencies: [],
+                    version: "1.2.3",
+                    type: "remote",
+                },
+                () => Promise.resolve([])
             );
             const item = node.toTreeItem();
 
             expect(item.label).to.equal("SwiftMarkdown");
             expect(item.description).to.deep.equal("1.2.3");
             expect(item.command).to.be.undefined;
+        });
+
+        const fsMock = mockGlobalModule(fs);
+
+        test("enumeates child dependencies and files", async () => {
+            fsMock.readdir.resolves(["file1", "file2"] as any);
+            fsMock.stat.resolves({ isFile: () => true, isDirectory: () => false } as any);
+
+            const node = new PackageNode(
+                {
+                    identity: "SwiftMarkdown",
+                    path: "/path/to/.build/swift-markdown",
+                    location: "https://github.com/swiftlang/swift-markdown.git",
+                    dependencies: [],
+                    version: "1.2.3",
+                    type: "remote",
+                },
+                () =>
+                    Promise.resolve([
+                        {
+                            identity: "SomeChildDependency",
+                            path: "/path/to/.build/child-dependency",
+                            location: "https://github.com/swiftlang/some-child-dependency.git",
+                            dependencies: [],
+                            version: "1.2.4",
+                            type: "remote",
+                        },
+                    ])
+            );
+
+            const children = await node.getChildren();
+
+            expect(children).to.have.lengthOf(3);
+            const [childDep, ...childFiles] = children;
+            expect(childDep.name).to.equal("SomeChildDependency");
+            expect(childFiles).to.deep.equal([
+                new FileNode(
+                    "file1",
+                    "/path/to/.build/swift-markdown/file1",
+                    false,
+                    "SwiftMarkdown-1.2.3"
+                ),
+                new FileNode(
+                    "file2",
+                    "/path/to/.build/swift-markdown/file2",
+                    false,
+                    "SwiftMarkdown-1.2.3"
+                ),
+            ]);
         });
     });
 });


### PR DESCRIPTION
Currently the Package Dependencies view lists all dependencies in a flat list. This list not only includes those explicitly defined in the project's Package.swift, but also all the dependencies of dependencies.

As such its difficult to tell at a glance how a dependency is included. It can also be confusing to see dependencies in the list that you did not explicitly add.

Instead, show a top level list that is only the dependencies explicitly defined in Package.swift. Expanding one shows any child dependencies of the dependency. The files in the dependency's folder are still shown as well, just after any child deps.