### PR TITLE
Rename extension ID from `swiftlang.vscode-swift` to `swiftlang.swift`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 2.0.0 - 2025-01-28
 
-The Swift extension for VS Code has moved to the [official swiftlang organization in the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=swiftlang.vscode-swift)!
-The new extension id is `swiftlang.vscode-swift`.
+The Swift extension for VS Code has moved to the [official swiftlang organization in the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift)!
+The new extension id is `swiftlang.swift`.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,10 @@ If you haven't already, follow the instructions in [Development](#development) t
 npm run dev-package
 ```
 
-This builds a file that looks like `vscode-swift-[version]-dev.vsix`. Now install the extension with:
+This builds a file that looks like `swift-[version]-dev.vsix`. Now install the extension with:
 
 ```sh
-code --install-extension vscode-swift-[version]-dev.vsix
+code --install-extension swift-[version]-dev.vsix
 ```
 
 Alternatively you can install the extension from the Extensions panel by clicking the `...` button at the top of the panel and choosing `Install from VSIX...`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To give clarity of what is expected of our members, Swift has adopted the code o
 
 ## Installation
 
-For the extension to work, you must have Swift installed on your system. Please see the [Getting Started Guide on Swift.org](https://www.swift.org/getting-started/) for details on how to install Swift on your system. Install the extension from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=swiftlang.vscode-swift) and open a Swift package! You'll be prompted to install and configure the CodeLLDB extension, which you should do so.
+For the extension to work, you must have Swift installed on your system. Please see the [Getting Started Guide on Swift.org](https://www.swift.org/getting-started/) for details on how to install Swift on your system. Install the extension from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=swiftlang.swift) and open a Swift package! You'll be prompted to install and configure the CodeLLDB extension, which you should do so.
 
 ## Features
 

--- a/docs/remote-dev.md
+++ b/docs/remote-dev.md
@@ -21,7 +21,7 @@ First create the directory. Next, create `devcontainer.json` and insert the foll
     "name": "Swift 5.5",
     "image": "swift:5.5",
     "extensions": [
-      "swiftlang.vscode-swift"
+      "swiftlang.swift"
     ],
     "settings": {
       "lldb.library": "/usr/lib/liblldb.so"
@@ -73,7 +73,7 @@ Your `devcontainer.json` should look something like this
     "service": "app",
     "workspaceFolder": "/workspace",
     "extensions": [
-      "swiftlang.vscode-swift",
+      "swiftlang.swift",
     ],
     "settings": {
       "lldb.library": "/usr/lib/liblldb.so"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "version": "1.11.4",
-  "name": "vscode-swift",
+  "name": "swift",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "version": "1.11.4",
       "hasInstallScript": true,
-      "name": "vscode-swift",
+      "name": "swift",
       "dependencies": {
         "@vscode/codicons": "^0.0.36",
         "lcov-parse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-swift",
+  "name": "swift",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
   "version": "2.0.0",

--- a/test/integration-tests/ExtensionActivation.test.ts
+++ b/test/integration-tests/ExtensionActivation.test.ts
@@ -33,7 +33,7 @@ suite("Extension Activation/Deactivation Tests", () => {
 
         async function activate(currentTest?: Mocha.Test) {
             assert.ok(await activateExtension(currentTest), "Extension did not return its API");
-            const ext = vscode.extensions.getExtension("swiftlang.vscode-swift");
+            const ext = vscode.extensions.getExtension("swiftlang.swift");
             assert.ok(ext, "Extension is not found");
             assert.strictEqual(ext.isActive, true);
         }
@@ -57,7 +57,7 @@ suite("Extension Activation/Deactivation Tests", () => {
     test("Deactivation", async function () {
         const workspaceContext = await activateExtension(this.test as Mocha.Test);
         await deactivateExtension();
-        const ext = vscode.extensions.getExtension("swiftlang.vscode-swift");
+        const ext = vscode.extensions.getExtension("swiftlang.swift");
         assert(ext);
         assert.equal(workspaceContext.subscriptions.length, 0);
     });

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -129,7 +129,7 @@ const extensionBootstrapper = (() => {
                     `Extension is already activated. Last test that activated the extension: ${lastTestName}`
                 );
             }
-            const extensionId = "swiftlang.vscode-swift";
+            const extensionId = "swiftlang.swift";
             const ext = vscode.extensions.getExtension<Api>(extensionId);
             if (!ext) {
                 throw new Error(`Unable to find extension "${extensionId}"`);
@@ -138,7 +138,7 @@ const extensionBootstrapper = (() => {
             let workspaceContext: WorkspaceContext | undefined;
 
             // We can only _really_ call activate through
-            // `vscode.extensions.getExtension<Api>("swiftlang.vscode-swift")` once.
+            // `vscode.extensions.getExtension<Api>("swiftlang.swift")` once.
             // Subsequent activations must be done through the returned API object.
             if (!activator) {
                 activatedAPI = await ext.activate();


### PR DESCRIPTION
Because there is already another extension with `vscode-swift` as its name, and the VS Code Marketplace _name_ must be unique (not just the full ID), switch to the extension ID `swiftlang.swift`.