### PR TITLE
Migrate from nightly-6.0 to nightly-6.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM swiftlang/swift:nightly-6.0-jammy
+FROM swiftlang/swift:nightly-6.1-jammy
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,7 +56,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "nightly-6.0"}, {"swift_version": "nightly-main"}]'
+      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-main"}]'
       linux_env_vars: |
         NODE_VERSION=v18.19.0
         NODE_PATH=/usr/local/nvm/versions/node/v18.19.0/bin

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly-main"}]'
+      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-main"}]'
       linux_env_vars: |
         NODE_VERSION=v18.19.0
         NODE_PATH=/usr/local/nvm/versions/node/v18.19.0/bin


### PR DESCRIPTION
swiftlang/github-workflows migrated linux builds from nightly-6.0 to the nightly-6.1. Need https://github.com/swiftlang/github-workflows/pull/90 to land before we can migrate windows