### PR TITLE
Use one launch configuration type for all debug adapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -638,9 +638,25 @@
       {
         "title": "Debugger",
         "properties": {
+          "swift.debugger.debugAdapter": {
+            "type": "string",
+            "default": "auto",
+            "enum": [
+              "auto",
+              "lldb-dap",
+              "CodeLLDB"
+            ],
+            "enumDescriptions": [
+              "Automatically select which debug adapter to use based on your Swift toolchain version.",
+              "Use the LLDB debug adapter extension. Requires Swift 6 or later.",
+              "Use the CodeLLDB extension's debug adapter."
+            ],
+            "order": 1
+          },
           "swift.debugger.useDebugAdapterFromToolchain": {
             "type": "boolean",
             "default": false,
+            "markdownDeprecationMessage": "**Deprecated**: Use the `swift.debugger.debugAdapter` setting instead. This will be removed in future versions of the Swift extension.",
             "markdownDescription": "Use the LLDB debug adapter packaged with the Swift toolchain as your debug adapter. Note: this is only available starting with Swift 6. The CodeLLDB extension will be used if your Swift toolchain does not contain lldb-dap.",
             "order": 1
           },
@@ -1158,8 +1174,8 @@
     ],
     "debuggers": [
       {
-        "type": "swift-lldb",
-        "label": "Swift LLDB Debugger",
+        "type": "swift",
+        "label": "Swift Debugger",
         "configurationAttributes": {
           "launch": {
             "required": [

--- a/package.json
+++ b/package.json
@@ -648,7 +648,7 @@
             ],
             "enumDescriptions": [
               "Automatically select which debug adapter to use based on your Swift toolchain version.",
-              "Use the LLDB debug adapter extension. Requires Swift 6 or later.",
+              "Use the `lldb-dap` executable from the toolchain. Requires Swift 6 or later.",
               "Use the CodeLLDB extension's debug adapter."
             ],
             "order": 1

--- a/src/commands/attachDebugger.ts
+++ b/src/commands/attachDebugger.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { getLldbProcess } from "../debugger/lldb";
-import { LaunchConfigType } from "../debugger/debugAdapter";
+import { SWIFT_LAUNCH_CONFIG_TYPE } from "../debugger/debugAdapter";
 
 /**
  * Attaches the LLDB debugger to a running process selected by the user.
@@ -37,7 +37,7 @@ export async function attachDebugger(ctx: WorkspaceContext) {
         });
         if (picked) {
             const debugConfig: vscode.DebugConfiguration = {
-                type: LaunchConfigType.SWIFT_EXTENSION,
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
                 request: "attach",
                 name: "Attach",
                 pid: picked.pid,

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -20,7 +20,7 @@ import configuration from "../configuration";
 import { FolderContext } from "../FolderContext";
 import { BuildFlags } from "../toolchain/BuildFlags";
 import { regexEscapedString, swiftRuntimeEnv } from "../utilities/utilities";
-import { DebugAdapter } from "./debugAdapter";
+import { SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 import { TargetType } from "../SwiftPackage";
 import { Version } from "../utilities/version";
 import { TestLibrary } from "../TestExplorer/TestRunner";
@@ -515,7 +515,7 @@ export class TestingConfigurationFactory {
         }).map(([key, value]) => `settings set target.env-vars ${key}="${value}"`);
 
         return {
-            type: DebugAdapter.getLaunchConfigType(this.ctx.workspaceContext.swiftVersion),
+            type: SWIFT_LAUNCH_CONFIG_TYPE,
             request: "custom",
             name: `Test ${this.ctx.swiftPackage.name}`,
             targetCreateCommands: [`file -a ${arch} ${xctestPath}/xctest`],
@@ -738,7 +738,7 @@ export class TestingConfigurationFactory {
 function getBaseConfig(ctx: FolderContext, expandEnvVariables: boolean) {
     const { folder, nameSuffix } = getFolderAndNameSuffix(ctx, expandEnvVariables);
     return {
-        type: DebugAdapter.getLaunchConfigType(ctx.workspaceContext.swiftVersion),
+        type: SWIFT_LAUNCH_CONFIG_TYPE,
         request: "launch",
         sourceLanguages: ["swift"],
         name: `Test ${ctx.swiftPackage.name}`,

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -17,7 +17,7 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { BuildFlags } from "../toolchain/BuildFlags";
 import { stringArrayInEnglish, swiftLibraryPathKey, swiftRuntimeEnv } from "../utilities/utilities";
-import { DebugAdapter } from "./debugAdapter";
+import { SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 import { getFolderAndNameSuffix } from "./buildConfig";
 import configuration from "../configuration";
 import { CI_DISABLE_ASLR } from "./lldb";
@@ -136,7 +136,7 @@ function createExecutableConfigurations(ctx: FolderContext): vscode.DebugConfigu
 
     return executableProducts.flatMap(product => {
         const baseConfig = {
-            type: DebugAdapter.getLaunchConfigType(ctx.workspaceContext.swiftVersion),
+            type: SWIFT_LAUNCH_CONFIG_TYPE,
             request: "launch",
             args: [],
             cwd: folder,
@@ -174,7 +174,7 @@ export function createSnippetConfiguration(
     const buildDirectory = BuildFlags.buildDirectoryFromWorkspacePath(folder, true);
 
     return {
-        type: DebugAdapter.getLaunchConfigType(ctx.workspaceContext.swiftVersion),
+        type: SWIFT_LAUNCH_CONFIG_TYPE,
         request: "launch",
         name: `Run ${snippetName}`,
         program: path.posix.join(buildDirectory, "debug", snippetName),

--- a/test/unit-tests/debugger/attachDebugger.test.ts
+++ b/test/unit-tests/debugger/attachDebugger.test.ts
@@ -27,6 +27,7 @@ import { SwiftToolchain } from "../../../src/toolchain/toolchain";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { registerDebugger } from "../../../src/debugger/debugAdapterFactory";
 import { Version } from "../../../src/utilities/version";
+import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 
 suite("attachDebugger Unit Test Suite", () => {
     const lldbMock = mockGlobalModule(lldb);
@@ -42,6 +43,7 @@ suite("attachDebugger Unit Test Suite", () => {
         });
         mockContext = mockObject<WorkspaceContext>({
             toolchain: instance(mockToolchain),
+            outputChannel: instance(mockObject<SwiftOutputChannel>({})),
         });
     });
 


### PR DESCRIPTION
This PR changes the behaviour of the generated launch configurations to always use a type of `"swift"` instead of switching between `"swift-lldb"` and `"lldb"` based on user settings. This new launch configuration type will then delegate to the appropriate debug adapter depending on settings. That way the extension no longer has to check for debug configuration updates all the time.

I've deprecated the `swift.debugger.useDebuggerFromToolchain` setting in favour of using a new `swift.debugger.debugAdapter` setting that is an enumeration of `"auto"`, `"CodeLLDB"`, and `"lldb-dap"`. Auto mode will continue to use CodeLLDB by default until we can properly move to the LLDB DAP extension provided by LLVM. Setting this to `"lldb-dap"` will continue to use the extension provided debug adapter executable factory for the same reason.