### PR TITLE
Make CommandLineTools toolchain selectable if installed

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -363,8 +363,8 @@ export class SwiftToolchain {
             return [];
         }
 
-        const coolchainSwiftPath = path.join(commandLineToolsPath, "usr", "bin", "swift");
-        if (!(await pathExists(coolchainSwiftPath))) {
+        const toolchainSwiftPath = path.join(commandLineToolsPath, "usr", "bin", "swift");
+        if (!(await pathExists(toolchainSwiftPath))) {
             return [];
         }
         return [commandLineToolsPath];


### PR DESCRIPTION
If the CLT are installed add it to the list of available toolchains.

Also, if there are no Xcodes installed, omit the top level item from the list of quick pick options since it would render as an empty row.