### PR TITLE
Don't append .exe to binaries ending in .xctest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1216,6 +1216,10 @@
                 "description": "Don't retrieve STDIN, STDOUT and STDERR as the program is running.",
                 "default": false
               },
+              "testType": {
+                "type": "string",
+                "description": "If the program is a test, set this to the type of test (`XCTest` or `swift-testing`). This is typically set automatically and is only required when your launch program uses a non standard filename."
+              },
               "shellExpandArguments": {
                 "type": "boolean",
                 "description": "Expand program arguments as a shell would without actually launching the program in a shell.",

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -152,7 +152,8 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
         if (
             this.platform === "win32" &&
             launchConfig.testType === undefined &&
-            path.extname(launchConfig.program) !== ".exe"
+            path.extname(launchConfig.program) === "" &&
+            path.extname(launchConfig.program) !== ".xctest"
         ) {
             launchConfig.program += ".exe";
         }

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -152,7 +152,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
         if (
             this.platform === "win32" &&
             launchConfig.testType === undefined &&
-            path.extname(launchConfig.program) === "" &&
+            path.extname(launchConfig.program) !== ".exe" &&
             path.extname(launchConfig.program) !== ".xctest"
         ) {
             launchConfig.program += ".exe";


### PR DESCRIPTION
Certain non standard workflows (CMake) could produce binaries that end in .xctest. Only append .exe if it doesn't already have a valid extension.

Also declare `testType` in the debug configuration schema allowing users to declare what type of test framework they're using in the launch config if they're using a non standard flow.

Issue: #1364