### PR TITLE
add editor run actions for Swift executables

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,13 +136,15 @@
       },
       {
         "command": "swift.run",
-        "title": "Run Build",
-        "category": "Swift"
+        "title": "Run active Swift file",
+        "category": "Swift",
+        "icon": "$(play)"
       },
       {
         "command": "swift.debug",
-        "title": "Debug Build",
-        "category": "Swift"
+        "title": "Debug active Swift file",
+        "category": "Swift",
+        "icon": "$(debug)"
       },
       {
         "command": "swift.resetPackage",
@@ -860,6 +862,18 @@
           "command": "swift.previewDocumentation",
           "when": "swift.supportsDocumentationLivePreview && (editorLangId == markdown || editorLangId == tutorial || editorLangId == swift)",
           "group": "navigation"
+        }
+      ],
+      "editor/title/run": [
+        {
+          "command": "swift.run",
+          "group": "navigation@0",
+          "when": "resourceLangId == swift && !isInDiffEditor && !virtualWorkspace && swift.currentTargetType == 'executable'"
+        },
+        {
+          "command": "swift.debug",
+          "group": "navigation@0",
+          "when": "resourceLangId == swift && !isInDiffEditor && !virtualWorkspace && swift.currentTargetType == 'executable'"
         }
       ],
       "swift.editor": [

--- a/package.json
+++ b/package.json
@@ -136,13 +136,13 @@
       },
       {
         "command": "swift.run",
-        "title": "Run active Swift file",
+        "title": "Run Swift executable",
         "category": "Swift",
         "icon": "$(play)"
       },
       {
         "command": "swift.debug",
-        "title": "Debug active Swift file",
+        "title": "Debug Swift executable",
         "category": "Swift",
         "icon": "$(debug)"
       },
@@ -868,12 +868,12 @@
         {
           "command": "swift.run",
           "group": "navigation@0",
-          "when": "resourceLangId == swift && !isInDiffEditor && !virtualWorkspace && swift.currentTargetType == 'executable'"
+          "when": "resourceLangId == swift && swift.currentTargetType == 'executable'"
         },
         {
           "command": "swift.debug",
           "group": "navigation@0",
-          "when": "resourceLangId == swift && !isInDiffEditor && !virtualWorkspace && swift.currentTargetType == 'executable'"
+          "when": "resourceLangId == swift && swift.currentTargetType == 'executable'"
         }
       ],
       "swift.editor": [


### PR DESCRIPTION
This PR adds two new actions in the editor for running and debugging the active Swift file. These actions use existing commands and are only shown when the active Swift file belongs to an executable target.