### PR TITLE
Prompt for CodeLLDB settings only when launching a debug session

### DIFF
--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -33,8 +33,8 @@ export const CI_DISABLE_ASLR =
         : {};
 
 /**
- * Get LLDB library for given LLDB executable
- * @param executable LLDB executable
+ * Get the path to the LLDB library.
+ *
  * @returns Library path for LLDB
  */
 export async function getLLDBLibPath(toolchain: SwiftToolchain): Promise<Result<string>> {

--- a/test/unit-tests/debugger/debugAdapter.test.ts
+++ b/test/unit-tests/debugger/debugAdapter.test.ts
@@ -12,32 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as vscode from "vscode";
 import { expect } from "chai";
 import * as mockFS from "mock-fs";
-import {
-    mockGlobalObject,
-    MockedObject,
-    mockObject,
-    instance,
-    mockGlobalModule,
-    mockFn,
-} from "../../MockUtils";
+import { MockedObject, mockObject, instance, mockGlobalModule } from "../../MockUtils";
 import configuration from "../../../src/configuration";
 import { DebugAdapter, LaunchConfigType } from "../../../src/debugger/debugAdapter";
-import { SwiftToolchain } from "../../../src/toolchain/toolchain";
-import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 import { Version } from "../../../src/utilities/version";
-import contextKeys from "../../../src/contextKeys";
 
 suite("DebugAdapter Unit Test Suite", () => {
     const mockConfiguration = mockGlobalModule(configuration);
-    const mockedContextKeys = mockGlobalModule(contextKeys);
-    const mockedWindow = mockGlobalObject(vscode, "window");
 
     let mockDebugConfig: MockedObject<(typeof configuration)["debugger"]>;
-    let mockToolchain: MockedObject<SwiftToolchain>;
-    let mockOutputChannel: MockedObject<SwiftOutputChannel>;
 
     setup(() => {
         // Mock VS Code settings
@@ -48,16 +33,6 @@ suite("DebugAdapter Unit Test Suite", () => {
         mockConfiguration.debugger = instance(mockDebugConfig);
         // Mock the file system
         mockFS({});
-        // Mock the WorkspaceContext and related dependencies
-        const toolchainPath = "/toolchains/swift";
-        mockToolchain = mockObject<SwiftToolchain>({
-            swiftVersion: new Version(6, 0, 0),
-            getLLDBDebugAdapter: mockFn(s => s.callsFake(() => toolchainPath + "/lldb-dap")),
-            getLLDB: mockFn(s => s.callsFake(() => toolchainPath + "/lldb")),
-        });
-        mockOutputChannel = mockObject<SwiftOutputChannel>({
-            log: mockFn(),
-        });
     });
 
     teardown(() => {
@@ -102,212 +77,5 @@ suite("DebugAdapter Unit Test Suite", () => {
                 LaunchConfigType.CODE_LLDB
             );
         });
-    });
-
-    suite("verifyDebugAdapterExists()", () => {
-        suite("Using lldb-dap", () => {
-            setup(() => {
-                mockToolchain.swiftVersion = new Version(6, 0, 0);
-                mockDebugConfig.debugAdapter = "lldb-dap";
-                // Should be using lldb-dap in this case
-                mockFS({
-                    "/toolchains/swift/lldb-dap": mockFS.file({ content: "", mode: 0o770 }),
-                });
-            });
-
-            createCommonTests();
-
-            test("returns false when the toolchain throws an error trying to find lldb-dap", async () => {
-                mockToolchain.getLLDBDebugAdapter.rejects(new Error("Uh oh!"));
-
-                await expect(
-                    DebugAdapter.verifyDebugAdapterExists(
-                        instance(mockToolchain),
-                        instance(mockOutputChannel),
-                        false
-                    )
-                ).to.eventually.be.false;
-            });
-
-            test("shows an error message to the user when the toolchain throws an error trying to find lldb-dap", async () => {
-                mockToolchain.getLLDBDebugAdapter.rejects(new Error("Uh oh!"));
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    false
-                );
-                expect(mockedWindow.showErrorMessage).to.have.been.calledOnce;
-            });
-
-            test("disables the swift.lldbVSCodeAvailable context key if the toolchain throws an error trying to find lldb-dap", async () => {
-                mockToolchain.getLLDBDebugAdapter.rejects(new Error("Uh oh!"));
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    false
-                );
-                expect(mockedContextKeys.lldbVSCodeAvailable).to.be.false;
-            });
-        });
-
-        suite("Using lldb-dap with custom debug adapter path", () => {
-            setup(() => {
-                mockToolchain.swiftVersion = new Version(6, 0, 0);
-                mockDebugConfig.debugAdapter = "lldb-dap";
-                mockDebugConfig.customDebugAdapterPath = "/path/to/custom/lldb-dap";
-                // Should be using a custom lldb-dap in this case
-                mockFS({
-                    "/path/to/custom/lldb-dap": mockFS.file({ content: "", mode: 0o770 }),
-                });
-            });
-
-            createCommonTests();
-        });
-
-        suite("Using CodeLLDB", () => {
-            setup(() => {
-                mockToolchain.swiftVersion = new Version(6, 0, 0);
-                mockDebugConfig.debugAdapter = "CodeLLDB";
-                // Should be using CodeLLDB in this case
-                mockFS({
-                    "/toolchains/swift/lldb": mockFS.file({ content: "", mode: 0o770 }),
-                });
-            });
-
-            createCommonTests();
-
-            test("returns false when the toolchain throws an error trying to find lldb", async () => {
-                mockToolchain.getLLDB.rejects(new Error("Uh oh!"));
-
-                await expect(
-                    DebugAdapter.verifyDebugAdapterExists(
-                        instance(mockToolchain),
-                        instance(mockOutputChannel),
-                        false
-                    )
-                ).to.eventually.be.false;
-            });
-
-            test("shows an error message to the user when the toolchain throws an error trying to find lldb", async () => {
-                mockToolchain.getLLDB.rejects(new Error("Uh oh!"));
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    false
-                );
-                expect(mockedWindow.showErrorMessage).to.have.been.calledOnce;
-            });
-
-            test("disables the swift.lldbVSCodeAvailable context key if the toolchain throws an error trying to find lldb", async () => {
-                mockToolchain.getLLDB.rejects(new Error("Uh oh!"));
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    false
-                );
-                expect(mockedContextKeys.lldbVSCodeAvailable).to.be.false;
-            });
-        });
-
-        function createCommonTests() {
-            test("returns true when debug adapter exists regardless of quiet setting", async () => {
-                // Test with quiet = true
-                await expect(
-                    DebugAdapter.verifyDebugAdapterExists(
-                        instance(mockToolchain),
-                        instance(mockOutputChannel),
-                        true
-                    )
-                ).to.eventually.be.true;
-
-                // Test with quiet = false
-                await expect(
-                    DebugAdapter.verifyDebugAdapterExists(
-                        instance(mockToolchain),
-                        instance(mockOutputChannel),
-                        false
-                    )
-                ).to.eventually.be.true;
-            });
-
-            test("returns false when debug adapter doesn't exist regardless of quiet setting", async () => {
-                // Reset the file system to empty
-                mockFS({});
-
-                // Test with quiet = true
-                await expect(
-                    DebugAdapter.verifyDebugAdapterExists(
-                        instance(mockToolchain),
-                        instance(mockOutputChannel),
-                        true
-                    )
-                ).to.eventually.be.false;
-
-                // Test with quiet = false
-                await expect(
-                    DebugAdapter.verifyDebugAdapterExists(
-                        instance(mockToolchain),
-                        instance(mockOutputChannel),
-                        false
-                    )
-                ).to.eventually.be.false;
-            });
-
-            test("shows an error message to the user when the debug adapter doesn't exist and quiet is false", async () => {
-                // Reset the file system to empty
-                mockFS({});
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    false
-                );
-                expect(mockedWindow.showErrorMessage).to.have.been.called;
-            });
-
-            test("doesn't show an error message to the user when the debug adapter doesn't exist and quiet is false", async () => {
-                // Reset the file system to empty
-                mockFS({});
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    true
-                );
-                expect(mockedWindow.showErrorMessage).to.not.have.been.called;
-            });
-
-            test("doesn't show an error message to the user when the debug adapter exists", async () => {
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel),
-                    true
-                );
-                expect(mockedWindow.showErrorMessage).to.not.have.been.called;
-            });
-
-            test("enables the swift.lldbVSCodeAvailable context key if the debugger exists", async () => {
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel)
-                );
-                expect(mockedContextKeys.lldbVSCodeAvailable).to.be.true;
-            });
-
-            test("disables the swift.lldbVSCodeAvailable context key if the debugger doesn't exist", async () => {
-                // Reset the file system to empty
-                mockFS({});
-
-                await DebugAdapter.verifyDebugAdapterExists(
-                    instance(mockToolchain),
-                    instance(mockOutputChannel)
-                );
-                expect(mockedContextKeys.lldbVSCodeAvailable).to.be.false;
-            });
-        }
     });
 });

--- a/test/unit-tests/debugger/debugAdapterFactory.test.ts
+++ b/test/unit-tests/debugger/debugAdapterFactory.test.ts
@@ -27,17 +27,20 @@ import {
     mockGlobalModule,
     mockFn,
 } from "../../MockUtils";
-import configuration from "../../../src/configuration";
+import * as mockFS from "mock-fs";
 import {
     DebugAdapter,
     LaunchConfigType,
     SWIFT_LAUNCH_CONFIG_TYPE,
 } from "../../../src/debugger/debugAdapter";
+import * as lldb from "../../../src/debugger/lldb";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
 import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
+import * as debugAdapter from "../../../src/debugger/debugAdapter";
+import { Result } from "../../../src/utilities/result";
 
 suite("LLDBDebugAdapterExecutableFactory Tests", () => {
-    const mockAdapter = mockGlobalModule(DebugAdapter);
+    const mockDebugAdapter = mockGlobalModule(DebugAdapter);
     let mockToolchain: MockedObject<SwiftToolchain>;
     let mockOutputChannel: MockedObject<SwiftOutputChannel>;
 
@@ -48,11 +51,10 @@ suite("LLDBDebugAdapterExecutableFactory Tests", () => {
         });
     });
 
-    test("should return DebugAdapterExecutable when path and verification succeed", async () => {
+    test("should return a DebugAdapterExecutable with the path to lldb-dap", async () => {
         const toolchainPath = "/path/to/debug/adapter";
 
-        mockAdapter.debugAdapterPath.resolves(toolchainPath);
-        mockAdapter.verifyDebugAdapterExists.resolves(true);
+        mockDebugAdapter.getLLDBDebugAdapterPath.resolves(toolchainPath);
 
         const factory = new LLDBDebugAdapterExecutableFactory(
             instance(mockToolchain),
@@ -61,223 +63,267 @@ suite("LLDBDebugAdapterExecutableFactory Tests", () => {
         const result = await factory.createDebugAdapterDescriptor();
 
         expect(result).to.be.instanceOf(vscode.DebugAdapterExecutable);
-        expect((result as vscode.DebugAdapterExecutable).command).to.equal(toolchainPath);
-
-        expect(mockAdapter.debugAdapterPath).to.have.been.calledOnce;
-        expect(mockAdapter.verifyDebugAdapterExists).to.have.been.calledOnce;
-    });
-
-    test("should throw error if debugAdapterPath fails", async () => {
-        const errorMessage = "Failed to get debug adapter path";
-
-        mockAdapter.debugAdapterPath.rejects(new Error(errorMessage));
-
-        const factory = new LLDBDebugAdapterExecutableFactory(
-            instance(mockToolchain),
-            instance(mockOutputChannel)
-        );
-
-        await expect(factory.createDebugAdapterDescriptor()).to.eventually.be.rejectedWith(
-            Error,
-            errorMessage
-        );
-
-        expect(mockAdapter.debugAdapterPath).to.have.been.calledOnce;
-        expect(mockAdapter.verifyDebugAdapterExists).to.not.have.been.called;
-    });
-
-    test("should throw error if verifyDebugAdapterExists fails", async () => {
-        const toolchainPath = "/path/to/debug/adapter";
-        const errorMessage = "Failed to verify debug adapter exists";
-
-        mockAdapter.debugAdapterPath.resolves(toolchainPath);
-        mockAdapter.verifyDebugAdapterExists.rejects(new Error(errorMessage));
-
-        const factory = new LLDBDebugAdapterExecutableFactory(
-            instance(mockToolchain),
-            instance(mockOutputChannel)
-        );
-
-        await expect(factory.createDebugAdapterDescriptor()).to.eventually.be.rejectedWith(
-            Error,
-            errorMessage
-        );
-
-        expect(mockAdapter.debugAdapterPath).to.have.been.calledOnce;
-        expect(mockAdapter.verifyDebugAdapterExists).to.have.been.calledOnce;
+        expect(result).to.have.property("command").that.equals(toolchainPath);
     });
 });
 
 suite("LLDBDebugConfigurationProvider Tests", () => {
-    let swift6Toolchain: SwiftToolchain;
-    let swift5Toolchain: SwiftToolchain;
-    const mockDebugConfig = mockGlobalObject(configuration, "debugger");
+    let mockToolchain: MockedObject<SwiftToolchain>;
+    let mockOutputChannel: MockedObject<SwiftOutputChannel>;
+    const mockDebugAdapter = mockGlobalObject(debugAdapter, "DebugAdapter");
+    const mockWindow = mockGlobalObject(vscode, "window");
 
     setup(() => {
-        mockDebugConfig.debugAdapter = "auto";
-        swift6Toolchain = instance(
-            mockObject<SwiftToolchain>({
-                swiftVersion: new Version(6, 0, 0),
-            })
-        );
-        swift5Toolchain = instance(
-            mockObject<SwiftToolchain>({
-                swiftVersion: new Version(5, 10, 0),
-            })
-        );
-    });
-
-    test("delegates to CodeLLDB when debugAdapter is set to auto", async () => {
-        mockDebugConfig.debugAdapter = "auto";
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-        expect(launchConfig).to.containSubset({ type: LaunchConfigType.CODE_LLDB });
-    });
-
-    test("delegates to lldb-dap when debugAdapter is set to lldb-dap and swift version >=6.0.0", async () => {
-        mockDebugConfig.debugAdapter = "lldb-dap";
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-        expect(launchConfig).to.containSubset({ type: LaunchConfigType.LLDB_DAP });
-    });
-
-    test("delegates to CodeLLDB even though debugAdapter is set to lldb-dap and swift version >=6.0.0", async () => {
-        mockDebugConfig.debugAdapter = "lldb-dap";
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift5Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-        expect(launchConfig).to.containSubset({
-            type: LaunchConfigType.CODE_LLDB,
-            sourceLanguages: ["swift"],
+        mockToolchain = mockObject<SwiftToolchain>({ swiftVersion: new Version(6, 0, 0) });
+        mockOutputChannel = mockObject<SwiftOutputChannel>({
+            log: mockFn(),
         });
     });
 
-    test("modifies program to add file extension on Windows", async () => {
-        const configProvider = new LLDBDebugConfigurationProvider("win32", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
+    suite("CodeLLDB selected in settings", () => {
+        let mockLldbConfiguration: MockedObject<vscode.WorkspaceConfiguration>;
+        const mockLLDB = mockGlobalModule(lldb);
+        const mockWorkspace = mockGlobalObject(vscode, "workspace");
+
+        setup(() => {
+            mockLldbConfiguration = mockObject<vscode.WorkspaceConfiguration>({
+                get: mockFn(s => {
+                    s.withArgs("library").returns("/path/to/liblldb.dyLib");
+                    s.withArgs("launch.expressions").returns("native");
+                }),
+                update: mockFn(),
+            });
+            mockWorkspace.getConfiguration.returns(instance(mockLldbConfiguration));
+            mockLLDB.getLLDBLibPath.resolves(Result.makeSuccess("/path/to/liblldb.dyLib"));
+            mockDebugAdapter.getLaunchConfigType.returns(LaunchConfigType.CODE_LLDB);
         });
-        expect(launchConfig).to.containSubset({
-            program: "${workspaceFolder}/.build/debug/executable.exe",
+
+        test("returns a launch configuration that uses CodeLLDB as the debug adapter", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+            expect(launchConfig).to.containSubset({ type: LaunchConfigType.CODE_LLDB });
+        });
+
+        test("prompts the user to update CodeLLDB settings if they aren't configured yet", async () => {
+            mockLldbConfiguration.get.withArgs("library").returns(undefined);
+            mockWindow.showInformationMessage.resolves("Global" as any);
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            await expect(
+                configProvider.resolveDebugConfiguration(undefined, {
+                    name: "Test Launch Config",
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    program: "${workspaceFolder}/.build/debug/executable",
+                })
+            ).to.eventually.be.an("object");
+            expect(mockWindow.showInformationMessage).to.have.been.calledOnce;
+            expect(mockLldbConfiguration.update).to.have.been.calledWith(
+                "library",
+                "/path/to/liblldb.dyLib"
+            );
         });
     });
 
-    test("does not modify program on Windows if file extension is already present", async () => {
-        const configProvider = new LLDBDebugConfigurationProvider("win32", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable.exe",
-        });
-        expect(launchConfig).to.containSubset({
-            program: "${workspaceFolder}/.build/debug/executable.exe",
-        });
-    });
-
-    test("does not modify program on macOS", async () => {
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-        expect(launchConfig).to.containSubset({
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-    });
-
-    test("does not modify program on Linux", async () => {
-        const configProvider = new LLDBDebugConfigurationProvider("linux", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-        expect(launchConfig).to.containSubset({
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-    });
-
-    test("should convert environment variables to string[] format when using lldb-dap", async () => {
-        mockDebugConfig.debugAdapter = "lldb-dap";
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-            env: {
-                VAR1: "value1",
-                VAR2: "value2",
-            },
-        });
-        expect(launchConfig)
-            .to.have.property("env")
-            .that.deep.equals(["VAR1=value1", "VAR2=value2"]);
-    });
-
-    test("should leave env undefined when environment variables are undefined and using lldb-dap", async () => {
-        mockDebugConfig.debugAdapter = "lldb-dap";
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            name: "Test Launch Config",
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            program: "${workspaceFolder}/.build/debug/executable",
-        });
-        expect(launchConfig).to.not.have.property("env");
-    });
-
-    test("should convert empty environment variables when using lldb-dap", async () => {
-        mockDebugConfig.debugAdapter = "lldb-dap";
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            name: "Test Launch",
-            env: {},
+    suite("lldb-dap selected in settings", () => {
+        setup(() => {
+            mockDebugAdapter.getLaunchConfigType.returns(LaunchConfigType.LLDB_DAP);
+            mockDebugAdapter.getLLDBDebugAdapterPath.resolves("/path/to/lldb-dap");
+            mockFS({
+                "/path/to/lldb-dap": mockFS.file({ content: "", mode: 0o770 }),
+            });
         });
 
-        expect(launchConfig).to.have.property("env").that.deep.equals([]);
-    });
-
-    test("should handle a large number of environment variables when using lldb-dap", async () => {
-        mockDebugConfig.debugAdapter = "lldb-dap";
-        // Create 1000 environment variables
-        const env: { [key: string]: string } = {};
-        for (let i = 0; i < 1000; i++) {
-            env[`VAR${i}`] = `value${i}`;
-        }
-        const configProvider = new LLDBDebugConfigurationProvider("darwin", swift6Toolchain);
-        const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
-            type: SWIFT_LAUNCH_CONFIG_TYPE,
-            request: "launch",
-            name: "Test Launch",
-            env,
+        teardown(() => {
+            mockFS.restore();
         });
 
-        // Verify that all 1000 environment variables are properly converted
-        const expectedEnv = Array.from({ length: 1000 }, (_, i) => `VAR${i}=value${i}`);
-        expect(launchConfig).to.have.property("env").that.deep.equals(expectedEnv);
+        test("returns a launch configuration that uses lldb-dap as the debug adapter", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+            expect(launchConfig).to.containSubset({ type: LaunchConfigType.LLDB_DAP });
+        });
+
+        test("fails if the path to lldb-dap could not be found", async () => {
+            mockFS({}); // Reset mockFS so that no files exist
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            await expect(
+                configProvider.resolveDebugConfiguration(undefined, {
+                    name: "Test Launch Config",
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    program: "${workspaceFolder}/.build/debug/executable",
+                })
+            ).to.eventually.be.undefined;
+            expect(mockWindow.showErrorMessage).to.have.been.calledOnce;
+        });
+
+        test("modifies program to add file extension on Windows", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "win32",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+            expect(launchConfig).to.containSubset({
+                program: "${workspaceFolder}/.build/debug/executable.exe",
+            });
+        });
+
+        test("does not modify program on Windows if file extension is already present", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "win32",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable.exe",
+            });
+            expect(launchConfig).to.containSubset({
+                program: "${workspaceFolder}/.build/debug/executable.exe",
+            });
+        });
+
+        test("does not modify program on macOS", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+            expect(launchConfig).to.containSubset({
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+        });
+
+        test("does not modify program on Linux", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "linux",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+            expect(launchConfig).to.containSubset({
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+        });
+
+        test("should convert environment variables to string[] format when using lldb-dap", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+                env: {
+                    VAR1: "value1",
+                    VAR2: "value2",
+                },
+            });
+            expect(launchConfig)
+                .to.have.property("env")
+                .that.deep.equals(["VAR1=value1", "VAR2=value2"]);
+        });
+
+        test("should leave env undefined when environment variables are undefined and using lldb-dap", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                name: "Test Launch Config",
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                program: "${workspaceFolder}/.build/debug/executable",
+            });
+            expect(launchConfig).to.not.have.property("env");
+        });
+
+        test("should convert empty environment variables when using lldb-dap", async () => {
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                name: "Test Launch",
+                env: {},
+            });
+
+            expect(launchConfig).to.have.property("env").that.deep.equals([]);
+        });
+
+        test("should handle a large number of environment variables when using lldb-dap", async () => {
+            // Create 1000 environment variables
+            const env: { [key: string]: string } = {};
+            for (let i = 0; i < 1000; i++) {
+                env[`VAR${i}`] = `value${i}`;
+            }
+            const configProvider = new LLDBDebugConfigurationProvider(
+                "darwin",
+                instance(mockToolchain),
+                instance(mockOutputChannel)
+            );
+            const launchConfig = await configProvider.resolveDebugConfiguration(undefined, {
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                name: "Test Launch",
+                env,
+            });
+
+            // Verify that all 1000 environment variables are properly converted
+            const expectedEnv = Array.from({ length: 1000 }, (_, i) => `VAR${i}=value${i}`);
+            expect(launchConfig).to.have.property("env").that.deep.equals(expectedEnv);
+        });
     });
 });


### PR DESCRIPTION
Show an information modal when launching via CodeLLDB and the appropriate settings haven't been applied instead of showing a warning message on startup.