### PR TITLE
Fix extra parentheses in soundness.sh

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -100,7 +100,7 @@ EOF
             \( \! -path './assets/*' -a \
             \( \! -path './coverage/*' -a \
             \( "${matching_files[@]}" \) \
-            \) \) \) \) \) \) \) \)
+            \) \) \) \) \) \) \)
     } | while read -r line; do
       if [[ "$(replace_acceptable_years < "$line" | head -n "$expected_lines" | shasum)" != "$expected_sha" ]]; then
         printf "\033[0;31mmissing headers in file '%s'!\033[0m\n" "$line"


### PR DESCRIPTION
The soundness script was failing to run with the error: `find: you have too many ')'`