### PR TITLE
Remove dependency on CodeLLDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1459,7 +1459,6 @@
     ]
   },
   "extensionDependencies": [
-    "vadimcn.vscode-lldb",
     "llvm-vs-code-extensions.lldb-dap"
   ],
   "scripts": {

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -92,8 +92,14 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
         launchConfig.type = DebugAdapter.getLaunchConfigType(this.toolchain.swiftVersion);
         if (launchConfig.type === LaunchConfigType.CODE_LLDB) {
             launchConfig.sourceLanguages = ["swift"];
-            // Prompt the user to update CodeLLDB settings if necessary
-            await this.promptForCodeLldbSettings();
+            if (!vscode.extensions.getExtension("vadimcn.vscode-lldb")) {
+                if (!(await this.promptToInstallCodeLLDB())) {
+                    return undefined;
+                }
+            }
+            if (!(await this.promptForCodeLldbSettings())) {
+                return undefined;
+            }
         } else if (launchConfig.type === LaunchConfigType.LLDB_DAP) {
             if (launchConfig.env) {
                 launchConfig.env = this.convertEnvironmentVariables(launchConfig.env);
@@ -112,7 +118,36 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
         return launchConfig;
     }
 
-    private async promptForCodeLldbSettings(): Promise<void> {
+    private async promptToInstallCodeLLDB(): Promise<boolean> {
+        const selection = await vscode.window.showErrorMessage(
+            "The CodeLLDB extension is required to debug with Swift toolchains prior to version 6. Please install the extension to continue.",
+            { modal: true },
+            "Install CodeLLDB",
+            "View Extension"
+        );
+        switch (selection) {
+            case "Install CodeLLDB":
+                await vscode.commands.executeCommand(
+                    "workbench.extensions.installExtension",
+                    "vadimcn.vscode-lldb"
+                );
+                return true;
+            case "View Extension":
+                await vscode.commands.executeCommand(
+                    "workbench.extensions.search",
+                    "@id:vadimcn.vscode-lldb"
+                );
+                await vscode.commands.executeCommand(
+                    "workbench.extensions.action.showReleasedVersion",
+                    "vadimcn.vscode-lldb"
+                );
+                return false;
+            case undefined:
+                return false;
+        }
+    }
+
+    private async promptForCodeLldbSettings(): Promise<boolean> {
         const libLldbPathResult = await getLLDBLibPath(this.toolchain);
         if (!libLldbPathResult.success) {
             const errorMessage = `Error: ${getErrorDescription(libLldbPathResult.failure)}`;
@@ -120,7 +155,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
                 `Failed to setup CodeLLDB for debugging of Swift code. Debugging may produce unexpected results. ${errorMessage}`
             );
             this.outputChannel.log(`Failed to setup CodeLLDB: ${errorMessage}`);
-            return;
+            return true;
         }
         const libLldbPath = libLldbPathResult.success;
         const lldbConfig = vscode.workspace.getConfiguration("lldb");
@@ -128,7 +163,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
             lldbConfig.get<string>("library") === libLldbPath &&
             lldbConfig.get<string>("launch.expressions") === "native"
         ) {
-            return;
+            return true;
         }
         let userSelection: "Global" | "Workspace" | "Run Anyway" | undefined = undefined;
         switch (configuration.debugger.setupCodeLLDB) {
@@ -177,7 +212,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
                 );
                 break;
         }
-        return;
+        return true;
     }
 
     private convertEnvironmentVariables(map: { [key: string]: string }): string[] {

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -120,7 +120,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
 
     private async promptToInstallCodeLLDB(): Promise<boolean> {
         const selection = await vscode.window.showErrorMessage(
-            "The CodeLLDB extension is required to debug with Swift toolchains prior to version 6. Please install the extension to continue.",
+            "The CodeLLDB extension is required to debug with Swift toolchains prior to Swift 6.0. Please install the extension to continue.",
             { modal: true },
             "Install CodeLLDB",
             "View Extension"

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -55,6 +55,13 @@ const extensionBootstrapper = (() => {
         let autoTeardown: void | (() => Promise<void>);
         let restoreSettings: (() => Promise<void>) | undefined;
         before(async function () {
+            // Make sure that CodeLLDB is installed for debugging related tests
+            if (!vscode.extensions.getExtension("vadimcn.vscode-lldb")) {
+                await vscode.commands.executeCommand(
+                    "workbench.extensions.installExtension",
+                    "vadimcn.vscode-lldb"
+                );
+            }
             // Always activate the extension. If no test assets are provided,
             // default to adding `defaultPackage` to the workspace.
             workspaceContext = await extensionBootstrapper.activateExtension(


### PR DESCRIPTION
VS Code added an alarming warning when installing the Swift extension because it depends on the unverified CodeLLDB extension. Remove the direct dependency on CodeLLDB in favour of prompting the user to install it themselves when they try to debug a Swift toolchain <6.0.0.