### PR TITLE
Set swift.swiftSDK for target platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The extension adds the following commands, available via the command palette.
 
 The following command is only available on macOS:
 
-- **Select Target Platform**: This is an experimental command that offers code completion for iOS and tvOS projects.
+- **Select Target Platform**: This is an experimental command that offers code editing support for iOS, tvOS, watchOS and visionOS projects.
 
 #### Building and Debugging
 

--- a/package.json
+++ b/package.json
@@ -884,7 +884,7 @@
         },
         {
           "command": "swift.switchPlatform",
-          "when": "swift.isActivated && isMac"
+          "when": "swift.isActivated && isMac && swift.switchPlatformAvailable"
         },
         {
           "command": "swift.insertFunctionComment",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,7 +124,9 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
                 return runTestMultipleTimes(ctx.currentFolder, item, true);
             }
         }),
-        // Note: This is only available on macOS (gated in `package.json`) because its the only OS that has the iOS SDK available.
+        // Note: switchPlatform is only available on macOS and Swift 6.1 or later
+        // (gated in `package.json`) because it's the only OS and toolchain combination that
+        // has Darwin SDKs available and supports code editing with SourceKit-LSP
         vscode.commands.registerCommand("swift.switchPlatform", () => switchPlatform(ctx)),
         vscode.commands.registerCommand(Commands.RESET_PACKAGE, () => resetPackage(ctx)),
         vscode.commands.registerCommand("swift.runScript", () => runSwiftScript(ctx)),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -125,7 +125,7 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             }
         }),
         // Note: This is only available on macOS (gated in `package.json`) because its the only OS that has the iOS SDK available.
-        vscode.commands.registerCommand("swift.switchPlatform", () => switchPlatform()),
+        vscode.commands.registerCommand("swift.switchPlatform", () => switchPlatform(ctx)),
         vscode.commands.registerCommand(Commands.RESET_PACKAGE, () => resetPackage(ctx)),
         vscode.commands.registerCommand("swift.runScript", () => runSwiftScript(ctx)),
         vscode.commands.registerCommand("swift.openPackage", () => {

--- a/src/commands/switchPlatform.ts
+++ b/src/commands/switchPlatform.ts
@@ -19,7 +19,6 @@ import {
     getDarwinTargetTriple,
 } from "../toolchain/toolchain";
 import configuration from "../configuration";
-import { Version } from "../utilities/version";
 import { WorkspaceContext } from "../WorkspaceContext";
 
 /**
@@ -39,12 +38,7 @@ export async function switchPlatform(ctx: WorkspaceContext) {
         }
     );
     if (picked) {
-        if (ctx.toolchain.swiftVersion.isLessThan(new Version(6, 1, 0))) {
-            vscode.window.showWarningMessage(
-                "Code editing support for non-macOS platforms is only available starting Swift 6.1"
-            );
-        }
-        // show a status item as getSDKForTarget can sometimes take a long while to xcrun for the SDK
+        // show a status item as getSDKForTarget can sometimes take a long while to run xcrun to find the SDK
         const statusItemText = `Setting target platform to ${picked.label}`;
         ctx.statusItem.start(statusItemText);
         try {
@@ -60,8 +54,8 @@ export async function switchPlatform(ctx: WorkspaceContext) {
                     `Selecting the ${picked.label} target platform will provide code editing support, but compiling with a ${picked.label} SDK will have undefined results.`
                 );
             } else {
-                // set swiftSDK to undefined for macOS and other platforms
-                configuration.swiftSDK = undefined;
+                // set swiftSDK to an empty string for macOS and other platforms
+                configuration.swiftSDK = "";
             }
         } catch {
             vscode.window.showErrorMessage(

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -77,6 +77,11 @@ interface ContextKeys {
      * Whether the SourceKit-LSP server supports documentation live preview.
      */
     supportsDocumentationLivePreview: boolean;
+
+    /**
+     * Whether the swift.switchPlatform command is available.
+     */
+    switchPlatformAvailable: boolean;
 }
 
 /** Creates the getters and setters for the VS Code Swift extension's context keys. */
@@ -92,6 +97,7 @@ function createContextKeys(): ContextKeys {
     let createNewProjectAvailable: boolean = false;
     let supportsReindexing: boolean = false;
     let supportsDocumentationLivePreview: boolean = false;
+    let switchPlatformAvailable: boolean = false;
 
     return {
         get isActivated() {
@@ -199,6 +205,15 @@ function createContextKeys(): ContextKeys {
                 "swift.supportsDocumentationLivePreview",
                 value
             );
+        },
+
+        get switchPlatformAvailable() {
+            return switchPlatformAvailable;
+        },
+
+        set switchPlatformAvailable(value: boolean) {
+            switchPlatformAvailable = value;
+            vscode.commands.executeCommand("setContext", "swift.switchPlatformAvailable", value);
         },
     };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,12 +76,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 contextKeys.createNewProjectAvailable = toolchain.swiftVersion.isGreaterThanOrEqual(
                     new Version(5, 8, 0)
                 );
+                contextKeys.switchPlatformAvailable = toolchain.swiftVersion.isGreaterThanOrEqual(
+                    new Version(6, 1, 0)
+                );
                 return toolchain;
             })
             .catch(error => {
                 outputChannel.log("Failed to discover Swift toolchain");
                 outputChannel.log(error);
                 contextKeys.createNewProjectAvailable = false;
+                contextKeys.switchPlatformAvailable = false;
                 return undefined;
             });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,11 +102,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     event.affectsConfiguration("swift.SDK") ||
                     event.affectsConfiguration("swift.swiftSDK")
                 ) {
-                    // FIXME: There is a bug stopping us from restarting SourceKit-LSP directly.
-                    // As long as it's fixed we won't need to reload on newer versions.
-                    showReloadExtensionNotification(
-                        "Changing the Swift SDK path requires the project be reloaded."
-                    );
+                    vscode.commands.executeCommand("swift.restartLSPServer");
                 } else if (event.affectsConfiguration("swift.swiftEnvironmentVariables")) {
                     showReloadExtensionNotification(
                         "Changing environment variables requires the project be reloaded."

--- a/test/unit-tests/commands/switchPlatform.test.ts
+++ b/test/unit-tests/commands/switchPlatform.test.ts
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2021-2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import { expect } from "chai";
+import * as vscode from "vscode";
+import {
+    mockObject,
+    mockGlobalObject,
+    mockGlobalModule,
+    MockedObject,
+    mockFn,
+    instance,
+} from "../../MockUtils";
+import {
+    DarwinCompatibleTarget,
+    SwiftToolchain,
+    getDarwinTargetTriple,
+} from "../../../src/toolchain/toolchain";
+import { WorkspaceContext } from "../../../src/WorkspaceContext";
+import { switchPlatform } from "../../../src/commands/switchPlatform";
+import { StatusItem } from "../../../src/ui/StatusItem";
+import configuration from "../../../src/configuration";
+
+suite("Switch Target Platform Unit Tests", () => {
+    const mockedConfiguration = mockGlobalModule(configuration);
+    const windowMock = mockGlobalObject(vscode, "window");
+    const mockSwiftToolchain = mockGlobalModule(SwiftToolchain);
+    let mockContext: MockedObject<WorkspaceContext>;
+    let mockedStatusItem: MockedObject<StatusItem>;
+
+    setup(() => {
+        mockedStatusItem = mockObject<StatusItem>({
+            start: mockFn(),
+            end: mockFn(),
+        });
+        mockContext = mockObject<WorkspaceContext>({
+            statusItem: instance(mockedStatusItem),
+        });
+    });
+
+    test("Call Switch Platform and switch to iOS", async () => {
+        const selectedItem = { value: DarwinCompatibleTarget.iOS, label: "iOS" };
+        windowMock.showQuickPick.resolves(selectedItem);
+        mockSwiftToolchain.getSDKForTarget.resolves("");
+        expect(mockedConfiguration.swiftSDK).to.equal("");
+
+        await switchPlatform(instance(mockContext));
+
+        expect(windowMock.showQuickPick).to.have.been.calledOnce;
+        expect(windowMock.showWarningMessage).to.have.been.calledOnceWithExactly(
+            "Selecting the iOS target platform will provide code editing support, but compiling with a iOS SDK will have undefined results."
+        );
+        expect(mockedStatusItem.start).to.have.been.called;
+        expect(mockedStatusItem.end).to.have.been.called;
+        expect(mockedConfiguration.swiftSDK).to.equal(
+            getDarwinTargetTriple(DarwinCompatibleTarget.iOS)
+        );
+    });
+
+    test("Call Switch Platform and switch to macOS", async () => {
+        const selectedItem = { value: undefined, label: "macOS" };
+        windowMock.showQuickPick.resolves(selectedItem);
+        mockSwiftToolchain.getSDKForTarget.resolves("");
+        expect(mockedConfiguration.swiftSDK).to.equal("");
+
+        await switchPlatform(instance(mockContext));
+
+        expect(windowMock.showQuickPick).to.have.been.calledOnce;
+        expect(windowMock.showWarningMessage).to.not.have.been.called;
+        expect(mockedStatusItem.start).to.have.been.called;
+        expect(mockedStatusItem.end).to.have.been.called;
+        expect(mockedConfiguration.swiftSDK).to.equal("");
+    });
+});


### PR DESCRIPTION
SourceKit-LSP now provides code editing support for non-macOS Darwin platforms starting Swift 6.1 using the `--swift-sdk` flag. Set this flag to the appropriate target-triple when using the `Select Target Platform` feature on macOS.

Issue: #1335