### PR TITLE
Simplify XCTestOutputParser Tests

### DIFF
--- a/test/integration-tests/testexplorer/MockTestRunState.ts
+++ b/test/integration-tests/testexplorer/MockTestRunState.ts
@@ -44,16 +44,26 @@ interface ITestItemFinder {
 }
 
 export class DarwinTestItemFinder implements ITestItemFinder {
-    constructor(public tests: TestItem[]) {}
+    tests: TestItem[] = [];
     getIndex(id: string): number {
-        return this.tests.findIndex(item => item.name === id);
+        const index = this.tests.findIndex(item => item.name === id);
+        if (index === -1) {
+            this.tests.push({ name: id, status: TestStatus.enqueued, output: [] });
+            return this.tests.length - 1;
+        }
+        return index;
     }
 }
 
 export class NonDarwinTestItemFinder implements ITestItemFinder {
-    constructor(public tests: TestItem[]) {}
+    tests: TestItem[] = [];
     getIndex(id: string): number {
-        return this.tests.findIndex(item => item.name.endsWith(id));
+        const index = this.tests.findIndex(item => item.name.endsWith(id));
+        if (index === -1) {
+            this.tests.push({ name: id, status: TestStatus.enqueued, output: [] });
+            return this.tests.length - 1;
+        }
+        return index;
     }
 }
 
@@ -75,14 +85,11 @@ export class TestRunState implements ITestRunState {
         return this.testItemFinder.tests;
     }
 
-    constructor(testNames: string[], darwin: boolean) {
-        const tests = testNames.map(name => {
-            return { name: name, status: TestStatus.enqueued, output: [] };
-        });
+    constructor(darwin: boolean) {
         if (darwin) {
-            this.testItemFinder = new DarwinTestItemFinder(tests);
+            this.testItemFinder = new DarwinTestItemFinder();
         } else {
-            this.testItemFinder = new NonDarwinTestItemFinder(tests);
+            this.testItemFinder = new NonDarwinTestItemFinder();
         }
     }
 

--- a/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -41,6 +41,7 @@ class TestEventStream {
 
 suite("SwiftTestingOutputParser Suite", () => {
     let outputParser: SwiftTestingOutputParser;
+    let testRunState: TestRunState;
 
     beforeEach(() => {
         outputParser = new SwiftTestingOutputParser(
@@ -48,6 +49,7 @@ suite("SwiftTestingOutputParser Suite", () => {
             () => {},
             () => {}
         );
+        testRunState = new TestRunState(true);
     });
 
     type ExtractPayload<T> = T extends { payload: infer E } ? E : never;
@@ -76,7 +78,6 @@ suite("SwiftTestingOutputParser Suite", () => {
     }
 
     test("Passed test", async () => {
-        const testRunState = new TestRunState(["MyTests.MyTests/testPass()"], true);
         const events = new TestEventStream([
             testEvent("runStarted"),
             testEvent("testCaseStarted", "MyTests.MyTests/testPass()"),
@@ -97,7 +98,6 @@ suite("SwiftTestingOutputParser Suite", () => {
     });
 
     test("Skipped test", async () => {
-        const testRunState = new TestRunState(["MyTests.MyTests/testSkip()"], true);
         const events = new TestEventStream([
             testEvent("runStarted"),
             testEvent("testSkipped", "MyTests.MyTests/testSkip()"),
@@ -116,7 +116,6 @@ suite("SwiftTestingOutputParser Suite", () => {
     });
 
     async function performTestFailure(messages: EventMessage[]) {
-        const testRunState = new TestRunState(["MyTests.MyTests/testFail()"], true);
         const issueLocation = {
             _filePath: "file:///some/file.swift",
             line: 1,
@@ -174,7 +173,6 @@ suite("SwiftTestingOutputParser Suite", () => {
     });
 
     test("Parameterized test", async () => {
-        const testRunState = new TestRunState(["MyTests.MyTests/testParameterized()"], true);
         const events = new TestEventStream([
             {
                 kind: "test",
@@ -270,10 +268,6 @@ suite("SwiftTestingOutputParser Suite", () => {
     });
 
     test("Output is captured", async () => {
-        const testRunState = new TestRunState(
-            ["MyTests.MyTests/testOutput()", "MyTests.MyTests/testOutput2()"],
-            true
-        );
         const symbol = TestSymbol.pass;
         const makeEvent = (kind: ExtractPayload<EventRecord>["kind"], testId?: string) =>
             testEvent(kind, testId, [{ text: kind, symbol }]);


### PR DESCRIPTION
To write a new one of these tests you had to define all the participating test names in the TestRunState at the begining of the test.

Remove this constraint by returning an enqueued mock test item every time one is requested that hasn't been seen.