### PR TITLE
Add PrivateFrameworks as additional Swift Testing framework path

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -483,7 +483,9 @@ export class SwiftToolchain {
         if (!base) {
             return undefined;
         }
-        return path.join(base, "Library/Frameworks");
+        const frameworks = path.join(base, "Library/Frameworks");
+        const privateFrameworks = path.join(base, "Library/PrivateFrameworks");
+        return `${frameworks}:${privateFrameworks}`;
     }
 
     get diagnostics(): string {


### PR DESCRIPTION
This is essentially the same change made in:
https://github.com/swiftlang/swift-package-manager/pull/8199

VS Code would be able to leverage it for regular runs with `swift test` but because when debugging we launch the xctest executable directly to run tests, we must include the same framework search paths as SPM.