### PR TITLE
Fix output logs on integration test failure

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export interface Api {
  */
 export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     try {
-        const outputChannel = new SwiftOutputChannel("Swift", !process.env["VSCODE_TEST"]);
+        const outputChannel = new SwiftOutputChannel("Swift");
         outputChannel.log("Activating Swift for Visual Studio Code...");
 
         checkAndWarnAboutWindowsSymlinks(outputChannel);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -532,7 +532,7 @@ export class LanguageClientManager implements vscode.Disposable {
             documentSelector: LanguageClientManager.documentSelector,
             revealOutputChannelOn: RevealOutputChannelOn.Never,
             workspaceFolder: workspaceFolder,
-            outputChannel: new SwiftOutputChannel("SourceKit Language Server", false),
+            outputChannel: new SwiftOutputChannel("SourceKit Language Server"),
             middleware: {
                 provideCodeLenses: async (document, token, next) => {
                     const result = await next(document, token);

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -790,7 +790,7 @@ export class SwiftToolchain {
         const plistKey = type === "XCTest" ? "XCTEST_VERSION" : "SWIFT_TESTING_VERSION";
         const version = infoPlist.DefaultProperties[plistKey];
         if (!version) {
-            new SwiftOutputChannel("swift", true).appendLine(
+            new SwiftOutputChannel("swift").appendLine(
                 `Warning: ${platformManifest} is missing the ${plistKey} key.`
             );
             return undefined;

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -25,11 +25,9 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
      */
     constructor(
         public name: string,
-        private logToConsole: boolean = true,
         logStoreLinesSize: number = 250_000 // default to capturing 250k log lines
     ) {
         this.name = name;
-        this.logToConsole = process.env["CI"] !== "1" && logToConsole;
         this.channel = vscode.window.createOutputChannel(name, "Swift");
         this.logStore = new RollingLog(logStoreLinesSize);
     }
@@ -37,21 +35,11 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
     append(value: string): void {
         this.channel.append(value);
         this.logStore.append(value);
-
-        if (this.logToConsole) {
-            // eslint-disable-next-line no-console
-            console.log(value);
-        }
     }
 
     appendLine(value: string): void {
         this.channel.appendLine(value);
         this.logStore.appendLine(value);
-
-        if (this.logToConsole) {
-            // eslint-disable-next-line no-console
-            console.log(value);
-        }
     }
 
     replace(value: string): void {

--- a/test/integration-tests/ui/SwiftOutputChannel.test.ts
+++ b/test/integration-tests/ui/SwiftOutputChannel.test.ts
@@ -20,7 +20,7 @@ suite("SwiftOutputChannel", function () {
     const channels: SwiftOutputChannel[] = [];
     setup(function () {
         const channelName = `SwiftOutputChannel Tests ${this.currentTest?.id ?? "<unknown test>"}`;
-        channel = new SwiftOutputChannel(channelName, false, 3);
+        channel = new SwiftOutputChannel(channelName, 3);
         channels.push(channel);
     });
 

--- a/test/unit-tests/debugger/lldb.test.ts
+++ b/test/unit-tests/debugger/lldb.test.ts
@@ -154,7 +154,7 @@ suite("debugger.lldb Tests", () => {
             });
             mockContext = mockObject<WorkspaceContext>({
                 toolchain: instance(mockToolchain),
-                outputChannel: new SwiftOutputChannel("mockChannel", false),
+                outputChannel: new SwiftOutputChannel("mockChannel"),
             });
         });
 


### PR DESCRIPTION
The logging of the SwiftOutputChannel on test failures was printing the previous test's logs rather than the current test. Fix this by moving the `beforeEach()` and `afterEach()` hooks into the test runner setup.

I've also opted to remove the console logging in SwiftOutputChannel as it was just polluting the logs with extra unnecessary info. This isn't needed anymore since the test failure logging is working now.