### PR TITLE
Fix missing Test Result output on Linux when using `print`

### DIFF
--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -102,6 +102,14 @@ struct MixedSwiftTestingSuite {
   }
   #expect(2 == 3)
 }
+
+@Test func testLotsOfOutput() {
+  var string = ""
+  for i in 1...100_000 {
+    string += "\(i)\n"
+  }
+  print(string)
+}
 #endif
 
 #if swift(>=6.1)

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -93,11 +93,12 @@ export class TestRunArguments {
                 const terminator = hasChildren ? "/" : "$";
                 // Debugging XCTests requires exact matches, so we don't need a trailing terminator.
                 return isDebug ? arg.id : `${arg.id}${terminator}`;
-            } else {
+            } else if (hasChildren) {
                 // Append a trailing slash to match a suite name exactly.
                 // This prevents TestTarget.MySuite matching TestTarget.MySuite2.
                 return `${arg.id}/`;
             }
+            return arg.id;
         });
     }
 

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -715,7 +715,8 @@ export class TestRunner {
                     presentationOptions: { reveal: vscode.TaskRevealKind.Never },
                 },
                 this.folderContext.workspaceContext.toolchain,
-                { ...process.env, ...testBuildConfig.env }
+                { ...process.env, ...testBuildConfig.env },
+                { readOnlyTerminal: process.platform !== "win32" }
             );
 
             task.execution.onDidWrite(str => {

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -268,7 +268,8 @@ export function createSwiftTask(
     name: string,
     config: TaskConfig,
     toolchain: SwiftToolchain,
-    cmdEnv: { [key: string]: string } = {}
+    cmdEnv: { [key: string]: string } = {},
+    options: { readOnlyTerminal: boolean } = { readOnlyTerminal: false }
 ): SwiftTask {
     const swift = toolchain.getToolchainExecutable("swift");
     args = toolchain.buildFlags.withAdditionalFlags(args);
@@ -313,6 +314,7 @@ export function createSwiftTask(
             cwd: fullCwd,
             env: env,
             presentation,
+            readOnlyTerminal: options.readOnlyTerminal,
         })
     );
     // This doesn't include any quotes added by VS Code.

--- a/test/integration-tests/testexplorer/TestRunArguments.test.ts
+++ b/test/integration-tests/testexplorer/TestRunArguments.test.ts
@@ -240,7 +240,7 @@ suite("TestRunArguments Suite", () => {
         const testArgs = new TestRunArguments(runRequestByIds([anotherSwiftTestId]), false);
         assertRunArguments(testArgs, {
             xcTestArgs: [],
-            swiftTestArgs: [`${anotherSwiftTestId}/`],
+            swiftTestArgs: [anotherSwiftTestId],
             testItems: [swiftTestSuiteId, testTargetId, anotherSwiftTestId],
         });
     });

--- a/test/integration-tests/testexplorer/utilities.ts
+++ b/test/integration-tests/testexplorer/utilities.ts
@@ -110,9 +110,23 @@ export function assertTestControllerHierarchy(
  *
  * @param array The array to check.
  * @param value The value to check for.
+ * @param message An optional message to display if the assertion fails.
  */
-export function assertContains<T>(array: T[], value: T) {
-    assert.ok(array.includes(value), `${value} is not in ${array}`);
+export function assertContains<T>(array: T[], value: T, message?: string) {
+    assert.ok(array.includes(value), message ?? `${value} is not in ${array}`);
+}
+
+/**
+ * Asserts that an array of strings contains the value ignoring
+ * leading/trailing whitespace.
+ *
+ * @param array The array to check.
+ * @param value The value to check for.
+ * @param message An optional message to display if the assertion fails.
+ */
+export function assertContainsTrimmed(array: string[], value: string, message?: string) {
+    const found = array.find(row => row.trim() === value);
+    assert.ok(found, message ?? `${value} is not in ${array}`);
 }
 
 /**


### PR DESCRIPTION
node-pty on Linux suffers from a long standing issue where the last chunk of output before a program exits is sometimes dropped, especially if that program produces a lot of output immediately before exiting. See https://github.com/microsoft/node-pty/issues/72

For swift processes that don't require input and may produce a lot of output that could potentially be truncated we can add a new `ReadOnlySwiftProcess` that spawns a child process using node's built in `child_process`. These spawned child processes emit their full output before exiting without the need to resort to flakey workarounds on the node-pty process.

When creating new `SwiftExecution`s in future `readOnlyTerminal` should be set to `true` unless the process may require user input.

Issue: #1393