### PR TITLE
Disable nightly-6.1 run against insiders

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "nightly-6.0"}, {"swift_version": "nightly"}]'
+      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly"}]'
       windows_env_vars: |
         CI=1
         VSCODE_TEST=1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.0"},{"swift_version": "nightly"}]'
+      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly"}]'
       windows_env_vars: |
         CI=1
         VSCODE_TEST=1


### PR DESCRIPTION
Now that nightly-6.1 matrix option is available for windows, we do not want to run this against vscode insiders