### PR TITLE
Increase timeout for TaskQueue test

### DIFF
--- a/test/integration-tests/tasks/TaskQueue.test.ts
+++ b/test/integration-tests/tasks/TaskQueue.test.ts
@@ -156,7 +156,7 @@ suite("TaskQueue Test Suite", () => {
             taskQueue.queueOperation(new TaskOperation(task2)).then(rt => results.push(rt)),
         ]);
         assert.notStrictEqual(results, [1, 2]);
-    }).timeout(8000);
+    }).timeout(15000);
 
     // check queuing task will return expected value
     test("swift exec", async () => {


### PR DESCRIPTION
Although I cannot reproduce locally it is taking 7600ms which is very close to the timeout so going to try increasing the timeout to fix.