### PR TITLE
Notify sourcekit-lsp of active document changes

### DIFF
--- a/src/sourcekit-lsp/didChangeActiveDocument.ts
+++ b/src/sourcekit-lsp/didChangeActiveDocument.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2025 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/didChangeActiveDocument.ts
+++ b/src/sourcekit-lsp/didChangeActiveDocument.ts
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import * as langclient from "vscode-languageclient/node";
+import { checkExperimentalCapability } from "./LanguageClientManager";
+import { DidChangeActiveDocumentNotification } from "./extensions/DidChangeActiveDocumentRequest";
+
+export function activateDidChangeActiveDocument(
+    client: langclient.LanguageClient
+): vscode.Disposable {
+    const disposable = vscode.window.onDidChangeActiveTextEditor(event => {
+        if (
+            event &&
+            checkExperimentalCapability(client, DidChangeActiveDocumentNotification.method, 1)
+        ) {
+            client.sendNotification(DidChangeActiveDocumentNotification.method, {
+                textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
+                    event.document
+                ),
+            });
+        }
+    });
+
+    // Fire an inital notification
+    const activeEditor = vscode.window.activeTextEditor;
+    if (
+        activeEditor &&
+        checkExperimentalCapability(client, DidChangeActiveDocumentNotification.method, 1)
+    ) {
+        client.sendNotification(DidChangeActiveDocumentNotification.method, {
+            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
+                activeEditor.document
+            ),
+        });
+    }
+    return disposable;
+}

--- a/src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest.ts
+++ b/src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Copyright (c) 2025 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest.ts
+++ b/src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest.ts
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2021-2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import { MessageDirection, NotificationType, TextDocumentIdentifier } from "vscode-languageclient";
+
+// We use namespaces to store request information just like vscode-languageclient
+/* eslint-disable @typescript-eslint/no-namespace */
+
+export interface DidChangeActiveDocumentParams {
+    /**
+     * The document that is being displayed in the active editor.
+     */
+    textDocument: TextDocumentIdentifier;
+}
+
+/**
+ * Notify the server that the active document has changed.
+ */
+export namespace DidChangeActiveDocumentNotification {
+    export const method = "window/didChangeActiveDocument" as const;
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new NotificationType<DidChangeActiveDocumentParams>(method);
+}

--- a/src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest.ts
+++ b/src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest.ts
@@ -21,7 +21,7 @@ export interface DidChangeActiveDocumentParams {
     /**
      * The document that is being displayed in the active editor.
      */
-    textDocument: TextDocumentIdentifier;
+    textDocument?: TextDocumentIdentifier;
 }
 
 /**

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -123,6 +123,13 @@ suite("LanguageClientManager Suite", () => {
                     dispose: mockFn(),
                 })
             ),
+            initializeResult: {
+                capabilities: {
+                    experimental: {
+                        "window/didChangeActiveDocument": true,
+                    },
+                },
+            },
             start: mockFn(s =>
                 s.callsFake(async () => {
                     const oldState = languageClientMock.state;


### PR DESCRIPTION
`sourcekit-lsp` recently added an LSP extension method to notify the server of the active documnent, so it doesn't need to infer it from information in other requests. This capability was added in https://github.com/swiftlang/sourcekit-lsp/pull/1989.

This also relies on https://github.com/swiftlang/sourcekit-lsp/pull/1994