### PR TITLE
Use `lldb-dap` by default when `swift.debugger.debugAdapter` is set to `"auto"`

### DIFF
--- a/src/debugger/debugAdapter.ts
+++ b/src/debugger/debugAdapter.ts
@@ -44,7 +44,7 @@ export class DebugAdapter {
      */
     public static getLaunchConfigType(swiftVersion: Version): LaunchConfigType {
         const lldbDapIsAvailable = swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0));
-        if (lldbDapIsAvailable && configuration.debugger.debugAdapter === "lldb-dap") {
+        if (lldbDapIsAvailable && configuration.debugger.debugAdapter !== "CodeLLDB") {
             return LaunchConfigType.LLDB_DAP;
         } else {
             return LaunchConfigType.CODE_LLDB;

--- a/test/unit-tests/debugger/debugAdapter.test.ts
+++ b/test/unit-tests/debugger/debugAdapter.test.ts
@@ -40,22 +40,23 @@ suite("DebugAdapter Unit Test Suite", () => {
     });
 
     suite("getLaunchConfigType()", () => {
-        test("returns SWIFT_EXTENSION when Swift version >=6.0.0 and swift.debugger.debugAdapter is set to lldb-dap", () => {
+        test("returns LLDB_DAP when Swift version >=6.0.0 and swift.debugger.debugAdapter is set to lldb-dap", () => {
             mockDebugConfig.debugAdapter = "lldb-dap";
             expect(DebugAdapter.getLaunchConfigType(new Version(6, 0, 1))).to.equal(
                 LaunchConfigType.LLDB_DAP
             );
         });
 
-        test("returns CODE_LLDB when Swift version >=6.0.0 and swift.debugger.debugAdapter is set to auto or CodeLLDB", () => {
-            // Try with the setting set to auto
+        test("returns LLDB_DAP when Swift version >=6.0.0 and swift.debugger.debugAdapter is set to auto", () => {
             mockDebugConfig.debugAdapter = "auto";
-            expect(DebugAdapter.getLaunchConfigType(new Version(5, 10, 0))).to.equal(
-                LaunchConfigType.CODE_LLDB
+            expect(DebugAdapter.getLaunchConfigType(new Version(6, 0, 1))).to.equal(
+                LaunchConfigType.LLDB_DAP
             );
-            // Try with the setting set to CodeLLDB
+        });
+
+        test("returns CODE_LLDB when Swift version >=6.0.0 and swift.debugger.debugAdapter is set to CODE_LLDB", () => {
             mockDebugConfig.debugAdapter = "CodeLLDB";
-            expect(DebugAdapter.getLaunchConfigType(new Version(5, 10, 0))).to.equal(
+            expect(DebugAdapter.getLaunchConfigType(new Version(6, 0, 1))).to.equal(
                 LaunchConfigType.CODE_LLDB
             );
         });


### PR DESCRIPTION
Now that we've removed the dependency on CodeLLDB to avoid VS Code warnings about untrusted extensions, we should use `lldb-dap` by default on Swift 6.0 and later.