### PR TITLE
Configurable Command Plugin Build Configuration

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,7 +6,7 @@ This document outlines useful configuration options not covered by the settings 
 
 ## Command Plugins
 
-Swift packages can define [command plugins](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Plugins.md) that can perform arbitrary tasks. For example, the [swift-format](https://github.com/swiftlang/swift-format) package exposes a `format-source-code` command which will use swift-format to format source code in a folder. These plugin commands can be invoked from VS Code using `> Swift: Run Command Plugin`. 
+Swift packages can define [command plugins](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/Plugins.md) that can perform arbitrary tasks. For example, the [swift-format](https://github.com/swiftlang/swift-format) package exposes a `format-source-code` command which will use swift-format to format source code in a folder. These plugin commands can be invoked from VS Code using `> Swift: Run Command Plugin`.
 
 A plugin may require permissions to perform tasks like writing to the file system or using the network. If a plugin command requires one of these permissions, you will be prompted in the integrated terminal to accept them. If you trust the command and wish to apply permissions on every command execution, you can configure a setting in your `settings.json`.
 
@@ -23,7 +23,7 @@ A plugin may require permissions to perform tasks like writing to the file syste
 }
 ```
 
-A key of `PluginName:command` will set permissions for a specific command. A key of `PluginName` will set permissions for all commands in the plugin.
+A key of `PluginName:command` will set permissions for a specific command. A key of `PluginName` will set permissions for all commands in the plugin. If you'd like the same permissions to be applied to all plugins use `*` as the plugin name. Precedence order is determined by specificity, where more specific names take priority. The name `*` is the least specific and `PluginName:command` is the most specific.
 
 Alternatively, you can define a task in your tasks.json and define permissions directly on the task. This will create a new entry in the list shown by `> Swift: Run Command Plugin`.
 
@@ -40,6 +40,24 @@ Alternatively, you can define a task in your tasks.json and define permissions d
   "allowWritingToDirectory": "/some/path/",
   "allowNetworkConnections": "all",
   "disableSandbox": true
+}
+```
+
+If you'd like to provide specific arguments to your plugin command invocation you can  use the `swift.pluginArguments` setting. Defining an array for this setting applies the same arguments to all plugin command invocations.
+
+```json
+{
+  "swift.pluginArguments": ["-c", "release"]
+}
+```
+
+Alternatively you can specfiy which specific command the arguments should apply to using `PluginName:command`. A key of `PluginName` will use the arguments for all commands in the plugin. If you'd like the same arguments to be used for all plugins use `*` as the plugin name.
+
+```json
+{
+  "swift.pluginArguments": {
+    "PluginName:command": ["-c", "release"]
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -418,6 +418,30 @@
             "default": true,
             "markdownDescription": "Controls whether or not the extension will contribute environment variables defined in `Swift: Environment Variables` to the integrated terminal. If this is set to `true` and a custom `Swift: Path` is also set then the swift path is appended to the terminal's `PATH`."
           },
+          "swift.pluginArguments": {
+            "default": [],
+            "markdownDescription": "Configure a list of arguments to pass to command invocations. This can either be an array of arguments, which will apply to all command invocations, or an object with an with command names as the key where the value is an array of arguments.",
+            "scope": "machine-overridable",
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "object",
+                "patternProperties": {
+                  "^([a-zA-Z0-9_-]+(:[a-zA-Z0-9_-]+)?)$": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
+          },
           "swift.pluginPermissions": {
             "type": "object",
             "default": {},

--- a/package.json
+++ b/package.json
@@ -420,7 +420,7 @@
           },
           "swift.pluginArguments": {
             "default": [],
-            "markdownDescription": "Configure a list of arguments to pass to command invocations. This can either be an array of arguments, which will apply to all command invocations, or an object with an with command names as the key where the value is an array of arguments.",
+            "markdownDescription": "Configure a list of arguments to pass to command invocations. This can either be an array of arguments, which will apply to all command invocations, or an object with command names as the key where the value is an array of arguments.",
             "scope": "machine-overridable",
             "oneOf": [
               {


### PR DESCRIPTION
Packages can define their own plugins either directly or through their dependencies. These plugins define commands, and the extension exposes a list of these when you use `> Swift: Run Command Plugin`.

It may be desirable to build and run these plugins with specific arguments. This patch introduces a new setting that can be specified globally or on a per workspace folder basis that allows users to configure arguments to pass to plugin command invocations.

The setting is defined under `swift.pluginArguments`, and is specified as an object in the following form:

```json
{
  "PluginCommandName:intent-name": ["--some", "--args"]
}
```

- The top level string key is the command id in the form `PluginCommandName:intent-name`. For instance, swift-format's format-source-code command would be specified as `swift-format:format-source-code`
- Specifying `PluginCommandName` will apply the arguments to all intents in the command plugin
- Specifying `*` will apply the arguments to all commands.

This patch also adds this wildcard functionality to the `swift.pluginPermissions` setting.

Issue: #1365