### PR TITLE
Add missing spawn event on ReadOnlySwiftProcess

### DIFF
--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -187,6 +187,7 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
                 cwd: this.options.cwd,
                 env: { ...process.env, ...this.options.env },
             });
+            this.spawnEmitter.fire();
 
             this.spawnedProcess.stdout.on("data", data => {
                 this.writeEmitter.fire(data.toString());


### PR DESCRIPTION
This kept the executed command from being printed in the terminal when using `swift test`