### PR TITLE
Add tag to skipped test

### DIFF
--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -303,6 +303,15 @@ suite("Test Explorer Suite", function () {
                 assertTestResults(testRun, {
                     skipped: ["PackageTests.testWithKnownIssue()"],
                 });
+
+                const testItem = testRun.testItems.find(
+                    ({ id }) => id === "PackageTests.testWithKnownIssue()"
+                );
+                assert.ok(testItem, "Unable to find test item for testWithKnownIssue");
+                assert.ok(
+                    testItem.tags.find(tag => tag.id === "skipped"),
+                    "skipped tag was not found on test item"
+                );
             });
 
             test("testWithKnownIssueAndUnknownIssue", async () => {


### PR DESCRIPTION
Add a `skipped` tag to tests in the test explorer if they were skipped in the last run. This lets users filter down just the skipped tests in a test run.