### PR TITLE
Print the command being run when debugging tests

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -961,6 +961,8 @@ export class TestRunner {
                             );
 
                             const outputHandler = this.testOutputHandler(config.testType, runState);
+                            outputHandler(`> ${config.program} ${config.args.join(" ")}\n\n\r`);
+
                             LoggingDebugAdapterTracker.setDebugSessionCallback(
                                 session,
                                 this.workspaceContext.outputChannel,


### PR DESCRIPTION
Print the command being run when starting a debugging session while running tests, just like a regular non-debug run.