### PR TITLE
Reload extension when swiftEnvironmentVariables changes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,9 +97,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     showReloadExtensionNotification(
                         "Changing the Swift path requires Visual Studio Code be reloaded."
                     );
-                }
-                // on sdk config change, restart sourcekit-lsp
-                if (
+                } else if (
+                    // on sdk config change, restart sourcekit-lsp
                     event.affectsConfiguration("swift.SDK") ||
                     event.affectsConfiguration("swift.swiftSDK")
                 ) {
@@ -107,6 +106,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                     // As long as it's fixed we won't need to reload on newer versions.
                     showReloadExtensionNotification(
                         "Changing the Swift SDK path requires the project be reloaded."
+                    );
+                } else if (event.affectsConfiguration("swift.swiftEnvironmentVariables")) {
+                    showReloadExtensionNotification(
+                        "Changing environment variables requires the project be reloaded."
                     );
                 }
             })


### PR DESCRIPTION
The generated Swift build tasks are created once when the workspace folder is added to the workspace. The environment variables are captured at task creation time. If they're updated during the lifetime of the extension they wont be attached to the generated tasks until the extension restarts.

Issue: #1428