### PR TITLE
Use FileWatcher for background compilation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/chai-subset": "^1.3.6",
         "@types/glob": "^7.1.6",
         "@types/lcov-parse": "^1.0.2",
+        "@types/lodash.debounce": "^4.0.9",
         "@types/lodash.throttle": "^4.1.9",
         "@types/mocha": "^10.0.10",
         "@types/mock-fs": "^4.13.4",
@@ -1115,6 +1116,15 @@
       "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/lodash.throttle": {
       "version": "4.1.9",
@@ -6815,6 +6825,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
       "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/lodash.throttle": {
       "version": "4.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "esbuild": "^0.25.1",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^10.1.1",
+        "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
         "mocha": "^10.8.2",
         "mock-fs": "^5.5.0",
@@ -4063,6 +4064,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -8944,6 +8951,12 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -1600,6 +1600,7 @@
     "@types/glob": "^7.1.6",
     "@types/lcov-parse": "^1.0.2",
     "@types/lodash.throttle": "^4.1.9",
+    "@types/lodash.debounce": "^4.0.9",
     "@types/mocha": "^10.0.10",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^18.19.80",

--- a/package.json
+++ b/package.json
@@ -1623,6 +1623,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^10.1.1",
     "lodash.throttle": "^4.1.1",
+    "lodash.debounce": "^4.0.8",
     "mocha": "^10.8.2",
     "mock-fs": "^5.5.0",
     "node-pty": "^1.0.0",

--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -18,7 +18,7 @@ import configuration from "./configuration";
 import { FolderContext } from "./FolderContext";
 import { TaskOperation } from "./tasks/TaskQueue";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-import throttle = require("lodash.throttle");
+import debounce = require("lodash.debounce");
 
 export class BackgroundCompilation implements vscode.Disposable {
     private workspaceFileWatcher?: vscode.FileSystemWatcher;
@@ -56,7 +56,7 @@ export class BackgroundCompilation implements vscode.Disposable {
         // does a "Save All" or a process writes several files in quick succession.
         this.disposables.push(
             this.workspaceFileWatcher.onDidChange(
-                throttle(
+                debounce(
                     () => {
                         this.runTask();
                     },

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -54,6 +54,7 @@ export class FolderContext implements vscode.Disposable {
         this.linuxMain?.dispose();
         this.packageWatcher.dispose();
         this.testExplorer?.dispose();
+        this.backgroundCompilation.dispose();
     }
 
     /**

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -22,7 +22,6 @@ import { isPathInsidePath } from "./utilities/filesystem";
 import { LanguageClientManager } from "./sourcekit-lsp/LanguageClientManager";
 import { TemporaryFolder } from "./utilities/tempFolder";
 import { TaskManager } from "./tasks/TaskManager";
-import { BackgroundCompilation } from "./BackgroundCompilation";
 import { makeDebugConfigurations } from "./debugger/launch";
 import configuration from "./configuration";
 import contextKeys from "./contextKeys";
@@ -121,7 +120,6 @@ export class WorkspaceContext implements vscode.Disposable {
                     });
             }
         });
-        const backgroundCompilationOnDidSave = BackgroundCompilation.start(this);
         const contextKeysUpdate = this.onDidChangeFolders(event => {
             switch (event.operation) {
                 case FolderOperation.remove:
@@ -174,7 +172,6 @@ export class WorkspaceContext implements vscode.Disposable {
             swiftFileWatcher,
             onDidEndTask,
             this.commentCompletionProvider,
-            backgroundCompilationOnDidSave,
             contextKeysUpdate,
             onChangeConfig,
             this.tasks,


### PR DESCRIPTION
This `swift.backgroundCompilation` setting listened for file save events from VS Code and triggered the build task. This meant that only modifications made by saving in a VS Code editor would trigger background compilation.

Switch to using a `vscode.FileWatcher` so background compilation still gets kicked off even if a file is modified from outside VS Code. This is useful if you have a command plugin that modifies source files like swift-format.

Issue: #1274