### PR TITLE
Update diagnostics parsing to handle new warnings

### DIFF
--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -374,7 +374,7 @@ export class DiagnosticsManager implements vscode.Disposable {
     ): ParsedDiagnostic | vscode.DiagnosticRelatedInformation | undefined {
         const diagnosticRegex =
             /^(?:\S+\s+)?(.*?):(\d+)(?::(\d+))?:\s+(warning|error|note):\s+(.*)$/g;
-        const switfcExtraWarningsRegex = /\[-W.*?\]/g;
+        const switfcExtraWarningsRegex = /\[(-W|#).*?\]/g;
         const match = diagnosticRegex.exec(line);
         if (!match) {
             return;


### PR DESCRIPTION
Starting with Swift 6.2 some warnings may end with a tag such as `[#no-usage]`. Update parsing logic to remove these tags from the warnings to ensure we can combine them with the warnings from SourceKit.

Issue: #1434