### PR TITLE
Specify Visual C and Windows SDK versions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   tests:
     name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: award999/github-workflows/.github/workflows/swift_package_test.yml@win-11-sdk
     with:
       # Linux
       linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-main"}]'

--- a/scripts/test_windows.ps1
+++ b/scripts/test_windows.ps1
@@ -18,6 +18,14 @@ npm ci -ignore-script node-pty
 npm run lint
 npm run format
 npm run package
+$User_Directory=".vscode-test\user-data\User"
+New-Item $User_Directory -type directory -force
+$Settings = @'
+{
+    "swift.buildArguments": ["-Xswiftc", "-visualc-tools-version", "-Xswiftc", "14.42.34433", "-Xswiftc", "-windows-sdk-version", "-Xswiftc", "10.0.22000.0"]
+}
+'@
+$Settings | Set-Content "$User_Directory\settings.json"
 $Process = Start-Process npm "run integration-test" -Wait -PassThru -NoNewWindow
 if ($Process.ExitCode -eq 0) {
     Write-Host 'SUCCESS'


### PR DESCRIPTION
Hardcoding to versions we knew worked to unblock the vscode tests until there's a better fix for
https://github.com/swiftlang/github-workflows/issues/103