### PR TITLE
Build pre-release VSIX in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,6 +24,7 @@ jobs:
           npm ci
           npm run compile
           npm run package
+          npm run preview-package
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         if: always()

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,13 @@
       "request": "launch",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
       "runtimeArgs": ["${workspaceFolder}/scripts/update_swift_docc_render.ts"]
+    },
+    {
+      "name": "Preview Package",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/tsx",
+      "runtimeArgs": ["${workspaceFolder}/scripts/preview_package.ts"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swift-vscode",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "publisher": "swiftlang",
   "icon": "icon.png",
   "repository": {
@@ -1637,7 +1637,7 @@
     "compile-tests": "del-cli ./assets/test/**/.build && npm run compile",
     "package": "vsce package",
     "dev-package": "vsce package --no-update-package-json 2.1.0-dev",
-    "preview-package": "vsce package --pre-release",
+    "preview-package": "tsx ./scripts/preview_package.ts",
     "tag": "./scripts/tag_release.sh $npm_package_version",
     "contributors": "./scripts/generate_contributors_list.sh"
   },

--- a/package.json
+++ b/package.json
@@ -1630,6 +1630,7 @@
     "postinstall": "npm run update-swift-docc-render",
     "pretest": "npm run compile-tests",
     "soundness": "scripts/soundness.sh",
+    "check-package-json": "tsx ./scripts/check_package_json.ts",
     "test": "vscode-test",
     "integration-test": "npm test -- --label integrationTests",
     "unit-test": "npm test -- --label unitTests",

--- a/scripts/check_package_json.ts
+++ b/scripts/check_package_json.ts
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+/* eslint-disable no-console */
+
+import { getExtensionVersion, main } from "./lib/utilities";
+
+main(async () => {
+    const version = await getExtensionVersion();
+    if (version.minor % 2 !== 0) {
+        throw new Error(
+            `Invalid version number in package.json. ${version.toString()} does not have an even numbered minor version.`
+        );
+    }
+});

--- a/scripts/lib/utilities.ts
+++ b/scripts/lib/utilities.ts
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+/* eslint-disable no-console */
+
+import * as child_process from "child_process";
+
+export async function exec(
+    command: string,
+    args: string[],
+    options: child_process.SpawnOptionsWithoutStdio = {}
+): Promise<void> {
+    let logMessage = "> " + command;
+    if (args.length > 0) {
+        logMessage += " " + args.join(" ");
+    }
+    console.log(logMessage + "\n");
+    return new Promise<void>((resolve, reject) => {
+        const childProcess = child_process.spawn(command, args, { stdio: "inherit", ...options });
+        childProcess.once("error", reject);
+        childProcess.once("close", (code, signal) => {
+            if (signal !== null) {
+                reject(new Error(`Process exited due to signal '${signal}'`));
+            } else if (code !== 0) {
+                reject(new Error(`Process exited with code ${code}`));
+            } else {
+                resolve();
+            }
+            console.log("");
+        });
+    });
+}

--- a/scripts/lib/utilities.ts
+++ b/scripts/lib/utilities.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2025 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,6 +15,29 @@
 
 import * as child_process from "child_process";
 
+/**
+ * Executes the provided main function for the script while logging any errors.
+ *
+ * If an error is caught then the process will exit with code 1.
+ *
+ * @param mainFn The main function of the script that will be run.
+ */
+export async function main(mainFn: () => Promise<void>): Promise<void> {
+    try {
+        await mainFn();
+    } catch (error) {
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+/**
+ * Executes the given command, inheriting the current process' stdio.
+ *
+ * @param command The command to execute.
+ * @param args The arguments to provide to the command.
+ * @param options The options for executing the command.
+ */
 export async function exec(
     command: string,
     args: string[],

--- a/scripts/lib/utilities.ts
+++ b/scripts/lib/utilities.ts
@@ -14,6 +14,9 @@
 /* eslint-disable no-console */
 
 import * as child_process from "child_process";
+import { readFile } from "fs/promises";
+import * as path from "path";
+import * as semver from "semver";
 
 /**
  * Executes the provided main function for the script while logging any errors.
@@ -29,6 +32,30 @@ export async function main(mainFn: () => Promise<void>): Promise<void> {
         console.error(error);
         process.exit(1);
     }
+}
+
+/**
+ * Returns the root directory of the repository.
+ */
+export function getRootDirectory(): string {
+    return path.join(__dirname, "..", "..");
+}
+
+/**
+ * Retrieves the version number from the package.json.
+ */
+export async function getExtensionVersion(): Promise<semver.SemVer> {
+    const packageJSON = JSON.parse(
+        await readFile(path.join(getRootDirectory(), "package.json"), "utf-8")
+    );
+    if (typeof packageJSON.version !== "string") {
+        throw new Error("Version number in package.json is not a string");
+    }
+    const version = semver.parse(packageJSON.version);
+    if (version === null) {
+        throw new Error("Unable to parse version number in package.json");
+    }
+    return version;
 }
 
 /**

--- a/scripts/preview_package.ts
+++ b/scripts/preview_package.ts
@@ -2,7 +2,7 @@
 //
 // This source file is part of the VS Code Swift open source project
 //
-// Copyright (c) 2024 the VS Code Swift project authors
+// Copyright (c) 2025 the VS Code Swift project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -16,7 +16,7 @@
 import * as path from "path";
 import * as semver from "semver";
 import { readFile } from "fs/promises";
-import { exec } from "./lib/utilities";
+import { exec, main } from "./lib/utilities";
 
 /**
  * Formats the given date as a string in the form "YYYYMMddhhmm".
@@ -33,7 +33,7 @@ function formatDate(date: Date): string {
     return year + month + day + hour + minutes;
 }
 
-(async () => {
+main(async () => {
     const rootDirectory = path.join(__dirname, "..");
     // Grab the existing version number from the package.json
     const packageJSON = JSON.parse(
@@ -55,7 +55,4 @@ function formatDate(date: Date): string {
         ["vsce", "package", "--pre-release", "--no-update-package-json", previewVersion],
         { cwd: rootDirectory }
     );
-})().catch(error => {
-    console.error(error);
-    process.exit(1);
 });

--- a/scripts/preview_package.ts
+++ b/scripts/preview_package.ts
@@ -13,10 +13,7 @@
 //===----------------------------------------------------------------------===//
 /* eslint-disable no-console */
 
-import * as path from "path";
-import * as semver from "semver";
-import { readFile } from "fs/promises";
-import { exec, main } from "./lib/utilities";
+import { exec, getExtensionVersion, getRootDirectory, main } from "./lib/utilities";
 
 /**
  * Formats the given date as a string in the form "YYYYMMddhhmm".
@@ -34,18 +31,8 @@ function formatDate(date: Date): string {
 }
 
 main(async () => {
-    const rootDirectory = path.join(__dirname, "..");
-    // Grab the existing version number from the package.json
-    const packageJSON = JSON.parse(
-        await readFile(path.join(rootDirectory, "package.json"), "utf-8")
-    );
-    if (typeof packageJSON.version !== "string") {
-        throw new Error("Version number in package.json is not a string");
-    }
-    const version = semver.parse(packageJSON.version);
-    if (version === null) {
-        throw new Error("Unable to parse version number in package.json");
-    }
+    const rootDirectory = getRootDirectory();
+    const version = await getExtensionVersion();
     // Increment the minor version and set the patch version to today's date
     const minor = version.minor + 1;
     const patch = formatDate(new Date());

--- a/scripts/preview_package.ts
+++ b/scripts/preview_package.ts
@@ -37,6 +37,14 @@ main(async () => {
     const minor = version.minor + 1;
     const patch = formatDate(new Date());
     const previewVersion = `${version.major}.${minor}.${patch}`;
+    // Make sure that the new minor version is odd
+    if (minor % 2 !== 1) {
+        throw new Error(
+            `The minor version for the pre-release extension is even (${previewVersion}).` +
+                " The version in the package.json has probably been incorrectly set to an odd minor version."
+        );
+    }
+    // Use VSCE to package the extension
     await exec(
         "npx",
         ["vsce", "package", "--pre-release", "--no-update-package-json", previewVersion],

--- a/scripts/preview_package.ts
+++ b/scripts/preview_package.ts
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2024 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+/* eslint-disable no-console */
+
+import * as path from "path";
+import * as semver from "semver";
+import { readFile } from "fs/promises";
+import { exec } from "./lib/utilities";
+
+/**
+ * Formats the given date as a string in the form "YYYYMMddhhmm".
+ *
+ * @param date The date to format as a string.
+ * @returns The formatted date.
+ */
+function formatDate(date: Date): string {
+    const year = date.getUTCFullYear().toString().padStart(4, "0");
+    const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
+    const day = date.getUTCDate().toString().padStart(2, "0");
+    const hour = date.getUTCHours().toString().padStart(2, "0");
+    const minutes = date.getUTCMinutes().toString().padStart(2, "0");
+    return year + month + day + hour + minutes;
+}
+
+(async () => {
+    const rootDirectory = path.join(__dirname, "..");
+    // Grab the existing version number from the package.json
+    const packageJSON = JSON.parse(
+        await readFile(path.join(rootDirectory, "package.json"), "utf-8")
+    );
+    if (typeof packageJSON.version !== "string") {
+        throw new Error("Version number in package.json is not a string");
+    }
+    const version = semver.parse(packageJSON.version);
+    if (version === null) {
+        throw new Error("Unable to parse version number in package.json");
+    }
+    // Increment the minor version and set the patch version to today's date
+    const minor = version.minor + 1;
+    const patch = formatDate(new Date());
+    const previewVersion = `${version.major}.${minor}.${patch}`;
+    await exec(
+        "npx",
+        ["vsce", "package", "--pre-release", "--no-update-package-json", previewVersion],
+        { cwd: rootDirectory }
+    );
+})().catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -36,6 +36,9 @@ function replace_acceptable_years() {
     sed -e 's/20[12][0123456789]-20[12][0123456789]/YEARS/' -e 's/20[12][0123456789]/YEARS/'
 }
 
+printf "=> Checking package.json..."
+npm run check-package-json
+
 printf "=> Checking license headers... "
 tmp=$(mktemp /tmp/.vscode-swift-soundness_XXXXXX)
 

--- a/scripts/update_swift_docc_render.ts
+++ b/scripts/update_swift_docc_render.ts
@@ -18,7 +18,7 @@ import { stat, mkdtemp, mkdir, rm, readdir } from "fs/promises";
 import * as path from "path";
 import { tmpdir } from "os";
 import * as semver from "semver";
-import { exec, main } from "./lib/utilities";
+import { exec, getRootDirectory, main } from "./lib/utilities";
 
 function checkNodeVersion() {
     const nodeVersion = semver.parse(process.versions.node);
@@ -58,7 +58,7 @@ async function cloneSwiftDocCRender(buildDirectory: string): Promise<string> {
 }
 
 main(async () => {
-    const outputDirectory = path.join(__dirname, "..", "assets", "swift-docc-render");
+    const outputDirectory = path.join(getRootDirectory(), "assets", "swift-docc-render");
     if (process.argv.includes("postinstall")) {
         try {
             await stat(outputDirectory);

--- a/scripts/update_swift_docc_render.ts
+++ b/scripts/update_swift_docc_render.ts
@@ -18,7 +18,7 @@ import { stat, mkdtemp, mkdir, rm, readdir } from "fs/promises";
 import * as path from "path";
 import { tmpdir } from "os";
 import * as semver from "semver";
-import { exec } from "./lib/utilities";
+import { exec, main } from "./lib/utilities";
 
 function checkNodeVersion() {
     const nodeVersion = semver.parse(process.versions.node);
@@ -57,7 +57,7 @@ async function cloneSwiftDocCRender(buildDirectory: string): Promise<string> {
     return swiftDocCRenderDirectory;
 }
 
-(async () => {
+main(async () => {
     const outputDirectory = path.join(__dirname, "..", "assets", "swift-docc-render");
     if (process.argv.includes("postinstall")) {
         try {
@@ -88,7 +88,4 @@ async function cloneSwiftDocCRender(buildDirectory: string): Promise<string> {
             console.error(error);
         });
     }
-})().catch(error => {
-    console.error(error);
-    process.exit(1);
 });

--- a/scripts/update_swift_docc_render.ts
+++ b/scripts/update_swift_docc_render.ts
@@ -14,11 +14,11 @@
 /* eslint-disable no-console */
 
 import simpleGit, { ResetMode } from "simple-git";
-import { spawn } from "child_process";
 import { stat, mkdtemp, mkdir, rm, readdir } from "fs/promises";
 import * as path from "path";
 import { tmpdir } from "os";
 import * as semver from "semver";
+import { exec } from "./lib/utilities";
 
 function checkNodeVersion() {
     const nodeVersion = semver.parse(process.versions.node);
@@ -55,32 +55,6 @@ async function cloneSwiftDocCRender(buildDirectory: string): Promise<string> {
     console.log("> git apply \\\n" + patches.map(e => "    " + e).join(" \\\n"));
     await git.applyPatch(patches);
     return swiftDocCRenderDirectory;
-}
-
-async function exec(
-    command: string,
-    args: string[],
-    options: { cwd?: string; env?: { [key: string]: string } } = {}
-): Promise<void> {
-    let logMessage = "> " + command;
-    if (args.length > 0) {
-        logMessage += " " + args.join(" ");
-    }
-    console.log(logMessage + "\n");
-    return new Promise<void>((resolve, reject) => {
-        const childProcess = spawn(command, args, { stdio: "inherit", ...options });
-        childProcess.once("error", reject);
-        childProcess.once("close", (code, signal) => {
-            if (signal !== null) {
-                reject(new Error(`Process exited due to signal '${signal}'`));
-            } else if (code !== 0) {
-                reject(new Error(`Process exited with code ${code}`));
-            } else {
-                resolve();
-            }
-            console.log("");
-        });
-    });
 }
 
 (async () => {


### PR DESCRIPTION
Update the `preview-package` script to generate a pre-release package with one minor version greater than the current version from the `package.json` and a patch number set to today's date formatted as `YYYYMMddhhmm`. The nightly CI will now generate both a release and pre-release extension VSIX. This enables us to create a pre-release version of the Swift extension.

Going forward, we'll have to abide by the following rules in order for this to work:

1. The version in the `package.json` should always be the current release version of the extension as published on the VS Code marketplace.
2. Always use even numbered minor versions for releases. Pre-release builds will then always have an odd minor version.

I've added a check in CI to enforce even numbered minor versions in the `package.json`.