### PR TITLE
Cherry pick changelog from release/2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.2 - 2025-02-20
+
+### Fixed
+
+- Fix debugging of Swift tests when using Xcode 16.1 Beta ([#1396](https://github.com/swiftlang/vscode-swift/pull/1396))
+
 ## 2.0.1 - 2025-02-10
 
 Rename the `displayName` of the extension back to `Swift` now that the old `sswg` extension has been renamed to `Swift (Deprecated)`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swift-vscode",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swift-vscode",
-      "version": "2.1.0",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "dependencies": {
         "@vscode/codicons": "^0.0.36",


### PR DESCRIPTION
The changelog on main doesn't include the 2.0.2 release.