### PR TITLE
Show error message in project panel when manifest can't be built

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as path from "path";
 import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
 import { PackageNode } from "./ui/ProjectPanelProvider";
@@ -93,6 +94,7 @@ export enum Commands {
     RUN_ALL_TESTS_PARALLEL = "swift.runAllTestsParallel",
     DEBUG_ALL_TESTS = "swift.debugAllTests",
     COVER_ALL_TESTS = "swift.coverAllTests",
+    OPEN_MANIFEST = "swift.openManifest",
 }
 
 /**
@@ -209,6 +211,10 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         vscode.commands.registerCommand("swift.openEducationalNote", uri =>
             openEducationalNote(uri)
         ),
+        vscode.commands.registerCommand(Commands.OPEN_MANIFEST, (uri: vscode.Uri) => {
+            const packagePath = path.join(uri.fsPath, "Package.swift");
+            vscode.commands.executeCommand("vscode.open", vscode.Uri.file(packagePath));
+        }),
     ];
 }
 

--- a/test/integration-tests/ui/ProjectPanelProvider.test.ts
+++ b/test/integration-tests/ui/ProjectPanelProvider.test.ts
@@ -282,6 +282,15 @@ suite("ProjectPanelProvider Test Suite", function () {
             expect(items.find(n => n.name === "swift-markdown")).to.not.be.undefined;
             expect(items.find(n => n.name === "defaultpackage")).to.not.be.undefined;
         });
+
+        test("Shows an error node when there is a problem compiling Package.swift", async () => {
+            workspaceContext.folders[0].hasResolveErrors = true;
+            workspaceContext.currentFolder = workspaceContext.folders[0];
+            const treeProvider = new ProjectPanelProvider(workspaceContext);
+            const children = await treeProvider.getChildren();
+            const errorNode = children.find(n => n.name === "Error Parsing Package.swift");
+            expect(errorNode).to.not.be.undefined;
+        });
     });
 
     async function getHeaderChildren(headerName: string) {


### PR DESCRIPTION
Because we use `swift package describe` to extract metadata about the package we need the Package.swift to be buildable. If it isn't, create a header node in the project panel that calls out the fact that the Package.swift can't be built. Clicking it will take the user to the Package.swift.