### PR TITLE
Show all task types in project panel

### DIFF
--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -523,7 +523,6 @@ export class ProjectPanelProvider implements vscode.TreeDataProvider<TreeNode> {
                 // Plugin tasks are shown under the Commands header
                 .filter(
                     task =>
-                        task.definition.type === "swift" &&
                         task.definition.cwd === folderContext.folder.fsPath &&
                         task.source !== "swift-plugin"
                 )


### PR DESCRIPTION
If users want to have non-Swift task types in their package they should be able to.