### PR TITLE
Shorten pre-release version number

### DIFF
--- a/scripts/preview_package.ts
+++ b/scripts/preview_package.ts
@@ -16,7 +16,7 @@
 import { exec, getExtensionVersion, getRootDirectory, main } from "./lib/utilities";
 
 /**
- * Formats the given date as a string in the form "YYYYMMddhhmm".
+ * Formats the given date as a string in the form "YYYYMMdd".
  *
  * @param date The date to format as a string.
  * @returns The formatted date.
@@ -25,9 +25,7 @@ function formatDate(date: Date): string {
     const year = date.getUTCFullYear().toString().padStart(4, "0");
     const month = (date.getUTCMonth() + 1).toString().padStart(2, "0");
     const day = date.getUTCDate().toString().padStart(2, "0");
-    const hour = date.getUTCHours().toString().padStart(2, "0");
-    const minutes = date.getUTCMinutes().toString().padStart(2, "0");
-    return year + month + day + hour + minutes;
+    return year + month + day;
 }
 
 main(async () => {


### PR DESCRIPTION
VSCode only allows the patch version number to be between 0 and 2,147,483,647. The full date and time is not possible to fit into this value. Instead, we will now just do `YYYYMMdd` which will only allow us to publish daily builds. We could tack on a build number from 0-99 in the future like the Python extension if we ever need more than one build per day.

![Screenshot 2025-03-21 at 11 13 47 AM](https://github.com/user-attachments/assets/84e35436-d4f9-47aa-babd-03fd6f6f9ecb)
