### PR TITLE
Use `synchronize-request` in LSP tests on 6.2

### DIFF
--- a/test/integration-tests/language/LanguageClientIntegration.test.ts
+++ b/test/integration-tests/language/LanguageClientIntegration.test.ts
@@ -20,7 +20,11 @@ import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { testAssetUri } from "../../fixtures";
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities/tasks";
 import { getBuildAllTask, SwiftTask } from "../../../src/tasks/SwiftTaskProvider";
-import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
+import {
+    activateExtensionForSuite,
+    folderInRootWorkspace,
+    updateSettings,
+} from "../utilities/testutilities";
 import { waitForClientState, waitForIndex } from "../utilities/lsputilities";
 
 async function buildProject(ctx: WorkspaceContext, name: string) {
@@ -42,11 +46,22 @@ suite("Language Client Integration Suite @slow", function () {
         async setup(ctx) {
             workspaceContext = ctx;
 
+            const resetSettings = await updateSettings({
+                "swift.sourcekit-lsp.serverArguments": [
+                    "--experimental-feature",
+                    "synchronize-request",
+                ],
+            });
+
+            // Restart the LSP after changing its settings
+            await ctx.languageClientManager.restart();
+
             await buildProject(ctx, "defaultPackage");
 
             // Ensure lsp client is ready
             clientManager = ctx.languageClientManager;
             await waitForClientState(clientManager, langclient.State.Running);
+            return resetSettings;
         },
     });
 

--- a/test/integration-tests/utilities/lsputilities.ts
+++ b/test/integration-tests/utilities/lsputilities.ts
@@ -15,6 +15,7 @@
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 import { LanguageClientManager } from "../../../src/sourcekit-lsp/LanguageClientManager";
+import { Version } from "../../../src/utilities/version";
 
 export async function waitForClient<Result>(
     languageClientManager: LanguageClientManager,
@@ -41,10 +42,34 @@ export namespace PollIndexRequest {
     export const type = new langclient.RequestType<object, object, never>(method);
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace WorkspaceSynchronizeRequest {
+    export const method = "workspace/_synchronize" as const;
+    export const messageDirection: langclient.MessageDirection =
+        langclient.MessageDirection.clientToServer;
+    export const type = new langclient.RequestType<object, object, never>(method);
+}
+
 export async function waitForIndex(languageClientManager: LanguageClientManager): Promise<void> {
-    await languageClientManager.useLanguageClient(async (client, token) =>
-        client.sendRequest(PollIndexRequest.type, {}, token)
-    );
+    if (
+        languageClientManager.workspaceContext.swiftVersion.isGreaterThanOrEqual(
+            new Version(6, 2, 0)
+        )
+    ) {
+        await languageClientManager.useLanguageClient(async (client, token) =>
+            client.sendRequest(
+                WorkspaceSynchronizeRequest.type,
+                {
+                    index: true,
+                },
+                token
+            )
+        );
+    } else {
+        await languageClientManager.useLanguageClient(async (client, token) =>
+            client.sendRequest(PollIndexRequest.type, {}, token)
+        );
+    }
 }
 
 export async function waitForClientState(


### PR DESCRIPTION
The tests used `workspace/_pollIndex` to determine if sourcekit-lsp had finished indexing, however this hidden request was removed from sourcekit-lsp recently in favour of `workspace/_synchronize`

Issue: #1457