### PR TITLE
Resolve session promise on test run cancellation

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -776,6 +776,7 @@ export class TestRunner {
             // If the test run is iterrupted by a cancellation request from VS Code, ensure the task is terminated.
             const cancellationDisposable = this.testRun.token.onCancellationRequested(() => {
                 task.execution.terminate("SIGINT");
+                reject("Test run cancelled");
             });
 
             task.execution.onDidClose(code => {


### PR DESCRIPTION
When running a standard test session (not debugging) the xctest process was terminated when the user hit the cancel test button, but the promise to continue and mark the test run as ended was not resolved. This kept the UI in a state that looked like the test was still running.