### PR TITLE
Ensure only one reload extension dialog can be shown at a time

### DIFF
--- a/src/ui/ReloadExtension.ts
+++ b/src/ui/ReloadExtension.ts
@@ -14,23 +14,49 @@
 
 import * as vscode from "vscode";
 import { Workbench } from "../utilities/commands";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import debounce = require("lodash.debounce");
 
 /**
  * Prompts the user to reload the extension in cases where we are unable to do
- * so automatically.
+ * so automatically. Only one of these prompts will be shown at a time.
  *
  * @param message the warning message to display to the user
  * @param items extra buttons to display
  * @returns the selected button or undefined if cancelled
  */
-export async function showReloadExtensionNotification<T extends string>(
-    message: string,
-    ...items: T[]
-): Promise<"Reload Extensions" | T | undefined> {
-    const buttons: ("Reload Extensions" | T)[] = ["Reload Extensions", ...items];
-    const selected = await vscode.window.showWarningMessage(message, ...buttons);
-    if (selected === "Reload Extensions") {
-        await vscode.commands.executeCommand(Workbench.ACTION_RELOADWINDOW);
-    }
-    return selected;
+export function showReloadExtensionNotificationInstance<T extends string>() {
+    let inFlight: Promise<"Reload Extensions" | T | undefined> | null = null;
+
+    return async function (
+        message: string,
+        ...items: T[]
+    ): Promise<"Reload Extensions" | T | undefined> {
+        if (inFlight) {
+            return inFlight;
+        }
+
+        const buttons: ("Reload Extensions" | T)[] = ["Reload Extensions", ...items];
+        inFlight = (async () => {
+            try {
+                const selected = await vscode.window.showWarningMessage(message, ...buttons);
+                if (selected === "Reload Extensions") {
+                    await vscode.commands.executeCommand(Workbench.ACTION_RELOADWINDOW);
+                }
+                return selected;
+            } finally {
+                inFlight = null;
+            }
+        })();
+
+        return inFlight;
+    };
 }
+
+// In case the user closes the dialog immediately we want to debounce showing it again
+// for 10 seconds to prevent another popup perhaps immediately appearing.
+export const showReloadExtensionNotification = debounce(
+    showReloadExtensionNotificationInstance(),
+    10_000,
+    { leading: true }
+);


### PR DESCRIPTION
If `showReloadExtensionNotification` is in flight and being awaited then return the promise being awaited instead of showing another dialog.

Also, debounce `showReloadExtensionNotification` with a 5 second window because its possible for users to close the first dialog very fast and have another one appear immediately if we update several settings at a time that require an extension restart.

Issue: #1471