### PR TITLE
Generate dev-package version number from the version in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1637,7 +1637,7 @@
     "coverage": "npm test -- --coverage",
     "compile-tests": "del-cli ./assets/test/**/.build && npm run compile",
     "package": "vsce package",
-    "dev-package": "vsce package --no-update-package-json 2.1.0-dev",
+    "dev-package": "tsx ./scripts/dev_package.ts",
     "preview-package": "tsx ./scripts/preview_package.ts",
     "tag": "./scripts/tag_release.sh $npm_package_version",
     "contributors": "./scripts/generate_contributors_list.sh"

--- a/scripts/dev_package.ts
+++ b/scripts/dev_package.ts
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+/* eslint-disable no-console */
+
+import { exec, getExtensionVersion, getRootDirectory, main } from "./lib/utilities";
+
+main(async () => {
+    const rootDirectory = getRootDirectory();
+    const version = await getExtensionVersion();
+    // Increment the patch version from the package.json
+    const patch = version.patch + 1;
+    const devVersion = `${version.major}.${version.minor}.${patch}-dev`;
+    // Use VSCE to package the extension
+    await exec("npx", ["vsce", "package", "--no-update-package-json", devVersion], {
+        cwd: rootDirectory,
+    });
+});


### PR DESCRIPTION
Reduce the number of locations where we need to update a version number on release by having the `dev-package` script generate its version info much like `preview-package` does. In this case the development VSIX will just increment the patch version from the package.json.