### PR TITLE
feat: secondary quick pick for selecting Swift Version with `runSwiftScript` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,6 +324,19 @@
             },
             "markdownDescription": "Additional arguments to pass to `swift build` and `swift test`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propagated to that task."
           },
+          "swift.script.defaultSwiftVersion": {
+            "type": "number",
+            "default": null,
+            "description": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",
+            "enum": [
+              5,
+              6
+            ],
+            "enumDescriptions": [
+              "Swift 5",
+              "Swift 6"
+            ]
+          },
           "swift.packageArguments": {
             "type": "array",
             "default": [],

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
             },
             "markdownDescription": "Additional arguments to pass to `swift build` and `swift test`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propagated to that task."
           },
-          "swift.script.defaultSwiftVersion": {
+          "swift.defaultSwiftVersion": {
             "type": "number",
             "default": null,
             "description": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",

--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
             },
             "markdownDescription": "Additional arguments to pass to `swift build` and `swift test`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propagated to that task."
           },
-          "swift.defaultSwiftVersion": {
+          "swift.scriptSwiftLanguageVersion": {
             "type": [
               "number",
               null

--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
               "Prompt to select the Swift version each time a script is run."
             ],
             "default": "6",
-            "markdownDescription": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",
+            "markdownDescription": "The default Swift version to use when running Swift scripts.",
             "scope": "machine-overridable"
           },
           "swift.packageArguments": {

--- a/package.json
+++ b/package.json
@@ -325,11 +325,18 @@
             "markdownDescription": "Additional arguments to pass to `swift build` and `swift test`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propagated to that task."
           },
           "swift.scriptSwiftLanguageVersion": {
-            "type": [
-              "number",
-              null
+            "type": "string",
+            "enum": [
+              "6",
+              "5",
+              "Ask Every Run"
             ],
-            "default": null,
+            "enumDescriptions": [
+              "Use Swift 6 when running Swift scripts.",
+              "Use Swift 5 when running Swift scripts.",
+              "Prompt to select the Swift version each time a script is run."
+            ],
+            "default": "6",
             "markdownDescription": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",
             "scope": "machine-overridable"
           },

--- a/package.json
+++ b/package.json
@@ -325,17 +325,13 @@
             "markdownDescription": "Additional arguments to pass to `swift build` and `swift test`. Keys and values should be provided as individual entries in the list. If you have created a copy of the build task in `tasks.json` then these build arguments will not be propagated to that task."
           },
           "swift.defaultSwiftVersion": {
-            "type": "number",
+            "type": [
+              "number",
+              null
+            ],
             "default": null,
             "markdownDescription": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",
-            "enum": [
-              5,
-              6
-            ],
-            "enumDescriptions": [
-              "Swift 5",
-              "Swift 6"
-            ]
+            "scope": "machine-overridable"
           },
           "swift.packageArguments": {
             "type": "array",

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
           "swift.defaultSwiftVersion": {
             "type": "number",
             "default": null,
-            "description": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",
+            "markdownDescription": "The default Swift version to use when running Swift scripts. If set, skips the version selection dialog.",
             "enum": [
               5,
               6

--- a/src/commands/runSwiftScript.ts
+++ b/src/commands/runSwiftScript.ts
@@ -41,17 +41,17 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
         return;
     }
 
-    let target: number;
+    let target: string;
 
     const defaultVersion = configuration.scriptSwiftLanguageVersion;
-    if (defaultVersion !== undefined && defaultVersion !== null) {
+    if (defaultVersion !== "") {
         target = defaultVersion;
     } else {
         const picked = await vscode.window.showQuickPick(
             [
                 // Potentially add more versions here
-                { value: 5, label: "Swift 5" },
-                { value: 6, label: "Swift 6" },
+                { value: "5", label: "Swift 5" },
+                { value: "6", label: "Swift 6" },
             ],
             {
                 placeHolder: "Select a target Swift version",
@@ -77,7 +77,7 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
         await document.save();
     }
     const runTask = createSwiftTask(
-        ["-swift-version", target.toString(), filename],
+        ["-swift-version", target, filename],
         `Run ${filename}`,
         {
             scope: vscode.TaskScope.Global,

--- a/src/commands/runSwiftScript.ts
+++ b/src/commands/runSwiftScript.ts
@@ -44,9 +44,7 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
     let target: string;
 
     const defaultVersion = configuration.scriptSwiftLanguageVersion;
-    if (defaultVersion !== "") {
-        target = defaultVersion;
-    } else {
+    if (defaultVersion === "Ask Every Run") {
         const picked = await vscode.window.showQuickPick(
             [
                 // Potentially add more versions here
@@ -62,6 +60,8 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
             return;
         }
         target = picked.value;
+    } else {
+        target = defaultVersion;
     }
 
     let filename = document.fileName;

--- a/src/commands/runSwiftScript.ts
+++ b/src/commands/runSwiftScript.ts
@@ -44,7 +44,7 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
     let target: number;
 
     const defaultVersion = configuration.defaultSwiftVersion;
-    if (defaultVersion !== undefined) {
+    if (defaultVersion !== undefined && defaultVersion !== null) {
         target = defaultVersion;
     } else {
         const picked = await vscode.window.showQuickPick(

--- a/src/commands/runSwiftScript.ts
+++ b/src/commands/runSwiftScript.ts
@@ -42,7 +42,7 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
 
     const picked = await vscode.window.showQuickPick(
         [
-            // Potnetially add more versions here
+            // Potentially add more versions here
             { value: 5, label: "Swift 5" },
             { value: 6, label: "Swift 6" },
         ],

--- a/src/commands/runSwiftScript.ts
+++ b/src/commands/runSwiftScript.ts
@@ -43,7 +43,7 @@ export async function runSwiftScript(ctx: WorkspaceContext) {
 
     let target: number;
 
-    const defaultVersion = configuration.defaultSwiftVersion;
+    const defaultVersion = configuration.scriptSwiftLanguageVersion;
     if (defaultVersion !== undefined && defaultVersion !== null) {
         target = defaultVersion;
     } else {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -329,7 +329,7 @@ const configuration = {
             .map(substituteVariablesInString);
     },
     get defaultSwiftVersion(): number | undefined {
-        return vscode.workspace.getConfiguration("swift").get<number>("script.defaultSwiftVersion");
+        return vscode.workspace.getConfiguration("swift").get<number>("defaultSwiftVersion");
     },
     /** swift package arguments */
     get packageArguments(): string[] {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -328,6 +328,9 @@ const configuration = {
             .get<string[]>("buildArguments", [])
             .map(substituteVariablesInString);
     },
+    get defaultSwiftVersion(): number | undefined {
+        return vscode.workspace.getConfiguration("swift").get<number>("script.defaultSwiftVersion");
+    },
     /** swift package arguments */
     get packageArguments(): string[] {
         return vscode.workspace

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -331,7 +331,7 @@ const configuration = {
     get scriptSwiftLanguageVersion(): string {
         return vscode.workspace
             .getConfiguration("swift")
-            .get<string>("scriptSwiftLanguageVersion", "");
+            .get<string>("scriptSwiftLanguageVersion", "6");
     },
     /** swift package arguments */
     get packageArguments(): string[] {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -328,8 +328,8 @@ const configuration = {
             .get<string[]>("buildArguments", [])
             .map(substituteVariablesInString);
     },
-    get defaultSwiftVersion(): number | undefined {
-        return vscode.workspace.getConfiguration("swift").get<number>("defaultSwiftVersion");
+    get scriptSwiftLanguageVersion(): number | undefined {
+        return vscode.workspace.getConfiguration("swift").get<number>("scriptSwiftLanguageVersion");
     },
     /** swift package arguments */
     get packageArguments(): string[] {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -328,8 +328,10 @@ const configuration = {
             .get<string[]>("buildArguments", [])
             .map(substituteVariablesInString);
     },
-    get scriptSwiftLanguageVersion(): number | undefined {
-        return vscode.workspace.getConfiguration("swift").get<number>("scriptSwiftLanguageVersion");
+    get scriptSwiftLanguageVersion(): string {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<string>("scriptSwiftLanguageVersion", "");
     },
     /** swift package arguments */
     get packageArguments(): string[] {


### PR DESCRIPTION
This PR tries to implement a secondary quick pick for selecting desired Swift Version for `Run Swift Script` command, and also enabling global settings for it in vscode workspace.
- Fixes  #1427 