### PR TITLE
Release activities for 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.2.0 - 2025-04-07
+
+### Added
+
+- Convert the Dependencies View into the Project Panel to view all aspects of your Swift project ([#1382](https://github.com/swiftlang/vscode-swift/pull/1382))
+- Use the LLDB DAP extension to debug when using a Swift 6 toolchain ([#1384](https://github.com/swiftlang/vscode-swift/pull/1384))
+- Added run and debug buttons to Swift editors ([#1378](https://github.com/swiftlang/vscode-swift/pull/1378))
+- Educational notes from compiler diagnostics can be viewed directly in VS Code ([#1423](https://github.com/swiftlang/vscode-swift/pull/1423))
+- Swift settings now support variable substitutions ([#1439](https://github.com/swiftlang/vscode-swift/pull/1439))
+- SwiftPM plugin tasks are now configurable via settings ([#1409](https://github.com/swiftlang/vscode-swift/pull/1409))
+
+### Fixed
+
+- Prevent duplicate reload extension notifications from appearing ([#1473](https://github.com/swiftlang/vscode-swift/pull/1473))
+- "Actual" and "Expected" values are shown in the right order on test failure ([#1444](https://github.com/swiftlang/vscode-swift/issues/1444))
+- Correctly set the `DEVELOPER_DIR` environment variable when selecting between two Xcode installs ([#1433](https://github.com/swiftlang/vscode-swift/pull/1433))
+- Prompt to reload the extension when swiftEnvironmentVariables is changed ([#1430](https://github.com/swiftlang/vscode-swift/pull/1430))
+- Search for Swift packages in sub-folders of the workspace ([#1425](https://github.com/swiftlang/vscode-swift/pull/1425))
+- Fix missing test result output on Linux when using print ([#1401](https://github.com/swiftlang/vscode-swift/pull/1401))
+- Stop all actively running tests when stop button is pressed ([#1391](https://github.com/swiftlang/vscode-swift/pull/1391))
+- Properly set `--swift-sdk` when using `Swift: Select Target Platform` on Swift 6.1 ([#1390](https://github.com/swiftlang/vscode-swift/pull/1390))
+
 ## 2.0.2 - 2025-02-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Educational notes from compiler diagnostics can be viewed directly in VS Code ([#1423](https://github.com/swiftlang/vscode-swift/pull/1423))
 - Swift settings now support variable substitutions ([#1439](https://github.com/swiftlang/vscode-swift/pull/1439))
 - SwiftPM plugin tasks are now configurable via settings ([#1409](https://github.com/swiftlang/vscode-swift/pull/1409))
+- Added the `swift.scriptSwiftLanguageVersion` setting to choose Swift language mode when running scripts (thanks @louisunlimited) ([#1476](https://github.com/swiftlang/vscode-swift/pull/1476))
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swift-vscode",
-  "version": "2.0.2",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swift-vscode",
-      "version": "2.0.2",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@vscode/codicons": "^0.0.36",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swift-vscode",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
-  "version": "2.0.2",
+  "version": "2.2.0",
   "publisher": "swiftlang",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
- Bump version number to 2.2.0 in the `package.json`
- Update change log