### PR TITLE
Support finding compile_commands.json in non root project directories

### DIFF
--- a/src/utilities/workspace.ts
+++ b/src/utilities/workspace.ts
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as path from "path";
 import * as vscode from "vscode";
 import { pathExists } from "./filesystem";
 
@@ -55,27 +54,12 @@ export async function isValidWorkspaceFolder(
     folder: string,
     disableSwiftPMIntegration: boolean
 ): Promise<boolean> {
-    async function findInSubdirectories(folder: string, fileName: string): Promise<boolean> {
-        const entries = await vscode.workspace.fs.readDirectory(vscode.Uri.file(folder));
-        for (const [entryName, entryType] of entries) {
-            if (entryType === vscode.FileType.File && entryName === fileName) {
-                return true;
-            }
-            if (entryType === vscode.FileType.Directory && entryName[0] !== ".") {
-                const found = await findInSubdirectories(path.join(folder, entryName), fileName);
-                if (found) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     return (
         (!disableSwiftPMIntegration && (await pathExists(folder, "Package.swift"))) ||
         (await pathExists(folder, "compile_commands.json")) ||
-        (await findInSubdirectories(folder, "compile_commands.json")) ||
         (await pathExists(folder, "compile_flags.txt")) ||
-        (await pathExists(folder, "buildServer.json"))
+        (await pathExists(folder, "buildServer.json")) ||
+        (await pathExists(folder, "build")) ||
+        (await pathExists(folder, "out"))
     );
 }


### PR DESCRIPTION
Before: focus: undefined

After: 
```
19:13:49: Activating Swift for Visual Studio Code...
19:13:50: SourceKit-LSP setup
19:13:51: swift-data: add: /Users/chase/dev/swift-data
19:13:51: swift-data: focus: /Users/chase/dev/swift-data
```

Fix #1449 