### PR TITLE
Fix potential error when no toolchain found

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
                 outputChannel,
                 activate: () => activate(context),
                 deactivate: async () => {
-                    await workspaceContext.stop();
                     await deactivate(context);
                 },
             };


### PR DESCRIPTION
If there is no toolchain available we short circuit extension activation but still try and stop the workspace, which hasn't been created.