### PR TITLE
Run windows tests directly in same shell

### DIFF
--- a/scripts/test_windows.ps1
+++ b/scripts/test_windows.ps1
@@ -64,10 +64,10 @@ npm ci -ignore-script node-pty
 npm run lint
 npm run format
 npm run package
-$Process = Start-Process npm "run integration-test" -Wait -PassThru -NoNewWindow
-if ($Process.ExitCode -eq 0) {
+npm run integration-test
+if ($LASTEXITCODE -eq 0) {
     Write-Host 'SUCCESS'
 } else {
-    Write-Host  ('FAILED ({0})' -f $Process.ExitCode)
+    Write-Host ('FAILED ({0})' -f $LASTEXITCODE)
     exit 1
 }


### PR DESCRIPTION
Occasionally the Windows tests will hang after all tests have completed until the GitHub action times out. Using `Start-Process` with the `-Wait` flag will wait for the process and all of its child processes to terminate. This means that if the VS Code instance under test has any lingering processes the build may hang forever.

Instead run the test command directly, referencing the success status with `$LASTEXITCODE`. This should hopefully report the status more reliably without hanging.