### PR TITLE
Cleanup extension activation

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -183,6 +183,8 @@ export class WorkspaceContext implements vscode.Disposable {
             this.buildStatus,
         ];
         this.lastFocusUri = vscode.window.activeTextEditor?.document.uri;
+
+        this.setupEventListeners();
     }
 
     async stop() {
@@ -278,7 +280,7 @@ export class WorkspaceContext implements vscode.Disposable {
     }
 
     /** Setup the vscode event listeners to catch folder changes and active window changes */
-    setupEventListeners() {
+    private setupEventListeners() {
         // add event listener for when a workspace folder is added/removed
         const onWorkspaceChange = vscode.workspace.onDidChangeWorkspaceFolders(event => {
             if (this === undefined) {

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import { Version } from "./utilities/version";
 
 /**
  * References:
@@ -82,6 +83,11 @@ interface ContextKeys {
      * Whether the swift.switchPlatform command is available.
      */
     switchPlatformAvailable: boolean;
+
+    /**
+     * Sets values for context keys that are enabled/disabled based on the toolchain version in use.
+     */
+    updateKeysBasedOnActiveVersion(toolchainVersion: Version): void;
 }
 
 /** Creates the getters and setters for the VS Code Swift extension's context keys. */
@@ -100,6 +106,15 @@ function createContextKeys(): ContextKeys {
     let switchPlatformAvailable: boolean = false;
 
     return {
+        updateKeysBasedOnActiveVersion(toolchainVersion: Version) {
+            this.createNewProjectAvailable = toolchainVersion.isGreaterThanOrEqual(
+                new Version(5, 8, 0)
+            );
+            this.switchPlatformAvailable = toolchainVersion.isGreaterThanOrEqual(
+                new Version(6, 1, 0)
+            );
+        },
+
         get isActivated() {
             return isActivated;
         },

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -271,4 +271,13 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         }
         return args;
     }
+
+    /**
+     * Registers the Swift plugin task provider with VS Code.
+     * @param ctx The workspace context.
+     * @returns A disposable that unregisters the provider when disposed.
+     */
+    public static register(ctx: WorkspaceContext): vscode.Disposable {
+        return vscode.tasks.registerTaskProvider("swift-plugin", new SwiftPluginTaskProvider(ctx));
+    }
 }

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -464,4 +464,13 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
 
         return newTask;
     }
+
+    /**
+     * Registers the Swift task provider with VS Code.
+     * @param ctx The workspace context.
+     * @returns A disposable that unregisters the provider when disposed.
+     */
+    public static register(ctx: WorkspaceContext): vscode.Disposable {
+        return vscode.tasks.registerTaskProvider("swift", new SwiftTaskProvider(ctx));
+    }
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -92,4 +92,15 @@ export class SwiftTerminalProfileProvider implements vscode.TerminalProfileProvi
             env,
         });
     }
+
+    /**
+     * Registers the Swift terminal profile provider with VS Code.
+     * @returns A disposable that unregisters the provider when disposed.
+     */
+    public static register(): vscode.Disposable {
+        return vscode.window.registerTerminalProfileProvider(
+            "swift.terminalProfile",
+            new SwiftTerminalProfileProvider()
+        );
+    }
 }


### PR DESCRIPTION
Refactor the extension activation method such that it only starts up the necessary services and registers their disposables for extension deactivation. The startup order of services has been tweaked slightly so that it will fail fast if the toolchain is not configured properly. Fixes a few services that were registred for disposal twice.

Fixes up `registerDebugger` so that toggling the setting works immediately instead of silently requiring an extension restart before taking effect.