### PR TITLE
Enable unit tests on Windows

### DIFF
--- a/scripts/test_windows.ps1
+++ b/scripts/test_windows.ps1
@@ -64,7 +64,7 @@ npm ci -ignore-script node-pty
 npm run lint
 npm run format
 npm run package
-npm run integration-test
+npm run test
 if ($LASTEXITCODE -eq 0) {
     Write-Host 'SUCCESS'
 } else {

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
+import * as path from "path";
 import { expect } from "chai";
 import { match } from "sinon";
 import { FolderEvent, FolderOperation, WorkspaceContext } from "../../../src/WorkspaceContext";
@@ -301,7 +302,7 @@ suite("LanguageClientManager Suite", () => {
             DidChangeWorkspaceFoldersNotification.type,
             {
                 event: {
-                    added: [{ name: "folder1", uri: "/folder1" }],
+                    added: [{ name: "folder1", uri: path.normalize("/folder1") }],
                     removed: [],
                 },
             } as DidChangeWorkspaceFoldersParams
@@ -320,7 +321,7 @@ suite("LanguageClientManager Suite", () => {
             DidChangeWorkspaceFoldersNotification.type,
             {
                 event: {
-                    added: [{ name: "folder2", uri: "/folder2" }],
+                    added: [{ name: "folder2", uri: path.normalize("/folder2") }],
                     removed: [],
                 },
             } as DidChangeWorkspaceFoldersParams
@@ -340,7 +341,7 @@ suite("LanguageClientManager Suite", () => {
             {
                 event: {
                     added: [],
-                    removed: [{ name: "folder1", uri: "/folder1" }],
+                    removed: [{ name: "folder1", uri: path.normalize("/folder1") }],
                 },
             } as DidChangeWorkspaceFoldersParams
         );
@@ -472,7 +473,7 @@ suite("LanguageClientManager Suite", () => {
                 DidChangeActiveDocumentNotification.method,
                 {
                     textDocument: {
-                        uri: "/folder1/file.swift",
+                        uri: path.normalize("/folder1/file.swift"),
                     },
                 } as DidChangeActiveDocumentParams
             );
@@ -501,7 +502,7 @@ suite("LanguageClientManager Suite", () => {
                 DidChangeActiveDocumentNotification.method,
                 {
                     textDocument: {
-                        uri: "/folder1/file.swift",
+                        uri: path.normalize("/folder1/file.swift"),
                     },
                 } as DidChangeActiveDocumentParams
             );

--- a/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import * as assert from "assert";
+import * as path from "path";
 import { match } from "sinon";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftPluginTaskProvider } from "../../../src/tasks/SwiftPluginTaskProvider";
@@ -148,7 +149,10 @@ suite("SwiftPluginTaskProvider Unit Test Suite", () => {
                 new vscode.CancellationTokenSource().token
             );
             const swiftExecution = resolvedTask.execution as SwiftExecution;
-            assert.equal(swiftExecution.options.cwd, `${workspaceFolder.uri.fsPath}/myCWD`);
+            assert.equal(
+                swiftExecution.options.cwd,
+                path.normalize(`${workspaceFolder.uri.fsPath}/myCWD`)
+            );
         });
 
         test("includes fallback cwd", async () => {

--- a/test/unit-tests/toolchain/BuildFlags.test.ts
+++ b/test/unit-tests/toolchain/BuildFlags.test.ts
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as path from "path";
 import { expect } from "chai";
 import { DarwinCompatibleTarget, SwiftToolchain } from "../../../src/toolchain/toolchain";
 import { ArgumentFilter, BuildFlags } from "../../../src/toolchain/BuildFlags";
@@ -204,35 +205,41 @@ suite("BuildFlags Test Suite", () => {
 
             expect(
                 BuildFlags.buildDirectoryFromWorkspacePath("/some/full/workspace/test/path", false)
-            ).to.equal(".build");
+            ).to.equal(path.normalize(".build"));
 
             expect(
                 BuildFlags.buildDirectoryFromWorkspacePath("/some/full/workspace/test/path", true)
-            ).to.equal("/some/full/workspace/test/path/.build");
+            ).to.equal(path.normalize("/some/full/workspace/test/path/.build"));
         });
 
         test("absolute configuration provided", () => {
-            buildPathConfig.setValue("/some/other/full/test/path");
+            buildPathConfig.setValue(path.normalize("/some/other/full/test/path"));
 
             expect(
-                BuildFlags.buildDirectoryFromWorkspacePath("/some/full/workspace/test/path", false)
-            ).to.equal("/some/other/full/test/path");
+                BuildFlags.buildDirectoryFromWorkspacePath(
+                    path.normalize("/some/full/workspace/test/path"),
+                    false
+                )
+            ).to.equal(path.normalize("/some/other/full/test/path"));
 
             expect(
-                BuildFlags.buildDirectoryFromWorkspacePath("/some/full/workspace/test/path", true)
-            ).to.equal("/some/other/full/test/path");
+                BuildFlags.buildDirectoryFromWorkspacePath(
+                    path.normalize("/some/full/workspace/test/path"),
+                    true
+                )
+            ).to.equal(path.normalize("/some/other/full/test/path"));
         });
 
         test("relative configuration provided", () => {
-            buildPathConfig.setValue("some/relative/test/path");
+            buildPathConfig.setValue(path.normalize("some/relative/test/path"));
 
             expect(
                 BuildFlags.buildDirectoryFromWorkspacePath("/some/full/workspace/test/path", false)
-            ).to.equal("some/relative/test/path");
+            ).to.equal(path.normalize("some/relative/test/path"));
 
             expect(
                 BuildFlags.buildDirectoryFromWorkspacePath("/some/full/workspace/test/path", true)
-            ).to.equal("/some/full/workspace/test/path/some/relative/test/path");
+            ).to.equal(path.normalize("/some/full/workspace/test/path/some/relative/test/path"));
         });
     });
 

--- a/test/unit-tests/toolchain/toolchain.test.ts
+++ b/test/unit-tests/toolchain/toolchain.test.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import { expect } from "chai";
+import * as path from "path";
 import * as mockFS from "mock-fs";
 import * as utilities from "../../../src/utilities/utilities";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
@@ -78,7 +79,9 @@ suite("SwiftToolchain Unit Test Suite", () => {
                 });
 
                 await expect(sut.getLLDBDebugAdapter()).to.eventually.equal(
-                    "/Library/Developer/Toolchains/swift-6.0.1-RELEASE.xctoolchain/usr/bin/lldb-dap"
+                    path.normalize(
+                        "/Library/Developer/Toolchains/swift-6.0.1-RELEASE.xctoolchain/usr/bin/lldb-dap"
+                    )
                 );
             });
 
@@ -174,7 +177,7 @@ suite("SwiftToolchain Unit Test Suite", () => {
                 });
 
                 await expect(sut.getLLDBDebugAdapter()).to.eventually.equal(
-                    "/toolchains/swift-6.0.0/usr/bin/lldb-dap"
+                    path.normalize("/toolchains/swift-6.0.0/usr/bin/lldb-dap")
                 );
             });
 
@@ -213,7 +216,7 @@ suite("SwiftToolchain Unit Test Suite", () => {
                 });
 
                 await expect(sut.getLLDBDebugAdapter()).to.eventually.equal(
-                    "/toolchains/swift-6.0.0/usr/bin/lldb-dap.exe"
+                    path.normalize("/toolchains/swift-6.0.0/usr/bin/lldb-dap.exe")
                 );
             });
 

--- a/test/unit-tests/ui/PackageDependencyProvider.test.ts
+++ b/test/unit-tests/ui/PackageDependencyProvider.test.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import { expect } from "chai";
+import * as path from "path";
 import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import { FileNode, PackageNode } from "../../../src/ui/ProjectPanelProvider";
@@ -100,13 +101,13 @@ suite("PackageDependencyProvider Unit Test Suite", function () {
             expect(childFiles).to.deep.equal([
                 new FileNode(
                     "file1",
-                    "/path/to/.build/swift-markdown/file1",
+                    path.normalize("/path/to/.build/swift-markdown/file1"),
                     false,
                     "SwiftMarkdown-1.2.3"
                 ),
                 new FileNode(
                     "file2",
-                    "/path/to/.build/swift-markdown/file2",
+                    path.normalize("/path/to/.build/swift-markdown/file2"),
                     false,
                     "SwiftMarkdown-1.2.3"
                 ),

--- a/test/unit-tests/utilities/filesystem.test.ts
+++ b/test/unit-tests/utilities/filesystem.test.ts
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import * as path from "path";
 import { isPathInsidePath, expandFilePathTilde } from "../../../src/utilities/filesystem";
 import { expect } from "chai";
 
@@ -30,7 +31,7 @@ suite("File System Utilities Unit Test Suite", () => {
     suite("expandFilePathTilde", () => {
         test("expands tilde", () => {
             expect(expandFilePathTilde("~/Test", "/Users/John", "darwin")).to.equal(
-                "/Users/John/Test"
+                path.normalize("/Users/John/Test")
             );
         });
 


### PR DESCRIPTION
Only the integration tests were running on Windows in CI. Switch to running `npm run test` which will run both integration and unit tests, and fix path normalization issues that were preventing some tests from passing on Windows.