### PR TITLE
Fail tests if they crash

### DIFF
--- a/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests/PackageTests.swift
@@ -106,16 +106,25 @@ struct MixedSwiftTestingSuite {
   }
   print(string)
 }
-#endif
+
+@Test func testCrashing() throws {
+  print([1,2][3])
+}
 
 // Disabled until Attachments are formalized and released.
 // #if swift(>=6.1)
 // @Test func testAttachment() throws {
 //   Attachment("Hello, world!", named: "hello.txt").attach()
 // }
-// #endif
+#endif
 
 final class DuplicateSuffixTests: XCTestCase {
   func testPassing() throws {}
   func testPassingSuffix() throws {}
+}
+
+final class CrashingXCTests: XCTestCase {
+  func testCrashing() throws {
+    print([1,2][3])
+  }
 }

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -198,8 +198,11 @@ suite("Test Explorer Suite", function () {
                         "testWithKnownIssue()",
                         "testWithKnownIssueAndUnknownIssue()",
                         "testLotsOfOutput()",
+                        "testCrashing()",
                         "DuplicateSuffixTests",
                         ["testPassing()", "testPassingSuffix()"],
+                        "CrashingXCTests",
+                        ["testCrashing()"],
                     ],
                 ]);
             } else if (workspaceContext.swiftVersion.isLessThan(new Version(6, 0, 0))) {
@@ -208,6 +211,8 @@ suite("Test Explorer Suite", function () {
                 assertTestControllerHierarchy(testExplorer.controller, [
                     "PackageTests",
                     [
+                        "CrashingXCTests",
+                        ["testCrashing"],
                         "DebugReleaseTestSuite",
                         ["testDebug", "testRelease"],
                         "DuplicateSuffixTests",
@@ -342,6 +347,23 @@ suite("Test Explorer Suite", function () {
                 });
             });
 
+            test("crashing", async () => {
+                const testRun = await runTest(
+                    testExplorer,
+                    TestKind.standard,
+                    "PackageTests.testCrashing()"
+                );
+
+                assertTestResults(testRun, {
+                    failed: [
+                        {
+                            test: "PackageTests.testCrashing()",
+                            issues: ["Test did not complete."],
+                        },
+                    ],
+                });
+            });
+
             test("tests run in debug mode @slow", async function () {
                 const testRun = await runTest(
                     testExplorer,
@@ -437,6 +459,23 @@ suite("Test Explorer Suite", function () {
                     passed: [
                         "PackageTests.DuplicateSuffixTests",
                         "PackageTests.DuplicateSuffixTests/testPassing",
+                    ],
+                });
+            });
+
+            test("Crashing XCTest", async function () {
+                const crashingRun = await runTest(
+                    testExplorer,
+                    TestKind.standard,
+                    "PackageTests.CrashingXCTests/testCrashing"
+                );
+
+                assertTestResults(crashingRun, {
+                    failed: [
+                        {
+                            test: "PackageTests.CrashingXCTests/testCrashing",
+                            issues: ["Test did not complete."],
+                        },
                     ],
                 });
             });


### PR DESCRIPTION
If a test crashes during a test run the extension never marks the test as failed, since it doesn't see the output that marks the test as completed.

If we finish a test run and we still have a test in the 'pending' state where no pass/fail/skip has been seen, mark the test as failed with a message stating the test never finished.

Issue: #1504