### PR TITLE
Increase the size of child_process buffers

### DIFF
--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -109,6 +109,10 @@ export async function execFile(
             options.env = { ...(options.env ?? process.env), ...runtimeEnv };
         }
     }
+    options = {
+        ...options,
+        maxBuffer: options.maxBuffer ?? 1024 * 1024 * 64, // 64MB
+    };
     return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
         cp.execFile(executable, args, options, (error, stdout, stderr) => {
             if (error) {
@@ -198,6 +202,10 @@ export async function execSwift(
             ...configuration.swiftEnvironmentVariables,
         };
     }
+    options = {
+        ...options,
+        maxBuffer: options.maxBuffer ?? 1024 * 1024 * 64, // 64MB
+    };
     return await execFile(swift, args, options, folderContext);
 }
 


### PR DESCRIPTION
When running `execSwift` or `execFile` it was possible for very large results to exceed the default max buffer size as defined by Node.JS (1MB).

This was happening when initializing a complex package during the `swift package show-dependencies --format json` call, which produced a very large dependency graph.