### PR TITLE
Parse XCTest output anywhere in output lines

### DIFF
--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -38,37 +38,37 @@ enum TestCompletionState {
 /** Regex for parsing darwin XCTest output */
 export const darwinTestRegex = {
     // Regex "Test Case '-[<test target> <class.function>]' started"
-    started: /^Test Case '-\[(\S+)\s(.*)\]' started./,
+    started: /Test Case '-\[(\S+)\s(.*)\]' started\./,
     // Regex "Test Case '-[<test target> <class.function>]' <completion_state> (<duration> seconds)"
-    finished: /^Test Case '-\[(\S+)\s(.*)\]' (.*) \((\d.*) seconds\)/,
+    finished: /Test Case '-\[(\S+)\s(.*)\]' (.*) \((\d.*) seconds\)/,
     // Regex "<path/to/test>:<line number>: error: -[<test target> <class.function>] : <error>"
-    error: /^(.+):(\d+):\serror:\s-\[(\S+)\s(.*)\] : (.*)$/,
+    error: /(.+):(\d+):\serror:\s-\[(\S+)\s(.*)\] : (.*)$/,
     // Regex "<path/to/test>:<line number>: -[<test target> <class.function>] : Test skipped"
-    skipped: /^(.+):(\d+):\s-\[(\S+)\s(.*)\] : Test skipped/,
+    skipped: /(.+):(\d+):\s-\[(\S+)\s(.*)\] : Test skipped/,
     // Regex "Test Suite '<class>' started"
-    startedSuite: /^Test Suite '(.*)' started/,
+    startedSuite: /Test Suite '(.*)' started/,
     // Regex "Test Suite '<class>' passed"
-    passedSuite: /^Test Suite '(.*)' passed/,
+    passedSuite: /Test Suite '(.*)' passed/,
     // Regex "Test Suite '<class>' failed"
-    failedSuite: /^Test Suite '(.*)' failed/,
+    failedSuite: /Test Suite '(.*)' failed/,
 };
 
 /** Regex for parsing non darwin XCTest output */
 export const nonDarwinTestRegex = {
     // Regex "Test Case '-[<test target> <class.function>]' started"
-    started: /^Test Case '(.*)\.(.*)' started/,
+    started: /Test Case '(.*)\.(.*)' started/,
     // Regex "Test Case '<class>.<function>' <completion_state> (<duration> seconds)"
-    finished: /^Test Case '(.*)\.(.*)' (.*) \((\d.*) seconds\)/,
+    finished: /Test Case '(.*)\.(.*)' (.*) \((\d.*) seconds\)/,
     // Regex "<path/to/test>:<line number>: error: <class>.<function> : <error>"
-    error: /^(.+):(\d+):\serror:\s*(.*)\.(.*) : (.*)/,
+    error: /(.+):(\d+):\serror:\s*(.*)\.(.*) : (.*)/,
     // Regex "<path/to/test>:<line number>: <class>.<function> : Test skipped"
-    skipped: /^(.+):(\d+):\s*(.*)\.(.*) : Test skipped/,
+    skipped: /(.+):(\d+):\s*(.*)\.(.*) : Test skipped/,
     // Regex "Test Suite '<class>' started"
-    startedSuite: /^Test Suite '(.*)' started/,
+    startedSuite: /Test Suite '(.*)' started/,
     // Regex "Test Suite '<class>' passed"
-    passedSuite: /^Test Suite '(.*)' passed/,
+    passedSuite: /Test Suite '(.*)' passed/,
     // Regex "Test Suite '<class>' failed"
-    failedSuite: /^Test Suite '(.*)' failed/,
+    failedSuite: /Test Suite '(.*)' failed/,
 };
 
 export interface IXCTestOutputParser {

--- a/test/integration-tests/testexplorer/XCTestOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/XCTestOutputParser.test.ts
@@ -484,6 +484,37 @@ Test Suite 'Selected tests' failed at 2024-10-20 22:01:46.306.
                     assert.deepEqual(inputToTestOutput(input), testRunState.allOutput);
                 });
 
+                test("Interleaved user and XCTest output", () => {
+                    const input = `Test Suite 'Selected tests' started at 2024-10-20 22:01:46.206.
+Test Suite 'EmptyAppPackageTests.xctest' started at 2024-10-20 22:01:46.207.
+Test Suite 'TestSuite1' started at 2024-10-20 22:01:46.207.
+Test Case '-[MyTests.TestSuite1 testFirst]' started.
+[debug]: evaluating manifest for 'pkg' v. unknown
+[debug]: loading manifeTest Case '-[MyTests.TestSuite1 testFirst]' passed (0.001 seconds).
+Test Suite 'TestSuite1' passed at 2024-10-20 22:01:46.208.
+    Executed 1 test, with 0 failures (0 unexpected) in 0.000 (0.000) seconds`;
+
+                    outputParser.parseResult(input, testRunState);
+
+                    const testOutput = inputToTestOutput(input);
+                    assertTestRunState(testRunState, [
+                        {
+                            name: "MyTests.TestSuite1",
+                            output: [testOutput[2], testOutput[6]],
+                            status: TestStatus.passed,
+                        },
+                        {
+                            name: "MyTests.TestSuite1/testFirst",
+                            output: [testOutput[3], testOutput[5]],
+                            status: TestStatus.passed,
+                            timing: {
+                                duration: 0.001,
+                            },
+                        },
+                    ]);
+                    assert.deepEqual(inputToTestOutput(input), testRunState.allOutput);
+                });
+
                 suite("Diffs", () => {
                     const testRun = (message: string, actual?: string, expected?: string) => {
                         const input = `Test Case '-[MyTests.MyTests testFail]' started.


### PR DESCRIPTION
Sometimes when running tests that print user output during their execution this output can be printed on the same line as XCTest results output, either before or after the results string. Previously this showed as a test that never finished (pending) in the test explorer, but with the introduction of #1505 tests that start but don't find any completion output are assumed to be crashed and marked as failed.

This extra user output interleaved with XCTest output would cause false positives, leading users to believe that their test never completed (crashed) when really we just missed the success/failure message from XCTest due to overly strict parsing.

Relax the XCTest output parsing regexes so that matched strings don't need to be at the start of a line.