### PR TITLE
Add system-target and binary target icons to Project Panel

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -42,7 +42,7 @@ export interface Target {
     c99name: string;
     path: string;
     sources: string[];
-    type: "executable" | "test" | "library" | "snippet" | "plugin";
+    type: "executable" | "test" | "library" | "snippet" | "plugin" | "binary" | "system-target";
 }
 
 /** Swift Package Manager dependency */

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -239,6 +239,7 @@ class TargetNode {
         item.iconPath = new vscode.ThemeIcon(this.icon());
         item.contextValue = this.contextValue();
         item.accessibilityInformation = { label: name };
+        item.tooltip = `${name} (${this.target.type})`;
         return item;
     }
 
@@ -252,6 +253,12 @@ class TargetNode {
                 return "output";
             case "library":
                 return "library";
+            case "system-target":
+                return "server";
+            case "binary":
+                return "file-binary";
+            case "plugin":
+                return "plug";
             case "test":
                 if (this.activeTasks.has(testTaskName(this.name))) {
                     return LOADING_ICON;
@@ -262,8 +269,6 @@ class TargetNode {
                     return LOADING_ICON;
                 }
                 return "notebook";
-            case "plugin":
-                return "plug";
         }
     }
 


### PR DESCRIPTION
Missed a few target types when adding icons to the Project Panel. Also adds the target type description to the tooltip to make it more clear what icons correspond to what target type.