### PR TITLE
Fixup reference to CodeLLDB in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This extension adds language support for Swift to Visual Studio Code, providing 
 * Code completion
 * Jump to definition, peek definition, find all references, symbol search
 * Error annotations and apply suggestions from errors
-* Automatic generation of launch configurations for debugging with [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb)
+* Automatic generation of launch configurations for debugging with [LLDB DAP](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap)
 * Automatic task creation
 * Package dependency view
 * Test Explorer view
@@ -14,7 +14,7 @@ This extension adds language support for Swift to Visual Studio Code, providing 
 
 The official documentation for this extension is available at [vscode-swift](https://docs.swift.org/vscode/documentation/userdocs)
 
-This extension uses [SourceKit LSP](https://github.com/apple/sourcekit-lsp) for the [language server](https://microsoft.github.io/language-server-protocol/overviews/lsp/overview/), which powers code completion. It also has a dependency on [LLDB DAP](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap) for debugging.
+This extension uses [SourceKit LSP](https://github.com/apple/sourcekit-lsp) for the [language server](https://microsoft.github.io/language-server-protocol/overviews/lsp/overview/), which powers code completion. It also has a dependency on the [LLDB DAP](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap) extension to enable debugging.
 
 To propose new features, you can post on the [swift.org forums](https://forums.swift.org) in the [VS Code Swift Extension category](https://forums.swift.org/c/related-projects/vscode-swift-extension/). If you run into something that doesn't work the way you'd expect, you can [file an issue in the GitHub repository](https://github.com/swiftlang/vscode-swift/issues/new).
 


### PR DESCRIPTION
Now that we default to LLDB DAP on >=Swift 6 toolchains, update the README to mention LLDB DAP in the supported features list instead of CodeLLDB.