### PR TITLE
Disable clicking on links in Live Preview

### DIFF
--- a/src/documentation/webview/webview.ts
+++ b/src/documentation/webview/webview.ts
@@ -25,6 +25,13 @@ const themeObserver = new ThemeObserver();
 themeObserver.updateTheme();
 themeObserver.start();
 
+// Disable clicking on links as they do not work
+const disableLinks = document.createElement("style");
+disableLinks.textContent = `a {
+    pointer-events: none;
+}`;
+document.head.appendChild(disableLinks);
+
 // Set up the communication bridges to VS Code and swift-docc-render
 createCommunicationBridge().then(async bridge => {
     const vscode = acquireVsCodeApi();


### PR DESCRIPTION
The links generated by SwiftDocC will only break the webview and should be disabled in Live Preview mode.