### PR TITLE
Update DYLD_LIBRARY_PATH to fix debugging tests in nightly toolchains

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -492,7 +492,7 @@ export class SwiftToolchain {
         if (!base) {
             return undefined;
         }
-        return path.join(base, "usr/lib");
+        return `${path.join(base, "usr/lib")}:${path.join(base, "usr/lib/swift/macosx/testing")}`;
     }
 
     /**

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -488,11 +488,12 @@ export class SwiftToolchain {
      * Library path for swift-testing executables
      */
     public swiftTestingLibraryPath(): string | undefined {
+        let result = "";
         const base = this.basePlatformDeveloperPath();
-        if (!base) {
-            return undefined;
+        if (base) {
+            result = `${path.join(base, "usr/lib")}:`;
         }
-        return `${path.join(base, "usr/lib")}:${path.join(base, "usr/lib/swift/macosx/testing")}`;
+        return `${result}${path.join(this.toolchainPath, "lib/swift/macosx/testing")}`;
     }
 
     /**


### PR DESCRIPTION
A change in SwiftPM removed the rpath that pointed to `usr/lib/swift/macosx/testing`
(https://github.com/swiftlang/swift-package-manager/pull/8295).

Consequently when debugging tests in VS Code `libTesting.dylib` could not be found and the tests would not start. This is only happening in nightly toolchains that contain the SwiftPM change noted above.

Fix this by adding the search path to the DYLD_LIBRARY_PATH.