### PR TITLE
Add an extension setting to control inlay hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,6 +311,11 @@
       {
         "title": "Swift",
         "properties": {
+          "swift.inlayHints.enabled": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Display inlay hints. Inlay hints are variable annotations indicating their inferred type."
+          },
           "swift.path": {
             "type": "string",
             "default": "",
@@ -683,9 +688,9 @@
           },
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "markdownDescription": "Display Inlay Hints. Inlay Hints are variable annotations indicating their inferred type. They are only available if you are using Swift 5.6 or later.",
-            "markdownDeprecationMessage": "**Deprecated**: Please use `#editor.inlayHints.enabled#` instead."
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.inlayHints.enabled#` instead."
           },
           "sourcekit-lsp.support-c-cpp": {
             "type": "string",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,7 @@ import { runTask } from "./commands/runTask";
 import { TestKind } from "./TestExplorer/TestKind";
 import { pickProcess } from "./commands/pickProcess";
 import { openDocumentation } from "./commands/openDocumentation";
+import { toggleInlayHints } from "./commands/toggleInlayHints";
 
 /**
  * References:
@@ -217,6 +218,7 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             vscode.commands.executeCommand("vscode.open", vscode.Uri.file(packagePath));
         }),
         vscode.commands.registerCommand("swift.openDocumentation", () => openDocumentation()),
+        vscode.commands.registerCommand("swift.toggleInlayHints", () => toggleInlayHints()),
     ];
 }
 

--- a/src/commands/toggleInlayHints.ts
+++ b/src/commands/toggleInlayHints.ts
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import configuration from "../configuration";
+
+/**
+ * Configures editor.inlayHints.enabled settings based on swift.inlayHints.enabled settings
+ */
+export async function toggleInlayHints() {
+    let settingValue = undefined;
+
+    if (!configuration.inlayHintsEnabled) {
+        settingValue = "off";
+    }
+
+    const config = vscode.workspace.getConfiguration("", { languageId: "swift" });
+    await config.update(
+        "editor.inlayHints.enabled",
+        settingValue,
+        vscode.ConfigurationTarget.Workspace,
+        true
+    );
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,7 @@ import * as os from "os";
 import * as path from "path";
 import { showReloadExtensionNotification } from "./ui/ReloadExtension";
 import { WorkspaceContext } from "./WorkspaceContext";
+import { toggleInlayHints } from "./commands/toggleInlayHints";
 
 export type DebugAdapters = "auto" | "lldb-dap" | "CodeLLDB";
 export type SetupCodeLLDBOptions =
@@ -410,6 +411,10 @@ const configuration = {
     get diagnostics(): boolean {
         return vscode.workspace.getConfiguration("swift").get<boolean>("diagnostics", false);
     },
+    /** enable inlay hints from SourceKit LSP by setting editor.inlayHints.enabled */
+    get inlayHintsEnabled(): boolean {
+        return vscode.workspace.getConfiguration("swift.inlayHints").get<boolean>("enabled", false);
+    },
     /**
      *  Test coverage settings
      */
@@ -535,6 +540,8 @@ export function handleConfigurationChangeEvent(
             showReloadExtensionNotification(
                 "Changing environment variables requires the project be reloaded."
             );
+        } else if (event.affectsConfiguration("swift.inlayHints.enabled")) {
+            toggleInlayHints();
         }
     };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { checkAndWarnAboutWindowsSymlinks } from "./ui/win32";
 import { SwiftEnvironmentVariablesManager, SwiftTerminalProfileProvider } from "./terminal";
 import { resolveFolderDependencies } from "./commands/dependencies/resolve";
 import { SelectedXcodeWatcher } from "./toolchain/SelectedXcodeWatcher";
+import { toggleInlayHints } from "./commands/toggleInlayHints";
 import configuration, { handleConfigurationChangeEvent } from "./configuration";
 import contextKeys from "./contextKeys";
 
@@ -139,6 +140,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
         // Mark the extension as activated.
         contextKeys.isActivated = true;
+
+        // toggle inlay hints based on swift.inlayHints.enabled settings
+        toggleInlayHints();
 
         return {
             workspaceContext,


### PR DESCRIPTION
Add an extension setting that controls `[swift]` language inlay hints so that hints can be disabled by default for now. Most other language extensions have inlay hints turned off by default (particularly for inferred variable types), likely because it is tricky to figure out how to turn them off/on otherwise.

Later on, when there is a walkthrough mode, we can provide users with an option to set inlay hints on or off when the extension runs for the first time.

Issue: #1512