### PR TITLE
Allow renaming the prerelease VSIX

### DIFF
--- a/scripts/download_vsix.ts
+++ b/scripts/download_vsix.ts
@@ -59,5 +59,9 @@ const repo = repository.split("/")[1];
     const newName = process.env["VSCODE_SWIFT_VSIX"] || "vscode-swift.vsix";
     await rename(files[0].path, newName);
     console.log(`Renamed artifact: ${files[0].path} => ${newName}`);
+    const preNewName =
+        process.env["VSCODE_SWIFT_PRERELEASE_VSIX"] || "vscode-swift-prerelease.vsix";
+    await rename(files[1].path, preNewName);
+    console.log(`Renamed artifact: ${files[1].path} => ${preNewName}`);
     await unlink("artifacts.zip");
 })();


### PR DESCRIPTION
Since pre-release is always 1 minor version higher, we know it's the second binary