### PR TITLE
Combine results from mdfind and xcode-select when searching for available Xcode applications

### DIFF
--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -143,7 +143,7 @@ async function getQuickPickItems(
     activeToolchain: SwiftToolchain | undefined
 ): Promise<SelectToolchainItem[]> {
     // Find any Xcode installations on the system
-    const xcodes = (await SwiftToolchain.getXcodeInstalls())
+    const xcodes = (await SwiftToolchain.findXcodeInstalls())
         .reverse()
         .map<SwiftToolchainItem>(xcodePath => {
             const toolchainPath = path.join(


### PR DESCRIPTION
Using the Spotlight index to find Xcode installations on macOS may not always find all available Xcode applications depending on macOS settings and the state of the Spotlight index itself. Include the result of `xcode-select -p` when finding Xcode applications to ensure that the currently selected Xcode is always included in the list of available Xcode applications for toolchain selection.

Issue: #1528