### PR TITLE
Changes for release process

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
             echo "Created bundle $name"
             mv "$file" "$name"
           done
+          git rev-parse HEAD > vscode-swift-sha.txt
       - name: Archive production artifacts
         id: archive
         uses: actions/upload-artifact@v4
@@ -41,6 +42,7 @@ jobs:
           name: vscode-swift-extension
           path: |
             *.vsix
+            vscode-swift-sha.txt
 
   tests_release:
     name: Test Release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,7 @@ jobs:
             echo "Created bundle $name"
             mv "$file" "$name"
           done
+          git config --global --add safe.directory $PWD
           git rev-parse HEAD > vscode-swift-sha.txt
       - name: Archive production artifacts
         id: archive

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,7 @@ jobs:
             echo "Created bundle $name"
             mv "$file" "$name"
           done
+          git config --global --add safe.directory $PWD
           git rev-parse HEAD > vscode-swift-sha.txt
       - name: Archive production artifacts
         id: archive

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -58,8 +58,6 @@ jobs:
         NVM_DIR=/usr/local/nvm
         CI=1
         FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}
-        VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}
-        GITHUB_REPOSITORY=${{github.repository}}
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
@@ -67,9 +65,6 @@ jobs:
       windows_env_vars: |
         CI=1
         FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}
-        VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}
-        VSCODE_SWIFT_VSIX=vscode-swift.vsix
-        GITHUB_REPOSITORY=${{github.repository}}
       windows_pre_build_command: .github\workflows\scripts\windows\setup.ps1
       windows_build_command: scripts\test_windows.ps1
       enable_windows_docker: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,6 +49,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     needs: package
     with:
+      needs_token: true
       # Linux
       linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-main"}]'
       linux_env_vars: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,9 +5,48 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+  package:
+    name: Package Extension
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.0-jammy
+    outputs:
+      artifact-id: ${{ steps.archive.outputs.artifact-id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build Extension
+        run: |
+          export NODE_VERSION=v20.18.2
+          export NODE_PATH=/usr/local/nvm/versions/node/v20.18.2/bin
+          export NVM_DIR=/usr/local/nvm
+          . .github/workflows/scripts/setup-linux.sh
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          npm ci
+          npm run compile
+          npm run package
+          npm run preview-package
+          for file in *.vsix; do
+            name="$(basename "$file" .vsix)-${{github.run_number}}.vsix"
+            echo "Created bundle $name"
+            mv "$file" "$name"
+          done
+          git rev-parse HEAD > vscode-swift-sha.txt
+      - name: Archive production artifacts
+        id: archive
+        uses: actions/upload-artifact@v4
+        if: ${{ env.ACT != 'true' }}
+        with:
+          if-no-files-found: error
+          name: vscode-swift-extension
+          path: |
+            *.vsix
+            vscode-swift-sha.txt
+
   tests:
     name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    needs: package
     with:
       # Linux
       linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-main"}]'
@@ -17,6 +56,8 @@ jobs:
         NVM_DIR=/usr/local/nvm
         CI=1
         FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}
+        VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}
+        GITHUB_REPOSITORY=${{github.repository}}
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
@@ -24,6 +65,9 @@ jobs:
       windows_env_vars: |
         CI=1
         FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}
+        VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}
+        VSCODE_SWIFT_VSIX=vscode-swift.vsix
+        GITHUB_REPOSITORY=${{github.repository}}
       windows_pre_build_command: .github\workflows\scripts\windows\install-nodejs.ps1
       windows_build_command: scripts\test_windows.ps1
       enable_windows_docker: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -70,7 +70,7 @@ jobs:
         VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}
         VSCODE_SWIFT_VSIX=vscode-swift.vsix
         GITHUB_REPOSITORY=${{github.repository}}
-      windows_pre_build_command: .github\workflows\scripts\windows\install-nodejs.ps1
+      windows_pre_build_command: .github\workflows\scripts\windows\setup.ps1
       windows_build_command: scripts\test_windows.ps1
       enable_windows_docker: false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/chai": "^4.3.19",
         "@types/chai-as-promised": "^7.1.8",
         "@types/chai-subset": "^1.3.6",
+        "@types/decompress": "^4.2.7",
         "@types/glob": "^7.1.6",
         "@types/lcov-parse": "^1.0.2",
         "@types/lodash.debounce": "^4.0.9",
@@ -1604,6 +1605,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/chai": "<5.2.0"
+      }
+    },
+    "node_modules/@types/decompress": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.7.tgz",
+      "integrity": "sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/glob": {
@@ -9890,6 +9901,15 @@
       "integrity": "sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==",
       "dev": true,
       "requires": {}
+    },
+    "@types/decompress": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.7.tgz",
+      "integrity": "sha512-9z+8yjKr5Wn73Pt17/ldnmQToaFHZxK0N1GHysuk/JIPT8RIdQeoInM01wWPgypRcvb6VH1drjuFpQ4zmY437g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -1676,6 +1676,7 @@
     "@types/chai": "^4.3.19",
     "@types/chai-as-promised": "^7.1.8",
     "@types/chai-subset": "^1.3.6",
+    "@types/decompress": "^4.2.7",
     "@types/glob": "^7.1.6",
     "@types/lcov-parse": "^1.0.2",
     "@types/lodash.debounce": "^4.0.9",

--- a/scripts/download_vsix.ts
+++ b/scripts/download_vsix.ts
@@ -57,11 +57,21 @@ const repo = repository.split("/")[1];
     const files = await decompress("artifacts.zip", process.cwd());
     console.log(`Downloaded artifact(s): ${files.map(f => f.path).join(", ")}`);
     const newName = process.env["VSCODE_SWIFT_VSIX"] || "vscode-swift.vsix";
-    await rename(files[0].path, newName);
-    console.log(`Renamed artifact: ${files[0].path} => ${newName}`);
+    const releaseVSIX = files.find(f => /swift-vscode-\d.\d.\d-\d+.vsix/m.test(f.path));
+    if (!releaseVSIX) {
+        console.error("Cound not find vscode-swift release VSIX in artifact bundle");
+        process.exit(1);
+    }
+    await rename(releaseVSIX.path, newName);
+    const prereleaseVSIX = files.find(f => /swift-vscode-\d.\d.\d{8}-\d+.vsix/m.test(f.path));
+    if (!prereleaseVSIX) {
+        console.error("Cound not find vscode-swift pre-release VSIX in artifact bundle");
+        process.exit(1);
+    }
+    console.log(`Renamed artifact: ${releaseVSIX.path} => ${newName}`);
     const preNewName =
         process.env["VSCODE_SWIFT_PRERELEASE_VSIX"] || "vscode-swift-prerelease.vsix";
-    await rename(files[1].path, preNewName);
-    console.log(`Renamed artifact: ${files[1].path} => ${preNewName}`);
+    await rename(prereleaseVSIX.path, preNewName);
+    console.log(`Renamed artifact: ${prereleaseVSIX.path} => ${preNewName}`);
     await unlink("artifacts.zip");
 })();

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -31,7 +31,6 @@ cd /tmp/code
 npm ci
 npm run lint
 npm run format
-npm run package
 npm run soundness -- --force-run
 
 xvfb-run -a npm run coverage 2>&1 | grep -Ev "Failed to connect to the bus|GPU stall due to ReadPixels"


### PR DESCRIPTION

## Allow renaming the prerelease VSIX
- Since pre-release is always 1 minor version higher, we know it's the second binary

## Archive the commit SHA used to package the VSIX
- Eventually will be used downstream to tag releases
- Also setup PR job to package the VSIX and run tests against it so we can test against that in verifier jobs as well