### PR TITLE
Shorten the name of the `Swift: Capture Diagnostics Bundle` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
       },
       {
         "command": "swift.captureDiagnostics",
-        "title": "Capture VS Code Swift Diagnostic Bundle",
+        "title": "Capture Diagnostic Bundle",
         "category": "Swift"
       },
       {


### PR DESCRIPTION
The `VS Code Swift` portion of the command name is implied and only makes it harder to remember.