### PR TITLE
Fix reseting of settings

### DIFF
--- a/assets/test/.vscode/settings.json
+++ b/assets/test/.vscode/settings.json
@@ -8,5 +8,5 @@
         "-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
     ],
     "lldb.verboseLogging": true,
-    "swift.backgroundCompilation": false
+    "swift.sourcekit-lsp.backgroundIndexing": "off"
 }


### PR DESCRIPTION
Fix logic to reset these when changed, also consider if default value when reseting. This causes backgroundCompilation on in test project to get removed since that is the default