### PR TITLE
Clear cache during teardowns

### DIFF
--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -121,8 +121,19 @@ const buildAllTaskCache = (() => {
         set(name: string, folderContext: FolderContext, task: SwiftTask) {
             cache.set(key(name, folderContext, task), task);
         },
+        reset() {
+            cache.clear();
+        },
     };
 })();
+
+/**
+ * Should only be used for tests purposes
+ */
+export function resetBuildAllTaskCache() {
+    // Don't want to expose the whole cache, just the reset
+    buildAllTaskCache.reset();
+}
 
 function buildAllTaskName(folderContext: FolderContext, release: boolean): string {
     let buildTaskName = release

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -21,7 +21,7 @@ import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { Commands } from "../../../src/commands";
 import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities/tasks";
-import { getBuildAllTask, SwiftTask } from "../../../src/tasks/SwiftTaskProvider";
+import { createBuildAllTask } from "../../../src/tasks/SwiftTaskProvider";
 
 suite("Dependency Commmands Test Suite", function () {
     // full workflow's interaction with spm is longer than the default timeout
@@ -58,7 +58,7 @@ suite("Dependency Commmands Test Suite", function () {
 
         setup(async () => {
             await workspaceContext.focusFolder(depsContext);
-            await executeTaskAndWaitForResult((await getBuildAllTask(depsContext)) as SwiftTask);
+            await executeTaskAndWaitForResult(await createBuildAllTask(depsContext));
             treeProvider = new ProjectPanelProvider(workspaceContext);
         });
 

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -25,6 +25,7 @@ import { isDeepStrictEqual } from "util";
 import { Version } from "../../../src/utilities/version";
 import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 import configuration from "../../../src/configuration";
+import { resetBuildAllTaskCache } from "../../../src/tasks/SwiftTaskProvider";
 
 function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     const result = vscode.workspace.workspaceFolders?.at(0);
@@ -141,6 +142,7 @@ const extensionBootstrapper = (() => {
                     await autoTeardown();
                 }
                 await waitForNoRunningTasks();
+                resetBuildAllTaskCache();
             } catch (error) {
                 if (workspaceContext) {
                     printLogs(workspaceContext.outputChannel, "Error during test/suite teardown");


### PR DESCRIPTION
Was an issue with using the cached tasks between successive extension activations. Also using, create over get variant of the helper to not go through all the extra paths of fetching and matching names