### PR TITLE
Support for multi-root .code-workspace workspaces

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -90,6 +90,40 @@ module.exports = defineConfig({
             installExtensions,
         },
         {
+            label: "codeWorkspaceTests",
+            files: [
+                "dist/test/common.js",
+                "dist/test/integration-tests/extension.test.js",
+                "dist/test/integration-tests/WorkspaceContext.test.js",
+                "dist/test/integration-tests/tasks/**/*.test.js",
+                "dist/test/integration-tests/commands/build.test.js",
+            ],
+            version: process.env["VSCODE_VERSION"] ?? "stable",
+            workspaceFolder: "./assets/test.code-workspace",
+            launchArgs,
+            extensionDevelopmentPath: vsixPath
+                ? [`${__dirname}/.vscode-test/extensions/${publisher}.${name}-${version}`]
+                : undefined,
+            mocha: {
+                ui: "tdd",
+                color: true,
+                timeout,
+                forbidOnly: isCIBuild,
+                grep: isFastTestRun ? "@slow" : undefined,
+                invert: isFastTestRun,
+                slow: 10000,
+                retries: 1,
+                reporter: path.join(__dirname, ".mocha-reporter.js"),
+                reporterOptions: {
+                    jsonReporterOptions: {
+                        output: path.join(__dirname, "test-results", "code-workspace-tests.json"),
+                    },
+                },
+            },
+            reuseMachineInstall: !isCIBuild,
+            installExtensions,
+        },
+        {
             label: "unitTests",
             files: ["dist/test/common.js", "dist/test/unit-tests/**/*.test.js"],
             version: process.env["VSCODE_VERSION"] ?? "stable",

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -97,6 +97,7 @@ module.exports = defineConfig({
                 "dist/test/integration-tests/WorkspaceContext.test.js",
                 "dist/test/integration-tests/tasks/**/*.test.js",
                 "dist/test/integration-tests/commands/build.test.js",
+                "dist/test/integration-tests/testexplorer/TestExplorerIntegration.test.js",
             ],
             version: process.env["VSCODE_VERSION"] ?? "stable",
             workspaceFolder: "./assets/test.code-workspace",

--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -98,6 +98,7 @@ module.exports = defineConfig({
                 "dist/test/integration-tests/tasks/**/*.test.js",
                 "dist/test/integration-tests/commands/build.test.js",
                 "dist/test/integration-tests/testexplorer/TestExplorerIntegration.test.js",
+                "dist/test/integration-tests/commands/dependency.test.js",
             ],
             version: process.env["VSCODE_VERSION"] ?? "stable",
             workspaceFolder: "./assets/test.code-workspace",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,19 @@
       "preLaunchTask": "compile-tests"
     },
     {
+      "name": "Code Workspace Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "testConfiguration": "${workspaceFolder}/.vscode-test.js",
+      "testConfigurationLabel": "codeWorkspaceTests",
+      "args": ["--profile=testing-debug"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "env": {
+        "VSCODE_DEBUG": "1"
+      },
+      "preLaunchTask": "compile-tests"
+    },
+    {
       "name": "Unit Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/assets/test.code-workspace
+++ b/assets/test.code-workspace
@@ -1,10 +1,6 @@
 {
 	"folders": [
 		{
-			"name": "test",
-			"path": "./test"
-		},
-		{
 			"name": "diagnostics",
 			"path": "./test/diagnostics"
 		},

--- a/assets/test.code-workspace
+++ b/assets/test.code-workspace
@@ -5,16 +5,16 @@
 			"path": "./test"
 		},
 		{
-			"name": "defaultPackage",
-			"path": "./test/defaultPackage"
-		},
-		{
 			"name": "diagnostics",
 			"path": "./test/diagnostics"
 		},
 		{
 			"name": "command-plugin",
 			"path": "./test/command-plugin"
+		},
+		{
+			"name": "defaultPackage",
+			"path": "./test/defaultPackage"
 		}
 	],
 	"settings": {
@@ -27,6 +27,8 @@
 			"-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
 		],
 		"lldb.verboseLogging": true,
+		"lldb.launch.terminal": "external",
+		"lldb-dap.detachOnError": true,
 		"swift.sourcekit-lsp.backgroundIndexing": "off"
 	},
 	"tasks": {
@@ -37,15 +39,17 @@
 				"args": [
 					"build",
 					"--build-tests",
-					"--verbose"
+					"--verbose",
+					"-Xswiftc",
+					"-DBAR"
 				],
 				"cwd": "${workspaceFolder:defaultPackage}",
 				"group": {
 					"kind": "build",
 					"isDefault": true
 				},
-				"label": "swift: Build All (defaultPackage)",
-				"detail": "swift build --build-tests --verbose"
+				"label": "swift: Build All (defaultPackage) (workspace)",
+				"detail": "swift build --build-tests --verbose -Xswiftc -DBAR"
 			},
 			{
 				"type": "swift",
@@ -55,7 +59,7 @@
 				],
 				"cwd": "${workspaceFolder:defaultPackage}",
 				"group": "build",
-				"label": "swift: Build All from tasks.json",
+				"label": "swift: Build All from code workspace",
 				"detail": "swift build --show-bin-path"
 			},
 			{
@@ -66,8 +70,42 @@
 				],
 				"cwd": "${workspaceFolder:command-plugin}",
 				"disableSandbox": true,
-				"label": "swift: command-plugin from tasks.json",
+				"label": "swift: command-plugin from code workspace",
 				"detail": "swift package command_plugin --foo"
+			},
+			{
+				"type": "swift",
+				"args": [
+					"build",
+					"--product",
+					"PackageExe",
+					"-Xswiftc",
+					"-diagnostic-style=llvm",
+					"-Xswiftc",
+					"-DBAR"
+				],
+				"cwd": "${workspaceFolder:defaultPackage}",
+				"group": "build",
+				"label": "swift: Build Debug PackageExe (defaultPackage) (workspace)",
+				"detail": "swift build --product PackageExe -Xswiftc -diagnostic-style=llvm -Xswiftc -DBAR"
+			},
+			{
+				"type": "swift",
+				"args": [
+					"build",
+					"-c",
+					"release",
+					"--product",
+					"PackageExe",
+					"-Xswiftc",
+					"-diagnostic-style=llvm",
+					"-Xswiftc",
+					"-DBAR"
+				],
+				"cwd": "${workspaceFolder:defaultPackage}",
+				"group": "build",
+				"label": "swift: Build Release PackageExe (defaultPackage) (workspace)",
+				"detail": "swift build -c release --product PackageExe -Xswiftc -diagnostic-style=llvm -Xswiftc -DBAR"
 			}
 		]
 	},
@@ -77,11 +115,11 @@
 			{
 				"type": "swift",
 				"request": "launch",
-				"name": "Debug PackageExe (defaultPackage)",
+				"name": "Debug PackageExe (defaultPackage) (workspace)",
 				"program": "${workspaceFolder:defaultPackage}/.build/debug/PackageExe",
 				"args": [],
 				"cwd": "${workspaceFolder:defaultPackage}",
-				"preLaunchTask": "swift: Build Debug PackageExe (defaultPackage)",
+				"preLaunchTask": "swift: Build Debug PackageExe (defaultPackage) (workspace)",
 				"disableASLR": false,
 				"initCommands": [
 					"settings set target.disable-aslr false"
@@ -90,11 +128,11 @@
 			{
 				"type": "swift",
 				"request": "launch",
-				"name": "Release PackageExe (defaultPackage)",
+				"name": "Release PackageExe (defaultPackage) (workspace)",
 				"program": "${workspaceFolder:defaultPackage}/.build/release/PackageExe",
 				"args": [],
 				"cwd": "${workspaceFolder:defaultPackage}",
-				"preLaunchTask": "swift: Build Release PackageExe (defaultPackage)",
+				"preLaunchTask": "swift: Build Release PackageExe (defaultPackage) (workspace)",
 				"disableASLR": false,
 				"initCommands": [
 					"settings set target.disable-aslr false"

--- a/assets/test.code-workspace
+++ b/assets/test.code-workspace
@@ -1,0 +1,106 @@
+{
+	"folders": [
+		{
+			"name": "test",
+			"path": "./test"
+		},
+		{
+			"name": "defaultPackage",
+			"path": "./test/defaultPackage"
+		},
+		{
+			"name": "diagnostics",
+			"path": "./test/diagnostics"
+		},
+		{
+			"name": "command-plugin",
+			"path": "./test/command-plugin"
+		}
+	],
+	"settings": {
+		"swift.disableAutoResolve": true,
+		"swift.autoGenerateLaunchConfigurations": false,
+		"swift.debugger.debugAdapter": "lldb-dap",
+		"swift.debugger.setupCodeLLDB": "alwaysUpdateGlobal",
+		"swift.additionalTestArguments": [
+			"-Xswiftc",
+			"-DTEST_ARGUMENT_SET_VIA_TEST_BUILD_ARGUMENTS_SETTING"
+		],
+		"lldb.verboseLogging": true,
+		"swift.sourcekit-lsp.backgroundIndexing": "off"
+	},
+	"tasks": {
+		"version": "2.0.0",
+		"tasks": [
+			{
+				"type": "swift",
+				"args": [
+					"build",
+					"--build-tests",
+					"--verbose"
+				],
+				"cwd": "${workspaceFolder:defaultPackage}",
+				"group": {
+					"kind": "build",
+					"isDefault": true
+				},
+				"label": "swift: Build All (defaultPackage)",
+				"detail": "swift build --build-tests --verbose"
+			},
+			{
+				"type": "swift",
+				"args": [
+					"build",
+					"--show-bin-path"
+				],
+				"cwd": "${workspaceFolder:defaultPackage}",
+				"group": "build",
+				"label": "swift: Build All from tasks.json",
+				"detail": "swift build --show-bin-path"
+			},
+			{
+				"type": "swift-plugin",
+				"command": "command_plugin",
+				"args": [
+					"--foo"
+				],
+				"cwd": "${workspaceFolder:command-plugin}",
+				"disableSandbox": true,
+				"label": "swift: command-plugin from tasks.json",
+				"detail": "swift package command_plugin --foo"
+			}
+		]
+	},
+	"launch": {
+		"version": "0.2.0",
+		"configurations": [
+			{
+				"type": "swift",
+				"request": "launch",
+				"name": "Debug PackageExe (defaultPackage)",
+				"program": "${workspaceFolder:defaultPackage}/.build/debug/PackageExe",
+				"args": [],
+				"cwd": "${workspaceFolder:defaultPackage}",
+				"preLaunchTask": "swift: Build Debug PackageExe (defaultPackage)",
+				"disableASLR": false,
+				"initCommands": [
+					"settings set target.disable-aslr false"
+				]
+			},
+			{
+				"type": "swift",
+				"request": "launch",
+				"name": "Release PackageExe (defaultPackage)",
+				"program": "${workspaceFolder:defaultPackage}/.build/release/PackageExe",
+				"args": [],
+				"cwd": "${workspaceFolder:defaultPackage}",
+				"preLaunchTask": "swift: Build Release PackageExe (defaultPackage)",
+				"disableASLR": false,
+				"initCommands": [
+					"settings set target.disable-aslr false"
+				]
+			}
+		],
+		"compounds": []
+	}
+}

--- a/assets/test.code-workspace
+++ b/assets/test.code-workspace
@@ -5,6 +5,10 @@
 			"path": "./test/diagnostics"
 		},
 		{
+			"name": "dependencies",
+			"path": "./test/dependencies"
+		},
+		{
 			"name": "command-plugin",
 			"path": "./test/command-plugin"
 		},

--- a/assets/test/.vscode/tasks.json
+++ b/assets/test/.vscode/tasks.json
@@ -6,7 +6,9 @@
 			"args": [
 				"build",
 				"--build-tests",
-				"--verbose"
+				"--verbose",
+				"-Xswiftc",
+				"-DFOO"
 			],
 			"cwd": "defaultPackage",
 			"problemMatcher": [
@@ -14,7 +16,7 @@
 			],
 			"group": "build",
 			"label": "swift: Build All (defaultPackage)",
-			"detail": "swift build --build-tests --verbose"
+			"detail": "swift build --build-tests --verbose -Xswiftc -DFOO"
 		},
 		{
 			"type": "swift",
@@ -33,7 +35,9 @@
 		{
 			"type": "swift-plugin",
 			"command": "command_plugin",
-			"args": ["--foo"],
+			"args": [
+				"--foo"
+			],
 			"cwd": "command-plugin",
 			"disableSandbox": true,
 			"problemMatcher": [

--- a/assets/test/defaultPackage/.vscode/launch copy.json
+++ b/assets/test/defaultPackage/.vscode/launch copy.json
@@ -1,0 +1,62 @@
+{
+    "configurations": [
+        {
+            "type": "swift",
+            "request": "launch",
+            "name": "Attach to Swift Executable",
+            "program": "${workspaceFolder}/.build/aarch64-unknown-linux-gnu/debug/PackageExe",
+            // "attachCommands": [
+            //     // "gdb-remote 1234",
+            //     // "process launch"
+            //     "platform select remote-linux",
+            //     "platform connect connect://127.0.0.1:1234"
+            // ],
+            // "initCommands": [
+            //     "target create .build/aarch64-unknown-linux-gnu/debug/PackageExe",
+            //     "b main.swift:7",
+            // ]
+            "initCommands": [
+                "platform select remote-linux",
+                // "platform connect connect://127.0.0.1:1234",
+                "gdb-remote 1234",
+                "settings set target.inherit-env false"
+            ]
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "name": "Debug package1",
+            "program": "${workspaceFolder:defaultPackage}/.build/debug/package1",
+            "args": [],
+            "cwd": "${workspaceFolder:defaultPackage}",
+            "preLaunchTask": "swift: Build Debug package1"
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "name": "Release package1",
+            "program": "${workspaceFolder:defaultPackage}/.build/release/package1",
+            "args": [],
+            "cwd": "${workspaceFolder:defaultPackage}",
+            "preLaunchTask": "swift: Build Release package1"
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:defaultPackage}",
+            "name": "Debug PackageExe",
+            "program": "${workspaceFolder:defaultPackage}/.build/debug/PackageExe",
+            "preLaunchTask": "swift: Build Debug PackageExe"
+        },
+        {
+            "type": "swift",
+            "request": "launch",
+            "args": [],
+            "cwd": "${workspaceFolder:defaultPackage}",
+            "name": "Release PackageExe",
+            "program": "${workspaceFolder:defaultPackage}/.build/release/PackageExe",
+            "preLaunchTask": "swift: Build Release PackageExe"
+        }
+    ]
+}

--- a/scripts/test_windows.ps1
+++ b/scripts/test_windows.ps1
@@ -15,6 +15,7 @@
 function Update-SwiftBuildAndPackageArguments {
     param (
         [string]$jsonFilePath = "./assets/test/.vscode/settings.json",
+        [string]$codeWorkspaceFilePath = "./assets/test.code-workspace",
         [string]$windowsSdkVersion = "10.0.22000.0",
         [string]$vcToolsVersion = "14.43.34808"
     )
@@ -28,9 +29,17 @@ function Update-SwiftBuildAndPackageArguments {
         exit 1
     }
 
+    try {
+        $codeWorkspaceContent = Get-Content -Raw -Path $codeWorkspaceFilePath | ConvertFrom-Json
+    } catch {
+        Write-Host "Invalid JSON content in $codeWorkspaceFilePath"
+        exit 1
+    }
+
     if ($jsonContent.PSObject.Properties['swift.buildArguments']) {
         $jsonContent.PSObject.Properties.Remove('swift.buildArguments')
     }
+    
 
     $jsonContent | Add-Member -MemberType NoteProperty -Name "swift.buildArguments" -Value @(
         "-Xbuild-tools-swiftc", "-windows-sdk-root", "-Xbuild-tools-swiftc", $windowsSdkRoot,
@@ -54,10 +63,20 @@ function Update-SwiftBuildAndPackageArguments {
         "-Xswiftc", "-visualc-tools-version", "-Xswiftc", $vcToolsVersion
     )
 
+
+    $codeWorkspaceContent.PSObject.Properties.Remove('settings')
+    $codeWorkspaceContent | Add-Member -MemberType NoteProperty -Name "settings" -Value $jsonContent
+
     $jsonContent | ConvertTo-Json -Depth 32 | Set-Content -Path $jsonFilePath
+
+    
+    $codeWorkspaceContent | ConvertTo-Json -Depth 32 | Set-Content -Path $codeWorkspaceFilePath
 
     Write-Host "Contents of ${jsonFilePath}:"
     Get-Content -Path $jsonFilePath
+    
+    Write-Host "Contents of ${codeWorkspaceFilePath}:"
+    Get-Content -Path $codeWorkspaceFilePath
 }
 
 $swiftVersionOutput = & swift --version

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -51,6 +51,7 @@ import { reduceTestItemChildren } from "./TestUtils";
 import { CompositeCancellationToken } from "../utilities/cancellation";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import stripAnsi = require("strip-ansi");
+import { packageName } from "../utilities/tasks";
 
 export enum TestLibrary {
     xctest = "XCTest",
@@ -774,7 +775,7 @@ export class TestRunner {
                 {
                     cwd: this.folderContext.folder,
                     scope: this.folderContext.workspaceFolder,
-                    prefix: this.folderContext.name,
+                    packageName: packageName(this.folderContext),
                     presentationOptions: { reveal: vscode.TaskRevealKind.Never },
                 },
                 this.folderContext.toolchain,

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -51,7 +51,7 @@ import { reduceTestItemChildren } from "./TestUtils";
 import { CompositeCancellationToken } from "../utilities/cancellation";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import stripAnsi = require("strip-ansi");
-import { packageName } from "../utilities/tasks";
+import { packageName, resolveScope } from "../utilities/tasks";
 
 export enum TestLibrary {
     xctest = "XCTest",
@@ -774,7 +774,7 @@ export class TestRunner {
                 `Building and Running Tests${kindLabel}`,
                 {
                     cwd: this.folderContext.folder,
-                    scope: this.folderContext.workspaceFolder,
+                    scope: resolveScope(this.folderContext.workspaceFolder),
                     packageName: packageName(this.folderContext),
                     presentationOptions: { reveal: vscode.TaskRevealKind.Never },
                 },

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -19,6 +19,7 @@ import { debugLaunchConfig, getLaunchConfiguration } from "../debugger/launch";
 import { executeTaskWithUI } from "./utilities";
 import { FolderContext } from "../FolderContext";
 import { Target } from "../SwiftPackage";
+import { packageName } from "../utilities/tasks";
 
 /**
  * Executes a {@link vscode.Task task} to run swift target.
@@ -56,7 +57,7 @@ export async function folderCleanBuild(folderContext: FolderContext) {
         {
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
-            prefix: folderContext.name,
+            packageName: packageName(folderContext),
             presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
             group: vscode.TaskGroup.Clean,
         },

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -112,7 +112,11 @@ export async function debugBuildWithOptions(
     const launchConfig = getLaunchConfiguration(target.name, current);
     if (launchConfig) {
         ctx.buildStarted(target.name, launchConfig, options);
-        const result = await debugLaunchConfig(current.workspaceFolder, launchConfig, options);
+        const result = await debugLaunchConfig(
+            vscode.workspace.workspaceFile ? undefined : current.workspaceFolder,
+            launchConfig,
+            options
+        );
         ctx.buildFinished(target.name, launchConfig, options);
         return result;
     }

--- a/src/commands/dependencies/edit.ts
+++ b/src/commands/dependencies/edit.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 import { createSwiftTask } from "../../tasks/SwiftTaskProvider";
 import { FolderOperation, WorkspaceContext } from "../../WorkspaceContext";
 import { executeTaskWithUI } from "../utilities";
+import { packageName } from "../../utilities/tasks";
 
 /**
  * Setup package dependency to be edited
@@ -34,7 +35,7 @@ export async function editDependency(identifier: string, ctx: WorkspaceContext) 
         {
             scope: currentFolder.workspaceFolder,
             cwd: currentFolder.folder,
-            prefix: currentFolder.name,
+            packageName: packageName(currentFolder),
         },
         currentFolder.toolchain
     );

--- a/src/commands/dependencies/resolve.ts
+++ b/src/commands/dependencies/resolve.ts
@@ -17,6 +17,7 @@ import { FolderContext } from "../../FolderContext";
 import { createSwiftTask, SwiftTaskProvider } from "../../tasks/SwiftTaskProvider";
 import { WorkspaceContext } from "../../WorkspaceContext";
 import { executeTaskWithUI, updateAfterError } from "../utilities";
+import { packageName } from "../../utilities/tasks";
 
 /**
  * Executes a {@link vscode.Task task} to resolve this package's dependencies.
@@ -43,7 +44,7 @@ export async function resolveFolderDependencies(
         {
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
-            prefix: folderContext.name,
+            packageName: packageName(folderContext),
             presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
         },
         folderContext.toolchain

--- a/src/commands/dependencies/update.ts
+++ b/src/commands/dependencies/update.ts
@@ -17,6 +17,7 @@ import { FolderContext } from "../../FolderContext";
 import { WorkspaceContext } from "../../WorkspaceContext";
 import { createSwiftTask, SwiftTaskProvider } from "../../tasks/SwiftTaskProvider";
 import { executeTaskWithUI, updateAfterError } from "./../utilities";
+import { packageName } from "../../utilities/tasks";
 
 /**
  * Executes a {@link vscode.Task task} to update this package's dependencies.
@@ -41,7 +42,7 @@ export async function updateFolderDependencies(folderContext: FolderContext) {
         {
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
-            prefix: folderContext.name,
+            packageName: packageName(folderContext),
             presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
         },
         folderContext.toolchain

--- a/src/commands/dependencies/useLocal.ts
+++ b/src/commands/dependencies/useLocal.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 import { FolderOperation, WorkspaceContext } from "../../WorkspaceContext";
 import { createSwiftTask } from "../../tasks/SwiftTaskProvider";
 import { executeTaskWithUI } from "../utilities";
+import { packageName } from "../../utilities/tasks";
 
 /**
  * Use local version of package dependency
@@ -61,7 +62,7 @@ export async function useLocalDependency(
         {
             scope: currentFolder.workspaceFolder,
             cwd: currentFolder.folder,
-            prefix: currentFolder.name,
+            packageName: packageName(currentFolder),
         },
         currentFolder.toolchain
     );

--- a/src/commands/resetPackage.ts
+++ b/src/commands/resetPackage.ts
@@ -17,6 +17,7 @@ import { FolderContext } from "../FolderContext";
 import { createSwiftTask, SwiftTaskProvider } from "../tasks/SwiftTaskProvider";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { executeTaskWithUI } from "./utilities";
+import { packageName } from "../utilities/tasks";
 
 /**
  * Executes a {@link vscode.Task task} to reset the complete cache/build directory.
@@ -40,7 +41,7 @@ export async function folderResetPackage(folderContext: FolderContext) {
         {
             cwd: folderContext.folder,
             scope: folderContext.workspaceFolder,
-            prefix: folderContext.name,
+            packageName: packageName(folderContext),
             presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
             group: vscode.TaskGroup.Clean,
         },
@@ -71,7 +72,7 @@ export async function folderResetPackage(folderContext: FolderContext) {
                 {
                     cwd: folderContext.folder,
                     scope: folderContext.workspaceFolder,
-                    prefix: folderContext.name,
+                    packageName: packageName(folderContext),
                     presentationOptions: { reveal: vscode.TaskRevealKind.Silent },
                 },
                 folderContext.toolchain

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -510,6 +510,13 @@ function computeVscodeVar(varName: string): string | null {
 
     const file = () => vscode.window.activeTextEditor?.document?.uri?.fsPath || "";
 
+    const regex = /workspaceFolder:(.*)/gm;
+    const match = regex.exec(varName);
+    if (match) {
+        const name = match[1];
+        return vscode.workspace.workspaceFolders?.find(f => f.name === name)?.uri.fsPath ?? null;
+    }
+
     // https://code.visualstudio.com/docs/editor/variables-reference
     // Variables to be substituted should be added here.
     const supportedVariables: { [k: string]: () => string } = {

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -27,6 +27,7 @@ import { TestLibrary } from "../TestExplorer/TestRunner";
 import { TestKind, isDebugging, isRelease } from "../TestExplorer/TestKind";
 import { buildOptions } from "../tasks/SwiftTaskProvider";
 import { updateLaunchConfigForCI } from "./lldb";
+import { packageName } from "../utilities/tasks";
 
 export class BuildConfigurationFactory {
     public static buildAll(
@@ -719,13 +720,14 @@ export function getFolderAndNameSuffix(
         ? ctx.workspaceFolder.uri.fsPath
         : `\${workspaceFolder:${ctx.workspaceFolder.name}}`;
     let folder: string;
-    let nameSuffix: string;
-    if (ctx.relativePath.length === 0) {
+    let nameSuffix;
+    const pkgName = packageName(ctx);
+    if (pkgName) {
+        folder = nodePath.join(workspaceFolder, ctx.relativePath);
+        nameSuffix = ` (${packageName(ctx)})`;
+    } else {
         folder = workspaceFolder;
         nameSuffix = "";
-    } else {
-        folder = nodePath.join(workspaceFolder, ctx.relativePath);
-        nameSuffix = ` (${ctx.relativePath})`;
     }
     return { folder: folder, nameSuffix: nameSuffix };
 }

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -18,7 +18,7 @@ import { WorkspaceContext } from "../WorkspaceContext";
 import { PackagePlugin } from "../SwiftPackage";
 import { swiftRuntimeEnv } from "../utilities/utilities";
 import { SwiftExecution } from "../tasks/SwiftExecution";
-import { resolveTaskCwd } from "../utilities/tasks";
+import { packageName, resolveTaskCwd } from "../utilities/tasks";
 import configuration, {
     PluginPermissionConfiguration,
     substituteVariablesInString,
@@ -31,7 +31,7 @@ interface TaskConfig {
     cwd: vscode.Uri;
     scope: vscode.WorkspaceFolder;
     presentationOptions?: vscode.TaskPresentationOptions;
-    prefix?: string;
+    packageName?: string;
 }
 
 /**
@@ -62,6 +62,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
                         presentationOptions: {
                             reveal: vscode.TaskRevealKind.Always,
                         },
+                        packageName: packageName(folderContext),
                     })
                 );
             }
@@ -150,13 +151,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
             }),
             []
         );
-        let prefix: string;
-        if (config.prefix) {
-            prefix = `(${config.prefix}) `;
-        } else {
-            prefix = "";
-        }
-        task.detail = `${prefix}swift ${swiftArgs.join(" ")}`;
+        task.detail = `swift ${swiftArgs.join(" ")}`;
         task.presentationOptions = presentation;
         return task as SwiftTask;
     }

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -24,7 +24,7 @@ import { swiftRuntimeEnv } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { SwiftToolchain } from "../toolchain/toolchain";
 import { SwiftExecution } from "../tasks/SwiftExecution";
-import { packageName, resolveTaskCwd } from "../utilities/tasks";
+import { packageName, resolveScope, resolveTaskCwd } from "../utilities/tasks";
 import { BuildConfigurationFactory } from "../debugger/buildConfig";
 
 /**
@@ -161,7 +161,7 @@ export async function createBuildAllTask(
         {
             group: vscode.TaskGroup.Build,
             cwd: folderContext.folder,
-            scope: folderContext.workspaceFolder,
+            scope: resolveScope(folderContext.workspaceFolder),
             presentationOptions: {
                 reveal: getBuildRevealOption(),
             },
@@ -246,7 +246,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
         {
             group: vscode.TaskGroup.Build,
             cwd: folderContext.folder,
-            scope: folderContext.workspaceFolder,
+            scope: resolveScope(folderContext.workspaceFolder),
             presentationOptions: {
                 reveal: getBuildRevealOption(),
             },
@@ -404,7 +404,7 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
                         type: "swift",
                         args: [],
                     },
-                    folderContext.workspaceFolder,
+                    resolveScope(folderContext.workspaceFolder),
                     buildTaskName,
                     "swift",
                     new vscode.CustomExecution(() => {

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -24,7 +24,7 @@ import { swiftRuntimeEnv } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { SwiftToolchain } from "../toolchain/toolchain";
 import { SwiftExecution } from "../tasks/SwiftExecution";
-import { resolveTaskCwd } from "../utilities/tasks";
+import { packageName, resolveTaskCwd } from "../utilities/tasks";
 import { BuildConfigurationFactory } from "../debugger/buildConfig";
 
 /**
@@ -44,7 +44,7 @@ interface TaskConfig {
     scope: vscode.TaskScope | vscode.WorkspaceFolder;
     group?: vscode.TaskGroup;
     presentationOptions?: vscode.TaskPresentationOptions;
-    prefix?: string;
+    packageName?: string;
     disableTaskQueue?: boolean;
     dontTriggerTestDiscovery?: boolean;
     showBuildStatus?: ShowBuildStatusOptions;
@@ -139,8 +139,9 @@ function buildAllTaskName(folderContext: FolderContext, release: boolean): strin
     let buildTaskName = release
         ? `${SwiftTaskProvider.buildAllName} - Release`
         : SwiftTaskProvider.buildAllName;
-    if (folderContext.relativePath.length > 0) {
-        buildTaskName += ` (${folderContext.relativePath})`;
+    const packageNamePostfix = packageName(folderContext);
+    if (packageNamePostfix) {
+        buildTaskName += ` (${packageNamePostfix})`;
     }
     return buildTaskName;
 }
@@ -232,12 +233,7 @@ export async function getBuildAllTask(
  */
 function createBuildTasks(product: Product, folderContext: FolderContext): vscode.Task[] {
     const toolchain = folderContext.toolchain;
-    let buildTaskNameSuffix = "";
-    if (folderContext.relativePath.length > 0) {
-        buildTaskNameSuffix = ` (${folderContext.relativePath})`;
-    }
-
-    const buildDebugName = `Build Debug ${product.name}${buildTaskNameSuffix}`;
+    const buildDebugName = `Build Debug ${product.name}`;
     const buildDebugTask = createSwiftTask(
         ["build", "--product", product.name, ...buildOptions(toolchain)],
         buildDebugName,
@@ -248,6 +244,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
             presentationOptions: {
                 reveal: getBuildRevealOption(),
             },
+            packageName: packageName(folderContext),
             disableTaskQueue: true,
             dontTriggerTestDiscovery: true,
         },
@@ -255,10 +252,10 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
     );
     const buildDebug = buildAllTaskCache.get(buildDebugName, folderContext, buildDebugTask);
 
-    const buildReleaseName = `Build Release ${product.name}${buildTaskNameSuffix}`;
+    const buildReleaseName = `Build Release ${product.name}`;
     const buildReleaseTask = createSwiftTask(
         ["build", "-c", "release", "--product", product.name, ...buildOptions(toolchain, false)],
-        `Build Release ${product.name}${buildTaskNameSuffix}`,
+        `Build Release ${product.name}`,
         {
             group: vscode.TaskGroup.Build,
             cwd: folderContext.folder,
@@ -266,6 +263,7 @@ function createBuildTasks(product: Product, folderContext: FolderContext): vscod
             presentationOptions: {
                 reveal: getBuildRevealOption(),
             },
+            packageName: packageName(folderContext),
             disableTaskQueue: true,
             dontTriggerTestDiscovery: true,
         },
@@ -306,6 +304,9 @@ export function createSwiftTask(
     }*/
     const env = { ...configuration.swiftEnvironmentVariables, ...swiftRuntimeEnv(), ...cmdEnv };
     const presentation = config?.presentationOptions ?? {};
+    if (config?.packageName) {
+        name += ` (${config?.packageName})`;
+    }
     const task = new vscode.Task(
         {
             type: "swift",
@@ -334,14 +335,7 @@ export function createSwiftTask(
     );
     // This doesn't include any quotes added by VS Code.
     // See also: https://github.com/microsoft/vscode/issues/137895
-
-    let prefix: string;
-    if (config?.prefix) {
-        prefix = `(${config.prefix}) `;
-    } else {
-        prefix = "";
-    }
-    task.detail = `${prefix}swift ${args.join(" ")}`;
+    task.detail = `swift ${args.join(" ")}`;
     task.group = config?.group;
     task.presentationOptions = presentation;
     return task as SwiftTask;

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -190,11 +190,17 @@ export async function getBuildAllTask(
     // search for build all task in task.json first, that are valid for folder
     const tasks = await vscode.tasks.fetchTasks();
     const workspaceTasks = tasks.filter(task => {
-        if (task.source !== "Workspace" || task.scope !== folderContext.workspaceFolder) {
+        if (task.source !== "Workspace") {
             return false;
         }
         const swiftExecutionOptions = (task.execution as SwiftExecution).options;
         let cwd = swiftExecutionOptions?.cwd;
+        if (task.scope === vscode.TaskScope.Workspace) {
+            return cwd && substituteVariablesInString(cwd) === folderContext.folder.fsPath;
+        }
+        if (task.scope !== folderContext.workspaceFolder) {
+            return false;
+        }
         if (cwd === "${workspaceFolder}" || cwd === undefined) {
             cwd = folderWorkingDir;
         }

--- a/src/ui/StatusItem.ts
+++ b/src/ui/StatusItem.ts
@@ -13,18 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 import * as vscode from "vscode";
-import * as path from "path";
 
 export class RunningTask {
     constructor(public task: vscode.Task | string) {}
     get name(): string {
         if (typeof this.task !== "string") {
-            const folder = this.task.definition.cwd as string;
-            if (folder) {
-                return `${this.task.name} (${path.basename(folder)})`;
-            } else {
-                return this.task.name;
-            }
+            return this.task.name;
         } else {
             return this.task;
         }

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import * as path from "path";
 import * as vscode from "vscode";
+import { substituteVariablesInString } from "../configuration";
 import { FolderContext } from "../FolderContext";
 
 export const lineBreakRegex = /\r\n|\n|\r/gm;
@@ -21,6 +22,10 @@ export function resolveTaskCwd(task: vscode.Task, cwd?: string): string | undefi
     const scopeWorkspaceFolder = getScopeWorkspaceFolder(task);
     if (!cwd) {
         return scopeWorkspaceFolder;
+    }
+
+    if (/\$\{.*\}/g.test(cwd)) {
+        return substituteVariablesInString(cwd);
     }
 
     if (path.isAbsolute(cwd)) {

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import * as path from "path";
 import * as vscode from "vscode";
+import { FolderContext } from "../FolderContext";
 
 export const lineBreakRegex = /\r\n|\n|\r/gm;
 
@@ -52,4 +53,12 @@ export function checkIfBuildComplete(line: string): boolean {
         return true;
     }
     return false;
+}
+
+export function packageName(folderContext: FolderContext): string | undefined {
+    if (vscode.workspace.workspaceFile) {
+        return folderContext.name;
+    } else if (folderContext.relativePath.length > 0) {
+        return folderContext.relativePath;
+    }
 }

--- a/src/utilities/tasks.ts
+++ b/src/utilities/tasks.ts
@@ -67,3 +67,10 @@ export function packageName(folderContext: FolderContext): string | undefined {
         return folderContext.relativePath;
     }
 }
+
+export function resolveScope(scope: vscode.WorkspaceFolder | vscode.TaskScope) {
+    if (vscode.workspace.workspaceFile) {
+        return vscode.TaskScope.Workspace;
+    }
+    return scope;
+}

--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -27,6 +27,7 @@ import {
 } from "./utilities/testutilities";
 import { FolderContext } from "../../src/FolderContext";
 import { assertContains } from "./testexplorer/utilities";
+import { resolveScope } from "../../src/utilities/tasks";
 
 function assertContainsArg(execution: SwiftExecution, arg: string) {
     assert(execution?.args.find(a => a === arg));
@@ -124,7 +125,7 @@ suite("WorkspaceContext Test Suite", () => {
             assertContainsArg(execution, "--build-tests");
             assertContainsArg(execution, "-Xswiftc");
             assertContainsArg(execution, "-diagnostic-style=llvm");
-            assert.strictEqual(buildAllTask.scope, folder.workspaceFolder);
+            assert.strictEqual(buildAllTask.scope, resolveScope(folder.workspaceFolder));
         });
 
         test('"default" diagnosticsStyle', async () => {
@@ -142,7 +143,7 @@ suite("WorkspaceContext Test Suite", () => {
             assertContainsArg(execution, "build");
             assertContainsArg(execution, "--build-tests");
             assertNotContainsArg(execution, "-diagnostic-style");
-            assert.strictEqual(buildAllTask.scope, folder.workspaceFolder);
+            assert.strictEqual(buildAllTask.scope, resolveScope(folder.workspaceFolder));
         });
 
         test('"swift" diagnosticsStyle', async () => {
@@ -161,7 +162,7 @@ suite("WorkspaceContext Test Suite", () => {
             assertContainsArg(execution, "--build-tests");
             assertContainsArg(execution, "-Xswiftc");
             assertContainsArg(execution, "-diagnostic-style=swift");
-            assert.strictEqual(buildAllTask.scope, folder.workspaceFolder);
+            assert.strictEqual(buildAllTask.scope, resolveScope(folder.workspaceFolder));
         });
 
         test("Build Settings", async () => {

--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -49,7 +49,7 @@ suite("WorkspaceContext Test Suite", () => {
                 workspaceContext = ctx;
             },
             // No default assets as we want to verify against a clean workspace.
-            testAssets: [],
+            testAssets: ["defaultPackage"],
         });
 
         test("Add", async () => {

--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -20,7 +20,11 @@ import { FolderOperation, WorkspaceContext } from "../../src/WorkspaceContext";
 import { createBuildAllTask } from "../../src/tasks/SwiftTaskProvider";
 import { Version } from "../../src/utilities/version";
 import { SwiftExecution } from "../../src/tasks/SwiftExecution";
-import { activateExtensionForSuite, updateSettings } from "./utilities/testutilities";
+import {
+    activateExtensionForSuite,
+    getRootWorkspaceFolder,
+    updateSettings,
+} from "./utilities/testutilities";
 import { FolderContext } from "../../src/FolderContext";
 import { assertContains } from "./testexplorer/utilities";
 
@@ -60,7 +64,7 @@ suite("WorkspaceContext Test Suite", () => {
                     recordedFolders.push(changedFolderRecord);
                 });
 
-                const workspaceFolder = vscode.workspace.workspaceFolders?.values().next().value;
+                const workspaceFolder = getRootWorkspaceFolder();
 
                 assert.ok(workspaceFolder, "No workspace folders found in workspace");
 
@@ -102,7 +106,7 @@ suite("WorkspaceContext Test Suite", () => {
         });
 
         // Was hitting a timeout in suiteSetup during CI build once in a while
-        this.timeout(5000);
+        this.timeout(15000);
 
         test("Default Task values", async () => {
             const folder = workspaceContext.folders.find(
@@ -244,4 +248,4 @@ suite("WorkspaceContext Test Suite", () => {
             });
         }).timeout(1000);
     });
-}).timeout(10000);
+}).timeout(15000);

--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -68,7 +68,8 @@ suite("Build Commands @slow", function () {
         // NB: "stopped" is the exact command when debuggee has stopped due to break point,
         // but "stackTrace" is the deterministic sync point we will use to make sure we can execute continue
         const bpPromise = waitForDebugAdapterRequest(
-            "Debug PackageExe (defaultPackage)",
+            "Debug PackageExe (defaultPackage)" +
+                (vscode.workspace.workspaceFile ? " (workspace)" : ""),
             workspaceContext.globalToolchain.swiftVersion,
             "stackTrace"
         );

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -36,6 +36,7 @@ suite("Dependency Commmands Test Suite", function () {
             workspaceContext = ctx;
             depsContext = await folderInRootWorkspace("dependencies", workspaceContext);
         },
+        testAssets: ["dependencies"],
     });
 
     setup(async () => {

--- a/test/integration-tests/configuration.test.ts
+++ b/test/integration-tests/configuration.test.ts
@@ -12,9 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import * as vscode from "vscode";
 import * as path from "path";
-import { activateExtensionForSuite, updateSettings } from "./utilities/testutilities";
+import {
+    activateExtensionForSuite,
+    getRootWorkspaceFolder,
+    updateSettings,
+} from "./utilities/testutilities";
 import { expect } from "chai";
 import { afterEach } from "mocha";
 import configuration from "../../src/configuration";
@@ -47,7 +50,7 @@ suite("Configuration Test Suite", function () {
         expect(task.definition.args).to.not.be.undefined;
         const index = task.definition.args.indexOf("--scratch-path");
         expect(task.definition.args[index + 1]).to.equal(
-            vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath + "/somepath"
+            getRootWorkspaceFolder()?.uri.fsPath + "/somepath"
         );
     });
 
@@ -56,7 +59,7 @@ suite("Configuration Test Suite", function () {
             "swift.buildPath": "${workspaceFolder}${pathSeparator}${workspaceFolderBasename}",
         });
 
-        const basePath = vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath;
+        const basePath = getRootWorkspaceFolder()?.uri.fsPath;
         const baseName = path.basename(basePath ?? "");
         const sep = path.sep;
         expect(configuration.buildPath).to.equal(`${basePath}${sep}${baseName}`);

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -245,7 +245,6 @@ suite("SwiftPluginTaskProvider Test Suite", function () {
                 });
 
                 test("provides", () => {
-                    expect(task?.detail).to.equal("swift package command_plugin");
                     expect(task?.execution.args).to.deep.equal(
                         folderContext.toolchain.buildFlags.withAdditionalFlags([
                             "package",
@@ -264,15 +263,24 @@ suite("SwiftPluginTaskProvider Test Suite", function () {
             });
 
             suite("includes command plugin provided by tasks.json", () => {
-                let task: vscode.Task | undefined;
+                let task: SwiftTask | undefined;
 
                 setup(async () => {
                     const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
-                    task = tasks.find(t => t.name === "swift: command-plugin from tasks.json");
+                    task = tasks.find(
+                        t => t.name === "swift: command-plugin from tasks.json"
+                    ) as SwiftTask;
                 });
 
                 test("provides", () => {
-                    expect(task?.detail).to.include("swift package command_plugin --foo");
+                    expect(task?.execution.args).to.deep.equal(
+                        folderContext.toolchain.buildFlags.withAdditionalFlags([
+                            "package",
+                            "--disable-sandbox",
+                            "command_plugin",
+                            "--foo",
+                        ])
+                    );
                 });
 
                 test("executes", async () => {

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -268,7 +268,10 @@ suite("SwiftPluginTaskProvider Test Suite", function () {
                 setup(async () => {
                     const tasks = await vscode.tasks.fetchTasks({ type: "swift-plugin" });
                     task = tasks.find(
-                        t => t.name === "swift: command-plugin from tasks.json"
+                        t =>
+                            t.name ===
+                            "swift: command-plugin from " +
+                                (vscode.workspace.workspaceFile ? "code workspace" : "tasks.json")
                     ) as SwiftTask;
                 });
 

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -245,6 +245,7 @@ suite("SwiftPluginTaskProvider Test Suite", function () {
                 });
 
                 test("provides", () => {
+                    expect(task?.detail).to.equal("swift package command_plugin");
                     expect(task?.execution.args).to.deep.equal(
                         folderContext.toolchain.buildFlags.withAdditionalFlags([
                             "package",

--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -120,7 +120,12 @@ suite("SwiftTaskProvider Test Suite", () => {
 
             setup(async () => {
                 const tasks = await vscode.tasks.fetchTasks({ type: "swift" });
-                task = tasks.find(t => t.name === "swift: Build All from tasks.json");
+                task = tasks.find(
+                    t =>
+                        t.name ===
+                        "swift: Build All from " +
+                            (vscode.workspace.workspaceFile ? "code workspace" : "tasks.json")
+                );
             });
 
             test("provided", async () => {

--- a/test/integration-tests/tasks/TaskQueue.test.ts
+++ b/test/integration-tests/tasks/TaskQueue.test.ts
@@ -17,7 +17,7 @@ import * as assert from "assert";
 import { testAssetPath } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftExecOperation, TaskOperation, TaskQueue } from "../../../src/tasks/TaskQueue";
-import { activateExtensionForSuite } from "../utilities/testutilities";
+import { activateExtensionForSuite, findWorkspaceFolder } from "../utilities/testutilities";
 
 suite("TaskQueue Test Suite", () => {
     let workspaceContext: WorkspaceContext;
@@ -155,7 +155,7 @@ suite("TaskQueue Test Suite", () => {
 
     // check queuing task will return expected value
     test("swift exec", async () => {
-        const folder = workspaceContext.folders.find(f => f.name === "test/defaultPackage");
+        const folder = findWorkspaceFolder("defaultPackage", workspaceContext);
         assert(folder);
         const operation = new SwiftExecOperation(
             ["--version"],
@@ -172,7 +172,7 @@ suite("TaskQueue Test Suite", () => {
 
     // check queuing swift exec operation will throw expected error
     test("swift exec error", async () => {
-        const folder = workspaceContext.folders.find(f => f.name === "test/defaultPackage");
+        const folder = findWorkspaceFolder("defaultPackage", workspaceContext);
         assert(folder);
         const operation = new SwiftExecOperation(
             ["--version"],

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -27,8 +27,10 @@ import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 import configuration from "../../../src/configuration";
 import { resetBuildAllTaskCache } from "../../../src/tasks/SwiftTaskProvider";
 
-function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
-    const result = vscode.workspace.workspaceFolders?.at(0);
+const codeWorkspaceFolders = ["defaultPackage", "diagnostics", "command-plugin"];
+
+export function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
+    const result = vscode.workspace.workspaceFolders?.find(f => f.name === "test");
     assert(result, "No workspace folders were opened for the tests to use");
     return result;
 }

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -238,7 +238,17 @@ const extensionBootstrapper = (() => {
             } else if (expectedAssets.length > 0) {
                 await new Promise<void>(res => {
                     const found: string[] = [];
-                    workspaceContext.onDidChangeFolders(e => {
+                    for (const f of workspaceContext.folders) {
+                        if (found.includes(f.name) || !expectedAssets.includes(f.name)) {
+                            continue;
+                        }
+                        found.push(f.name);
+                    }
+                    if (expectedAssets.length === found.length) {
+                        res();
+                        return;
+                    }
+                    const disposable = workspaceContext.onDidChangeFolders(e => {
                         if (
                             e.operation !== FolderOperation.add ||
                             found.includes(e.folder!.name) ||
@@ -249,6 +259,7 @@ const extensionBootstrapper = (() => {
                         found.push(e.folder!.name);
                         if (expectedAssets.length === found.length) {
                             res();
+                            disposable.dispose();
                         }
                     });
                 });

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -27,8 +27,6 @@ import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 import configuration from "../../../src/configuration";
 import { resetBuildAllTaskCache } from "../../../src/tasks/SwiftTaskProvider";
 
-const codeWorkspaceFolders = ["defaultPackage", "diagnostics", "command-plugin"];
-
 export function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     const result = vscode.workspace.workspaceFolders?.find(f => f.name === "test");
     assert(result, "No workspace folders were opened for the tests to use");

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -27,10 +27,8 @@ import { SwiftOutputChannel } from "../../../src/ui/SwiftOutputChannel";
 import configuration from "../../../src/configuration";
 import { resetBuildAllTaskCache } from "../../../src/tasks/SwiftTaskProvider";
 
-// const codeWorkspaceFolders = ["defaultPackage", "diagnostics", "command-plugin"];
-
 export function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
-    const result = vscode.workspace.workspaceFolders?.find(f => f.name === "test");
+    const result = vscode.workspace.workspaceFolders?.at(0);
     assert(result, "No workspace folders were opened for the tests to use");
     return result;
 }


### PR DESCRIPTION
- Support workspace folder variable subsitution, ex. `${workspaceFolder:proj1}`
- When a code-workspace add the configured `name` instead of the relative path as a postfix to the task name
- Add same postfixes to plugin tasks
- For Run and Debug Build commands, all fetching launch configurations from outside the workspace
- Add a new test target to test a handful of currated suites to make sure that .code-workspace support does not break

Issue: #1072