### PR TITLE
Only use the context key for enabling the "swift.switchPlatform" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -908,7 +908,7 @@
         },
         {
           "command": "swift.switchPlatform",
-          "when": "swift.isActivated && isMac && swift.switchPlatformAvailable"
+          "when": "swift.switchPlatformAvailable"
         },
         {
           "command": "swift.insertFunctionComment",

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -110,9 +110,10 @@ function createContextKeys(): ContextKeys {
             this.createNewProjectAvailable = toolchainVersion.isGreaterThanOrEqual(
                 new Version(5, 8, 0)
             );
-            this.switchPlatformAvailable = toolchainVersion.isGreaterThanOrEqual(
-                new Version(6, 1, 0)
-            );
+            this.switchPlatformAvailable =
+                process.platform === "darwin"
+                    ? toolchainVersion.isGreaterThanOrEqual(new Version(6, 1, 0))
+                    : false;
         },
 
         get isActivated() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -243,8 +243,6 @@ async function createActiveToolchain(
     } catch (error) {
         outputChannel.log("Failed to discover Swift toolchain");
         outputChannel.log(`${error}`);
-        contextKeys.createNewProjectAvailable = false;
-        contextKeys.switchPlatformAvailable = false;
         return undefined;
     }
 }


### PR DESCRIPTION
It appears that the `isMac` context key provided by VS Code does not work the way we expect when running in a remote extension host. Update the logic for the `swift.switchPlatformAvailable` context key to check for the active platform and use that instead.

Issue: #1363