### PR TITLE
Disable nightly-6.1 run for Windows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,6 +62,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
+      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"}]' # Missing https://github.com/swiftlang/swift/pull/80144
       windows_env_vars: |
         CI=1
         VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"}]' # Missing https://github.com/swiftlang/swift/pull/80144
+      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"}]'  # Missing https://github.com/swiftlang/swift/pull/80144
       windows_env_vars: |
         CI=1
         VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}


### PR DESCRIPTION
Hasn't been a build off release/6.1 since March 3rd but we need the fix for https://github.com/swiftlang/swift/pull/80144 that was made March 25th