### PR TITLE
Await the run plugin task command

### DIFF
--- a/src/commands/runPluginTask.ts
+++ b/src/commands/runPluginTask.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 
 export async function runPluginTask() {
-    vscode.commands.executeCommand("workbench.action.tasks.runTask", {
+    await vscode.commands.executeCommand("workbench.action.tasks.runTask", {
         type: "swift-plugin",
     });
 }


### PR DESCRIPTION
Explicitly calling so not awaiting here may be causing a timing issue
```
2) runPluginTask Test Suite
       Executes runTask command:
     AssertionError: expected stub to have been called exactly once with arguments 'workbench.action.tasks.runTask', { type: 'swift-plugin' }
      at Context.<anonymous> (d:\a\vscode-swift\vscode-swift\test\integration-tests\commands\runPluginTask.test.ts:37:58)
```

Issue: #1574