### PR TITLE
Add command to generate launch configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,11 @@
     ],
     "commands": [
       {
+        "command": "swift.generateLaunchConfigurations",
+        "title": "Generate Launch Configurations",
+        "category": "Swift"
+      },
+      {
         "command": "swift.previewDocumentation",
         "title": "Preview Documentation",
         "category": "Swift",
@@ -886,6 +891,10 @@
         }
       ],
       "commandPalette": [
+        {
+          "command": "swift.generateLaunchConfigurations",
+          "when": "swift.hasPackage"
+        },
         {
           "command": "swift.previewDocumentation",
           "when": "swift.supportsDocumentationLivePreview"

--- a/package.json
+++ b/package.json
@@ -893,7 +893,7 @@
       "commandPalette": [
         {
           "command": "swift.generateLaunchConfigurations",
-          "when": "swift.hasPackage"
+          "when": "swift.hasExecutableProduct"
         },
         {
           "command": "swift.previewDocumentation",

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -228,15 +228,18 @@ export class WorkspaceContext implements vscode.Disposable {
     updateContextKeys(folderContext: FolderContext | null) {
         if (!folderContext) {
             contextKeys.hasPackage = false;
+            contextKeys.hasExecutableProduct = false;
             contextKeys.packageHasDependencies = false;
             return;
         }
 
         Promise.all([
             folderContext.swiftPackage.foundPackage,
+            folderContext.swiftPackage.executableProducts,
             folderContext.swiftPackage.dependencies,
-        ]).then(([foundPackage, dependencies]) => {
+        ]).then(([foundPackage, executableProducts, dependencies]) => {
             contextKeys.hasPackage = foundPackage;
+            contextKeys.hasExecutableProduct = executableProducts.length > 0;
             contextKeys.packageHasDependencies = dependencies.length > 0;
         });
     }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -101,7 +101,7 @@ export class WorkspaceContext implements vscode.Disposable {
                     .then(async selected => {
                         if (selected === "Update") {
                             this.folders.forEach(ctx =>
-                                makeDebugConfigurations(ctx, undefined, true)
+                                makeDebugConfigurations(ctx, { yes: true })
                             );
                         }
                     });
@@ -120,7 +120,7 @@ export class WorkspaceContext implements vscode.Disposable {
                     .then(selected => {
                         if (selected === "Update") {
                             this.folders.forEach(ctx =>
-                                makeDebugConfigurations(ctx, undefined, true)
+                                makeDebugConfigurations(ctx, { yes: true })
                             );
                         }
                     });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -47,6 +47,7 @@ import { TestKind } from "./TestExplorer/TestKind";
 import { pickProcess } from "./commands/pickProcess";
 import { openDocumentation } from "./commands/openDocumentation";
 import restartLSPServer from "./commands/restartLSPServer";
+import { generateLaunchConfigurations } from "./commands/generateLaunchConfigurations";
 
 /**
  * References:
@@ -105,6 +106,9 @@ export enum Commands {
  */
 export function register(ctx: WorkspaceContext): vscode.Disposable[] {
     return [
+        vscode.commands.registerCommand("swift.generateLaunchConfigurations", () =>
+            generateLaunchConfigurations(ctx)
+        ),
         vscode.commands.registerCommand("swift.newFile", uri => newSwiftFile(uri)),
         vscode.commands.registerCommand(Commands.RESOLVE_DEPENDENCIES, () =>
             resolveDependencies(ctx)

--- a/src/commands/generateLaunchConfigurations.ts
+++ b/src/commands/generateLaunchConfigurations.ts
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import { makeDebugConfigurations } from "../debugger/launch";
+import { FolderContext } from "../FolderContext";
+import { WorkspaceContext } from "../WorkspaceContext";
+import * as vscode from "vscode";
+
+export async function generateLaunchConfigurations(ctx: WorkspaceContext): Promise<boolean> {
+    if (ctx.folders.length === 0) {
+        return false;
+    }
+
+    if (ctx.folders.length === 1) {
+        return await makeDebugConfigurations(ctx.folders[0], { force: true, yes: true });
+    }
+
+    const quickPickItems: SelectFolderQuickPick[] = ctx.folders.map(folder => ({
+        type: "folder",
+        folder,
+        label: folder.name,
+        detail: folder.workspaceFolder.uri.fsPath,
+    }));
+    quickPickItems.push({ type: "all", label: "Generate For All Folders" });
+    const selection = await vscode.window.showQuickPick(quickPickItems, {
+        matchOnDetail: true,
+        placeHolder: "Select a folder to generate launch configurations for",
+    });
+
+    if (!selection) {
+        return false;
+    }
+
+    const foldersToUpdate: FolderContext[] = [];
+    if (selection.type === "all") {
+        foldersToUpdate.push(...ctx.folders);
+    } else {
+        foldersToUpdate.push(selection.folder);
+    }
+
+    return (
+        await Promise.all(
+            foldersToUpdate.map(folder =>
+                makeDebugConfigurations(folder, { force: true, yes: true })
+            )
+        )
+    ).reduceRight((prev, curr) => prev || curr);
+}
+
+type SelectFolderQuickPick = AllQuickPickItem | FolderQuickPickItem;
+
+interface AllQuickPickItem extends vscode.QuickPickItem {
+    type: "all";
+}
+
+interface FolderQuickPickItem extends vscode.QuickPickItem {
+    type: "folder";
+    folder: FolderContext;
+}

--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -35,6 +35,11 @@ interface ContextKeys {
     hasPackage: boolean;
 
     /**
+     * Whether the workspace folder contains a Swift package with at least one executable product.
+     */
+    hasExecutableProduct: boolean;
+
+    /**
      * Whether the Swift package has any dependencies to display in the Package Dependencies view.
      */
     packageHasDependencies: boolean;
@@ -94,6 +99,7 @@ interface ContextKeys {
 function createContextKeys(): ContextKeys {
     let isActivated: boolean = false;
     let hasPackage: boolean = false;
+    let hasExecutableProduct: boolean = false;
     let flatDependenciesList: boolean = false;
     let packageHasDependencies: boolean = false;
     let packageHasPlugins: boolean = false;
@@ -132,6 +138,15 @@ function createContextKeys(): ContextKeys {
         set hasPackage(value: boolean) {
             hasPackage = value;
             vscode.commands.executeCommand("setContext", "swift.hasPackage", value);
+        },
+
+        get hasExecutableProduct() {
+            return hasExecutableProduct;
+        },
+
+        set hasExecutableProduct(value: boolean) {
+            hasExecutableProduct = value;
+            vscode.commands.executeCommand("setContext", "swift.hasExecutableTarget", value);
         },
 
         get packageHasDependencies() {

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -371,6 +371,7 @@ export class ProjectPanelProvider implements vscode.TreeDataProvider<TreeNode> {
     constructor(private workspaceContext: WorkspaceContext) {
         // default context key to false. These will be updated as folders are given focus
         contextKeys.hasPackage = false;
+        contextKeys.hasExecutableProduct = false;
         contextKeys.packageHasDependencies = false;
 
         this.observeTasks(workspaceContext);

--- a/test/unit-tests/debugger/launch.test.ts
+++ b/test/unit-tests/debugger/launch.test.ts
@@ -1,0 +1,286 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import * as vscode from "vscode";
+import { expect } from "chai";
+import configuration, { FolderConfiguration } from "../../../src/configuration";
+import { makeDebugConfigurations } from "../../../src/debugger/launch";
+import { FolderContext } from "../../../src/FolderContext";
+import {
+    instance,
+    MockedObject,
+    mockFn,
+    mockGlobalModule,
+    mockGlobalObject,
+    mockObject,
+} from "../../MockUtils";
+import { Product, SwiftPackage } from "../../../src/SwiftPackage";
+import { SWIFT_LAUNCH_CONFIG_TYPE } from "../../../src/debugger/debugAdapter";
+
+suite("Launch Configurations Test", () => {
+    const mockConfiguration = mockGlobalModule(configuration);
+    let mockFolderConfiguration: MockedObject<FolderConfiguration>;
+    const mockWorkspace = mockGlobalObject(vscode, "workspace");
+    let mockLaunchWSConfig: MockedObject<vscode.WorkspaceConfiguration>;
+
+    // Create a mock folder to be used by each test
+    const folderURI = vscode.Uri.file("/path/to/folder");
+    const swiftPackage = mockObject<SwiftPackage>({
+        executableProducts: Promise.resolve<Product[]>([
+            { name: "executable", targets: [], type: { executable: null } },
+        ]),
+    });
+    const folder = mockObject<FolderContext>({
+        folder: folderURI,
+        workspaceFolder: {
+            index: 0,
+            name: "folder",
+            uri: folderURI,
+        },
+        relativePath: "",
+        swiftPackage: instance(swiftPackage),
+    });
+
+    setup(() => {
+        mockFolderConfiguration = mockObject<FolderConfiguration>({
+            autoGenerateLaunchConfigurations: true,
+        });
+        mockConfiguration.folder.returns(mockFolderConfiguration);
+        mockLaunchWSConfig = mockObject<vscode.WorkspaceConfiguration>({
+            get: mockFn(),
+            update: mockFn(),
+        });
+        mockWorkspace.getConfiguration.withArgs("launch").returns(instance(mockLaunchWSConfig));
+        mockLaunchWSConfig.get.withArgs("configurations").returns([]);
+    });
+
+    test("generates launch configurations for executable products", async () => {
+        expect(await makeDebugConfigurations(instance(folder), { yes: true })).to.be.true;
+        expect(mockLaunchWSConfig.update).to.have.been.calledWith(
+            "configurations",
+            [
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Debug executable",
+                    program: "${workspaceFolder:folder}/.build/debug/executable",
+                    preLaunchTask: "swift: Build Debug executable",
+                },
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Release executable",
+                    program: "${workspaceFolder:folder}/.build/release/executable",
+                    preLaunchTask: "swift: Build Release executable",
+                },
+            ],
+            vscode.ConfigurationTarget.WorkspaceFolder
+        );
+    });
+
+    test("doesn't generate launch configurations if disabled in settings", async () => {
+        mockFolderConfiguration.autoGenerateLaunchConfigurations = false;
+
+        expect(await makeDebugConfigurations(instance(folder), { yes: true })).to.be.false;
+        expect(mockLaunchWSConfig.update).to.not.have.been.called;
+    });
+
+    test("forces the generation of launch configurations if force is set to true", async () => {
+        mockFolderConfiguration.autoGenerateLaunchConfigurations = false;
+
+        expect(await makeDebugConfigurations(instance(folder), { force: true, yes: true })).to.be
+            .true;
+        expect(mockLaunchWSConfig.update).to.have.been.calledWith(
+            "configurations",
+            [
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Debug executable",
+                    program: "${workspaceFolder:folder}/.build/debug/executable",
+                    preLaunchTask: "swift: Build Debug executable",
+                },
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Release executable",
+                    program: "${workspaceFolder:folder}/.build/release/executable",
+                    preLaunchTask: "swift: Build Release executable",
+                },
+            ],
+            vscode.ConfigurationTarget.WorkspaceFolder
+        );
+    });
+
+    test("updates launch configurations that have old lldb/swift-lldb types", async () => {
+        mockLaunchWSConfig.get.withArgs("configurations").returns([
+            {
+                type: "swift-lldb",
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Debug executable",
+                program: "${workspaceFolder:folder}/.build/debug/executable",
+                preLaunchTask: "swift: Build Debug executable",
+            },
+            {
+                type: "lldb",
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Release executable",
+                program: "${workspaceFolder:folder}/.build/release/executable",
+                preLaunchTask: "swift: Build Release executable",
+            },
+        ]);
+
+        expect(await makeDebugConfigurations(instance(folder), { yes: true })).to.be.true;
+        expect(mockLaunchWSConfig.update).to.have.been.calledWith(
+            "configurations",
+            [
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Debug executable",
+                    program: "${workspaceFolder:folder}/.build/debug/executable",
+                    preLaunchTask: "swift: Build Debug executable",
+                },
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Release executable",
+                    program: "${workspaceFolder:folder}/.build/release/executable",
+                    preLaunchTask: "swift: Build Release executable",
+                },
+            ],
+            vscode.ConfigurationTarget.WorkspaceFolder
+        );
+    });
+
+    test("doesn't update launch configurations if disabled in settings", async () => {
+        mockFolderConfiguration.autoGenerateLaunchConfigurations = false;
+        mockLaunchWSConfig.get.withArgs("configurations").returns([
+            {
+                type: "swift-lldb",
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Debug executable",
+                program: "${workspaceFolder:folder}/.build/debug/executable",
+                preLaunchTask: "swift: Build Debug executable",
+            },
+            {
+                type: "lldb",
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Release executable",
+                program: "${workspaceFolder:folder}/.build/release/executable",
+                preLaunchTask: "swift: Build Release executable",
+            },
+        ]);
+
+        expect(await makeDebugConfigurations(instance(folder), { yes: true })).to.be.false;
+        expect(mockLaunchWSConfig.update).to.not.have.been.called;
+    });
+
+    test("forces the updating of launch configurations if force is set to true", async () => {
+        mockFolderConfiguration.autoGenerateLaunchConfigurations = false;
+        mockLaunchWSConfig.get.withArgs("configurations").returns([
+            {
+                type: "swift-lldb",
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Debug executable",
+                program: "${workspaceFolder:folder}/.build/debug/executable",
+                preLaunchTask: "swift: Build Debug executable",
+            },
+            {
+                type: "lldb",
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Release executable",
+                program: "${workspaceFolder:folder}/.build/release/executable",
+                preLaunchTask: "swift: Build Release executable",
+            },
+        ]);
+
+        expect(await makeDebugConfigurations(instance(folder), { force: true, yes: true })).to.be
+            .true;
+        expect(mockLaunchWSConfig.update).to.have.been.calledWith(
+            "configurations",
+            [
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Debug executable",
+                    program: "${workspaceFolder:folder}/.build/debug/executable",
+                    preLaunchTask: "swift: Build Debug executable",
+                },
+                {
+                    type: SWIFT_LAUNCH_CONFIG_TYPE,
+                    request: "launch",
+                    args: [],
+                    cwd: "${workspaceFolder:folder}",
+                    name: "Release executable",
+                    program: "${workspaceFolder:folder}/.build/release/executable",
+                    preLaunchTask: "swift: Build Release executable",
+                },
+            ],
+            vscode.ConfigurationTarget.WorkspaceFolder
+        );
+    });
+
+    test("doesn't update launch configurations if they already exist", async () => {
+        mockLaunchWSConfig.get.withArgs("configurations").returns([
+            {
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Debug executable",
+                program: "${workspaceFolder:folder}/.build/debug/executable",
+                preLaunchTask: "swift: Build Debug executable",
+            },
+            {
+                type: SWIFT_LAUNCH_CONFIG_TYPE,
+                request: "launch",
+                args: [],
+                cwd: "${workspaceFolder:folder}",
+                name: "Release executable",
+                program: "${workspaceFolder:folder}/.build/release/executable",
+                preLaunchTask: "swift: Build Release executable",
+            },
+        ]);
+
+        expect(await makeDebugConfigurations(instance(folder), { yes: true })).to.be.false;
+        expect(mockLaunchWSConfig.update).to.not.have.been.called;
+    });
+});


### PR DESCRIPTION
Adds a new command called `Swift: Generate Launch Configurations` that can be used to manually trigger the generation of launch configurations for the workspace.

I've also simplified the logic for generating launch configurations by moving some of the generated keys into the debugAdapterFactory so they can be applied at runtime without needing to be set in the launch config. This will reduce the need for updating launch configurations and, by extension, reduce the number of notifications we push to the user.

Issue: #1533