### PR TITLE
Remove CI checks in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1656,11 +1656,11 @@
   "scripts": {
     "vscode:prepublish": "npm run bundle",
     "bundle": "del-cli ./dist && npm run bundle-extension && npm run bundle-documentation-webview",
-    "bundle-extension": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/src/extension.js --external:vscode --format=cjs --platform=node --target=node18 --minify --sourcemap",
+    "bundle-extension": "del-cli ./dist && esbuild ./src/extension.ts --bundle --outfile=dist/src/extension.js --external:vscode --define:process.env.NODE_ENV=\\\"production\\\" --define:process.env.CI=\\\"\\\" --format=cjs --platform=node --target=node18 --minify --sourcemap",
     "bundle-documentation-webview": "npm run compile-documentation-webview -- --minify",
     "compile": "del-cli ./dist/ && tsc --build",
     "watch": "npm run compile -- --watch",
-    "compile-documentation-webview": "del-cli ./assets/documentation-webview && esbuild ./src/documentation/webview/webview.ts --bundle --outfile=assets/documentation-webview/index.js --format=cjs --sourcemap",
+    "compile-documentation-webview": "del-cli ./assets/documentation-webview && esbuild ./src/documentation/webview/webview.ts --bundle --outfile=assets/documentation-webview/index.js --define:process.env.NODE_ENV=\\\"production\\\" --define:process.env.CI=\\\"\\\" --format=cjs --sourcemap",
     "watch-documentation-webview": "npm run compile-documentation-webview -- --watch",
     "lint": "eslint ./ --ext ts && tsc --noEmit",
     "update-swift-docc-render": "tsx ./scripts/update_swift_docc_render.ts",

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -26,7 +26,7 @@ import { Version } from "../utilities/version";
 import { TestLibrary } from "../TestExplorer/TestRunner";
 import { TestKind, isDebugging, isRelease } from "../TestExplorer/TestKind";
 import { buildOptions } from "../tasks/SwiftTaskProvider";
-import { CI_DISABLE_ASLR } from "./lldb";
+import { updateLaunchConfigForCI } from "./lldb";
 
 export class BuildConfigurationFactory {
     public static buildAll(
@@ -697,7 +697,7 @@ export class TestingConfigurationFactory {
 async function getBaseConfig(ctx: FolderContext, expandEnvVariables: boolean) {
     const { folder, nameSuffix } = getFolderAndNameSuffix(ctx, expandEnvVariables);
     const packageName = await ctx.swiftPackage.name;
-    return {
+    return updateLaunchConfigForCI({
         type: SWIFT_LAUNCH_CONFIG_TYPE,
         request: "launch",
         sourceLanguages: ["swift"],
@@ -706,8 +706,7 @@ async function getBaseConfig(ctx: FolderContext, expandEnvVariables: boolean) {
         args: [],
         preLaunchTask: `swift: Build All${nameSuffix}`,
         terminal: "console",
-        ...CI_DISABLE_ASLR,
-    };
+    });
 }
 
 export function getFolderAndNameSuffix(

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -20,7 +20,7 @@ import { registerLoggingDebugAdapterTracker } from "./logTracker";
 import { SwiftToolchain } from "../toolchain/toolchain";
 import { SwiftOutputChannel } from "../ui/SwiftOutputChannel";
 import { fileExists } from "../utilities/filesystem";
-import { CI_DISABLE_ASLR, getLLDBLibPath } from "./lldb";
+import { updateLaunchConfigForCI, getLLDBLibPath } from "./lldb";
 import { getErrorDescription, swiftRuntimeEnv } from "../utilities/utilities";
 import configuration from "../configuration";
 
@@ -171,10 +171,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
             launchConfig.debugAdapterExecutable = lldbDapPath;
         }
 
-        return {
-            ...launchConfig,
-            ...CI_DISABLE_ASLR,
-        };
+        return updateLaunchConfigForCI(launchConfig);
     }
 
     private async promptToInstallCodeLLDB(): Promise<boolean> {

--- a/src/ui/SwiftOutputChannel.ts
+++ b/src/ui/SwiftOutputChannel.ts
@@ -14,6 +14,7 @@
 
 import * as vscode from "vscode";
 import configuration from "../configuration";
+import { IS_RUNNING_IN_CI } from "../utilities/utilities";
 
 export class SwiftOutputChannel implements vscode.OutputChannel {
     private channel: vscode.OutputChannel;
@@ -76,7 +77,7 @@ export class SwiftOutputChannel implements vscode.OutputChannel {
     }
 
     logDiagnostic(message: string, label?: string) {
-        if (!configuration.diagnostics && process.env["CI"] !== "1") {
+        if (!configuration.diagnostics && !IS_RUNNING_IN_CI) {
             return;
         }
         const fullMessage = label !== undefined ? `${label}: ${message}` : message;

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -21,6 +21,22 @@ import { FolderContext } from "../FolderContext";
 import { SwiftToolchain } from "../toolchain/toolchain";
 
 /**
+ * Whether or not this is a production build.
+ *
+ * Code that checks for this will be removed completely when the extension is packaged into
+ * a VSIX.
+ */
+export const IS_PRODUCTION_BUILD = process.env.NODE_ENV === "production";
+
+/**
+ * Whether or not the code is being run in CI.
+ *
+ * Code that checks for this will be removed completely when the extension is packaged into
+ * a VSIX.
+ */
+export const IS_RUNNING_IN_CI = process.env.CI === "1";
+
+/**
  * Get required environment variable for Swift product
  *
  * @param base base environment configuration

--- a/test/integration-tests/debugger/lldb.test.ts
+++ b/test/integration-tests/debugger/lldb.test.ts
@@ -17,6 +17,7 @@ import { getLLDBLibPath } from "../../../src/debugger/lldb";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { activateExtensionForTest } from "../utilities/testutilities";
 import { Version } from "../../../src/utilities/version";
+import { IS_RUNNING_IN_CI } from "../../../src/utilities/utilities";
 
 suite("lldb contract test suite", () => {
     let workspaceContext: WorkspaceContext;
@@ -25,7 +26,7 @@ suite("lldb contract test suite", () => {
         async setup(ctx) {
             // lldb.exe on Windows is not launching correctly, but only in Docker.
             if (
-                process.env["CI"] &&
+                IS_RUNNING_IN_CI &&
                 process.platform === "win32" &&
                 ctx.globalToolchainSwiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0)) &&
                 ctx.globalToolchainSwiftVersion.isLessThan(new Version(6, 0, 2))

--- a/test/unit-tests/debugger/debugAdapterFactory.test.ts
+++ b/test/unit-tests/debugger/debugAdapterFactory.test.ts
@@ -152,6 +152,7 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
                 update: mockFn(),
             });
             mockWorkspace.getConfiguration.returns(instance(mockLldbConfiguration));
+            mockLLDB.updateLaunchConfigForCI.returnsArg(0);
             mockLLDB.getLLDBLibPath.resolves(Result.makeSuccess("/path/to/liblldb.dyLib"));
             mockDebuggerConfig.setupCodeLLDB = "prompt";
             mockDebugAdapter.getLaunchConfigType.returns(LaunchConfigType.CODE_LLDB);


### PR DESCRIPTION
There was a bunch of code that checks for `process.env.CI === "1"` (or variations of that). Consolidated all of these checks into a utility called `IS_RUNNING_IN_CI` that will get optimized out of production builds using esbuild's `--define` command line argument.