### PR TITLE
Break immediately when cancelling a multiple test run

### DIFF
--- a/src/commands/testMultipleTimes.ts
+++ b/src/commands/testMultipleTimes.ts
@@ -75,7 +75,10 @@ export async function runTestMultipleTimes(
 
         runStates.push(runState);
 
-        if (untilFailure && (runState.failed.length > 0 || runState.errored.length > 0)) {
+        if (
+            runner.testRun.isCancellationRequested ||
+            (untilFailure && (runState.failed.length > 0 || runState.errored.length > 0))
+        ) {
             break;
         }
     }


### PR DESCRIPTION
When using "Run Test Multiple Times" or "Run Until Failure" cancelling the run would prevent subsequent test runs from occuring, but the logs would still print out "Beginning Test Iteration #x" for each remaining test iteration.

Exit out of the loop that is running the tests multiple times once cancellation has been requested. Also clean up the cancellation error message in the logs to be formatted not as an error but just a message.