### PR TITLE
Updates for nightly-6.2 toolchain

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM swiftlang/swift:nightly-6.1-jammy
+FROM swiftlang/swift:nightly-6.2-jammy
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,6 +51,7 @@ jobs:
     with:
       needs_token: true
       # Linux
+      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"}]'
       linux_env_vars: |
         NODE_VERSION=v20.19.0
         NODE_PATH=/usr/local/nvm/versions/node/v20.19.0/bin
@@ -78,7 +79,7 @@ jobs:
     with:
       needs_token: true
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-main"}]'
+      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-6.2"}, {"swift_version": "nightly-main"}]'
       linux_env_vars: |
         NODE_VERSION=v20.19.0
         NODE_PATH=/usr/local/nvm/versions/node/v20.19.0/bin
@@ -90,7 +91,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "6.0"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly"}]'
+      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "6.0"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-6.2"}, {"swift_version": "nightly"}]'
       windows_env_vars: |
         CI=1
         VSCODE_VERSION=insiders

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-main"}]'
+      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-6.2"},{"swift_version": "nightly-main"}]'
       linux_env_vars: |
         NODE_VERSION=v20.19.0
         NODE_PATH=/usr/local/nvm/versions/node/v20.19.0/bin
@@ -58,7 +58,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly"}]'
+      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"},{"swift_version": "nightly-6.2"},{"swift_version": "nightly"}]'
       windows_env_vars: |
         CI=1
         FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}


### PR DESCRIPTION
Can use that in the devcontainer as latest. Turn of in CI verifier jobs, and don't run in insiders nightly