### PR TITLE
Properly cleanup task event emitters

### DIFF
--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -192,7 +192,6 @@ export class SwiftPtyProcess implements SwiftProcess {
 
     dispose() {
         this.disposables.forEach(d => d.dispose());
-        this.spawnedProcess?.kill();
     }
 
     onDidSpawn: vscode.Event<void> = this.spawnEmitter.event;

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -19,7 +19,7 @@ import * as vscode from "vscode";
 import { requireNativeModule } from "../utilities/native";
 const { spawn } = requireNativeModule<typeof nodePty>("node-pty");
 
-export interface SwiftProcess {
+export interface SwiftProcess extends vscode.Disposable {
     /**
      * Resolved path to the `swift` executable
      */
@@ -73,7 +73,7 @@ export interface SwiftProcess {
     setDimensions(dimensions: vscode.TerminalDimensions): void;
 }
 
-class CloseHandler {
+class CloseHandler implements vscode.Disposable {
     private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
         number | void
     >();
@@ -94,6 +94,10 @@ class CloseHandler {
         }
     }
 
+    dispose() {
+        this.closeEmitter.dispose();
+    }
+
     private queueClose() {
         this.closeTimeout = setTimeout(() => {
             this.closeEmitter.fire(this.exitCode);
@@ -110,6 +114,7 @@ export class SwiftPtyProcess implements SwiftProcess {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly errorEmitter: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
     private readonly closeHandler: CloseHandler = new CloseHandler();
+    private disposables: vscode.Disposable[] = [];
 
     private spawnedProcess?: nodePty.IPty;
 
@@ -117,7 +122,14 @@ export class SwiftPtyProcess implements SwiftProcess {
         public readonly command: string,
         public readonly args: string[],
         private options: vscode.ProcessExecutionOptions = {}
-    ) {}
+    ) {
+        this.disposables.push(
+            this.spawnEmitter,
+            this.writeEmitter,
+            this.errorEmitter,
+            this.closeHandler
+        );
+    }
 
     spawn(): void {
         try {
@@ -147,6 +159,11 @@ export class SwiftPtyProcess implements SwiftProcess {
                     this.closeHandler.handle();
                 }
             });
+            this.disposables.push(
+                this.onDidClose(() => {
+                    this.dispose();
+                })
+            );
         } catch (error) {
             this.errorEmitter.fire(new Error(`${error}`));
             this.closeHandler.handle();
@@ -173,6 +190,11 @@ export class SwiftPtyProcess implements SwiftProcess {
         this.spawnedProcess?.resize(dimensions.columns, dimensions.rows);
     }
 
+    dispose() {
+        this.disposables.forEach(d => d.dispose());
+        this.spawnedProcess?.kill();
+    }
+
     onDidSpawn: vscode.Event<void> = this.spawnEmitter.event;
 
     onDidWrite: vscode.Event<string> = this.writeEmitter.event;
@@ -197,6 +219,7 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly errorEmitter: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
     private readonly closeHandler: CloseHandler = new CloseHandler();
+    private disposables: vscode.Disposable[] = [];
 
     private spawnedProcess: child_process.ChildProcessWithoutNullStreams | undefined;
 
@@ -204,7 +227,14 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
         public readonly command: string,
         public readonly args: string[],
         private readonly options: vscode.ProcessExecutionOptions = {}
-    ) {}
+    ) {
+        this.disposables.push(
+            this.spawnEmitter,
+            this.writeEmitter,
+            this.errorEmitter,
+            this.closeHandler
+        );
+    }
 
     spawn(): void {
         try {
@@ -231,12 +261,16 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
 
             this.spawnedProcess.once("exit", code => {
                 this.closeHandler.handle(code ?? undefined);
-                this.dispose();
             });
+
+            this.disposables.push(
+                this.onDidClose(() => {
+                    this.dispose();
+                })
+            );
         } catch (error) {
             this.errorEmitter.fire(new Error(`${error}`));
             this.closeHandler.handle();
-            this.dispose();
         }
     }
 
@@ -260,6 +294,7 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
         this.spawnedProcess?.stdout.removeAllListeners();
         this.spawnedProcess?.stderr.removeAllListeners();
         this.spawnedProcess?.removeAllListeners();
+        this.disposables.forEach(d => d.dispose());
     }
 
     onDidSpawn: vscode.Event<void> = this.spawnEmitter.event;

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -76,6 +76,8 @@ export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Dispos
         for (const disposable of this.disposables) {
             disposable.dispose();
         }
+        this.writeEmitter.dispose();
+        this.closeEmitter.dispose();
     }
 
     /**

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -70,10 +70,17 @@ export class TestSwiftProcess implements SwiftProcess {
     close(exitCode: number): void {
         this.exitCode = exitCode;
         this.closeEmitter.fire(exitCode);
+        this.dispose();
     }
 
     terminate(): void {
         this.close(8);
+    }
+
+    dispose() {
+        [this.spawnEmitter, this.writeEmitter, this.errorEmitter, this.closeEmitter].forEach(d =>
+            d.dispose()
+        );
     }
 
     // These instantaneous task processes can lead to some

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -35,9 +35,12 @@ suite("Dependency Commmands Test Suite", function () {
         async setup(ctx) {
             workspaceContext = ctx;
             depsContext = await folderInRootWorkspace("dependencies", workspaceContext);
-            await waitForNoRunningTasks();
-            await workspaceContext.focusFolder(depsContext);
         },
+    });
+
+    setup(async () => {
+        await workspaceContext.focusFolder(depsContext);
+        await waitForNoRunningTasks();
     });
 
     test("Swift: Update Package Dependencies", async function () {
@@ -50,7 +53,8 @@ suite("Dependency Commmands Test Suite", function () {
         expect(result).to.be.true;
     });
 
-    suite("Swift: Use Local Dependency", function () {
+    // Skipping: https://github.com/swiftlang/vscode-swift/issues/1316
+    suite.skip("Swift: Use Local Dependency", function () {
         let treeProvider: ProjectPanelProvider;
 
         setup(async () => {
@@ -103,7 +107,6 @@ suite("Dependency Commmands Test Suite", function () {
         }
 
         test("Swift: Reset Package Dependencies", async function () {
-            this.skip(); // https://github.com/swiftlang/vscode-swift/issues/1316
             // spm reset after using local dependency is broken on windows
             if (process.platform === "win32") {
                 this.skip();
@@ -120,7 +123,6 @@ suite("Dependency Commmands Test Suite", function () {
         });
 
         test("Swift: Revert To Original Version", async function () {
-            this.skip(); // https://github.com/swiftlang/vscode-swift/issues/1316
             await useLocalDependencyTest();
 
             const result = await vscode.commands.executeCommand(

--- a/test/integration-tests/tasks/SwiftExecution.test.ts
+++ b/test/integration-tests/tasks/SwiftExecution.test.ts
@@ -16,7 +16,11 @@ import * as vscode from "vscode";
 import * as assert from "assert";
 import { testSwiftTask } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
-import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities/tasks";
+import {
+    executeTaskAndWaitForResult,
+    waitForNoRunningTasks,
+    waitForStartTaskProcess,
+} from "../../utilities/tasks";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
 import { activateExtensionForSuite } from "../utilities/testutilities";
 
@@ -48,7 +52,9 @@ suite("SwiftExecution Tests Suite", () => {
 
     test("Write event handler fires", async () => {
         const fixture = testSwiftTask("swift", ["build"], workspaceFolder, toolchain);
+        const startPromise = waitForStartTaskProcess(fixture.task);
         const promise = executeTaskAndWaitForResult(fixture);
+        await startPromise;
         fixture.process.write("Fetching some dependency");
         fixture.process.write("[5/7] Building main.swift");
         fixture.process.write("Build complete");

--- a/test/integration-tests/tasks/SwiftPseudoterminal.test.ts
+++ b/test/integration-tests/tasks/SwiftPseudoterminal.test.ts
@@ -21,7 +21,7 @@ import { SwiftPseudoterminal } from "../../../src/tasks/SwiftPseudoterminal";
 suite("SwiftPseudoterminal Tests Suite", () => {
     test("Close event handler fires", async () => {
         const process = new TestSwiftProcess("swift", ["build"]);
-        const terminal = new SwiftPseudoterminal(process, {});
+        const terminal = new SwiftPseudoterminal(() => process, {});
 
         terminal.open(undefined);
         const promise = waitForClose(terminal);
@@ -33,7 +33,7 @@ suite("SwiftPseudoterminal Tests Suite", () => {
 
     test("Write event handler fires", async () => {
         const process = new TestSwiftProcess("swift", ["build"]);
-        const terminal = new SwiftPseudoterminal(process, {});
+        const terminal = new SwiftPseudoterminal(() => process, {});
 
         terminal.open(undefined);
         const promise = waitForWrite(terminal);
@@ -46,7 +46,7 @@ suite("SwiftPseudoterminal Tests Suite", () => {
 
     test("Echoes the command", async () => {
         const process = new TestSwiftProcess("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: true });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: true });
         const promise = waitForWrite(terminal);
 
         terminal.open(undefined);
@@ -57,7 +57,7 @@ suite("SwiftPseudoterminal Tests Suite", () => {
 
     test("Does not echo the command", async () => {
         const process = new TestSwiftProcess("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: false });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: false });
         let wrote = false;
         const disposable = terminal.onDidWrite(() => {
             wrote = true;
@@ -71,7 +71,7 @@ suite("SwiftPseudoterminal Tests Suite", () => {
 
     test("Handles error on spawn", async () => {
         const process = new TestSwiftProcess("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: false });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: false });
         process.setError(new Error("Uh oh!"));
 
         const promise = waitForClose(terminal);
@@ -90,7 +90,7 @@ suite("SwiftPseudoterminal Tests Suite", () => {
                 this.input = input;
             }
         })("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: false });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: false });
         const promise = waitForClose(terminal);
 
         terminal.open(undefined);
@@ -109,7 +109,8 @@ suite("SwiftPseudoterminal Tests Suite", () => {
                 this.input = input;
             }
         })("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: false });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: false });
+        terminal.open(undefined);
 
         terminal.handleInput("foo");
 
@@ -124,7 +125,7 @@ suite("SwiftPseudoterminal Tests Suite", () => {
                 this.dimensions = dimensions;
             }
         })("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: false });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: false });
 
         terminal.open({ rows: 100, columns: 200 });
 
@@ -139,10 +140,14 @@ suite("SwiftPseudoterminal Tests Suite", () => {
                 this.dimensions = dimensions;
             }
         })("swift", ["build", "-c", "dbg"]);
-        const terminal = new SwiftPseudoterminal(process, { echo: false });
+        const terminal = new SwiftPseudoterminal(() => process, { echo: false });
 
-        terminal.setDimensions({ rows: 100, columns: 200 });
+        terminal.open({ rows: 100, columns: 200 });
 
         assert.deepEqual(process.dimensions, { rows: 100, columns: 200 });
+
+        terminal.setDimensions({ rows: 200, columns: 400 });
+
+        assert.deepEqual(process.dimensions, { rows: 200, columns: 400 });
     });
 });

--- a/test/utilities/tasks.ts
+++ b/test/utilities/tasks.ts
@@ -143,6 +143,29 @@ export function waitForEndTaskProcess(task: vscode.Task): Promise<number | undef
 }
 
 /**
+ * Ideally we would want to use {@link executeTaskAndWaitForResult} but that
+ * requires the tests creating the task through some means. If the
+ * {@link vscode.Task Task}, was provided by the extension under test, the
+ * {@link SwiftTask.execution} event emitters never seem to fire.
+ *
+ * @param task task to listen for start event
+ */
+export function waitForStartTaskProcess(task: vscode.Task): Promise<void> {
+    return new Promise<void>(res => {
+        const disposables: vscode.Disposable[] = [];
+        disposables.push(
+            vscode.tasks.onDidStartTaskProcess(e => {
+                if (task.detail !== e.execution.task.detail) {
+                    return;
+                }
+                disposables.forEach(d => d.dispose());
+                res();
+            })
+        );
+    });
+}
+
+/**
  * Cleans the provided output stripping ansi and
  * cleaning extra whitespace
  *


### PR DESCRIPTION
- Were not displosing of event emitters
- Were cleaning up read-only process data listeners early