### PR TITLE
Fix executable product context key

### DIFF
--- a/src/contextKeys.ts
+++ b/src/contextKeys.ts
@@ -155,7 +155,7 @@ function createContextKeys(): ContextKeys {
         set hasExecutableProduct(value: boolean) {
             hasExecutableProduct = value;
             void vscode.commands
-                .executeCommand("setContext", "swift.hasExecutableTarget", value)
+                .executeCommand("setContext", "swift.hasExecutableProduct", value)
                 .then(() => {
                     /* Put in worker queue */
                 });


### PR DESCRIPTION
Was usign the wrong key name https://github.com/swiftlang/vscode-swift/pull/1577/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R896

Issue: #1533