### PR TITLE
Remove redundant waitForNoRunningTasks()

### DIFF
--- a/test/integration-tests/BackgroundCompilation.test.ts
+++ b/test/integration-tests/BackgroundCompilation.test.ts
@@ -16,7 +16,6 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { WorkspaceContext } from "../../src/WorkspaceContext";
 import { testAssetUri } from "../fixtures";
-import { waitForNoRunningTasks } from "../utilities/tasks";
 import { Workbench } from "../../src/utilities/commands";
 import { activateExtensionForTest, updateSettings } from "./utilities/testutilities";
 
@@ -27,7 +26,6 @@ suite("BackgroundCompilation Test Suite", () => {
         async setup(ctx) {
             workspaceContext = ctx;
             assert.notEqual(workspaceContext.folders.length, 0);
-            await waitForNoRunningTasks();
             return await updateSettings({
                 "swift.backgroundCompilation": true,
             });

--- a/test/integration-tests/SwiftSnippet.test.ts
+++ b/test/integration-tests/SwiftSnippet.test.ts
@@ -14,7 +14,6 @@
 
 import * as vscode from "vscode";
 import { testAssetUri } from "../fixtures";
-import { waitForNoRunningTasks } from "../utilities/tasks";
 import { expect } from "chai";
 import {
     continueSession,
@@ -52,7 +51,6 @@ suite("SwiftSnippet Test Suite @slow", function () {
             resetSettings = await updateSettings({
                 "swift.debugger.debugAdapter": "lldb-dap",
             });
-            await waitForNoRunningTasks();
 
             // File needs to be open for command to be enabled
             await workspaceContext.focusFolder(folder);

--- a/test/integration-tests/commands/build.test.ts
+++ b/test/integration-tests/commands/build.test.ts
@@ -16,7 +16,6 @@ import * as vscode from "vscode";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { expect } from "chai";
-import { waitForNoRunningTasks } from "../../utilities/tasks";
 import { testAssetUri } from "../../fixtures";
 import { FolderContext } from "../../../src/FolderContext";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
@@ -49,7 +48,6 @@ suite("Build Commands @slow", function () {
             vscode.debug.addBreakpoints(breakpoints);
 
             workspaceContext = ctx;
-            await waitForNoRunningTasks();
             folderContext = await folderInRootWorkspace("defaultPackage", workspaceContext);
             await workspaceContext.focusFolder(folderContext);
         },

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -20,7 +20,7 @@ import { FolderContext } from "../../../src/FolderContext";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { Commands } from "../../../src/commands";
 import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
-import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities/tasks";
+import { executeTaskAndWaitForResult } from "../../utilities/tasks";
 import { createBuildAllTask } from "../../../src/tasks/SwiftTaskProvider";
 
 suite("Dependency Commmands Test Suite", function () {
@@ -40,7 +40,6 @@ suite("Dependency Commmands Test Suite", function () {
 
     setup(async () => {
         await workspaceContext.focusFolder(depsContext);
-        await waitForNoRunningTasks();
     });
 
     test("Swift: Update Package Dependencies", async function () {

--- a/test/integration-tests/tasks/SwiftExecution.test.ts
+++ b/test/integration-tests/tasks/SwiftExecution.test.ts
@@ -16,11 +16,7 @@ import * as vscode from "vscode";
 import * as assert from "assert";
 import { testSwiftTask } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
-import {
-    executeTaskAndWaitForResult,
-    waitForNoRunningTasks,
-    waitForStartTaskProcess,
-} from "../../utilities/tasks";
+import { executeTaskAndWaitForResult, waitForStartTaskProcess } from "../../utilities/tasks";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
 import { activateExtensionForSuite } from "../utilities/testutilities";
 
@@ -36,10 +32,6 @@ suite("SwiftExecution Tests Suite", () => {
             assert.notEqual(workspaceContext.folders.length, 0);
             workspaceFolder = workspaceContext.folders[0].workspaceFolder;
         },
-    });
-
-    setup(async () => {
-        await waitForNoRunningTasks();
     });
 
     test("Close event handler fires", async () => {

--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -22,11 +22,7 @@ import {
     getBuildAllTask,
 } from "../../../src/tasks/SwiftTaskProvider";
 import { SwiftToolchain } from "../../../src/toolchain/toolchain";
-import {
-    executeTaskAndWaitForResult,
-    waitForEndTaskProcess,
-    waitForNoRunningTasks,
-} from "../../utilities/tasks";
+import { executeTaskAndWaitForResult, waitForEndTaskProcess } from "../../utilities/tasks";
 import { Version } from "../../../src/utilities/version";
 import { FolderContext } from "../../../src/FolderContext";
 import { mockGlobalObject } from "../../MockUtils";
@@ -51,10 +47,6 @@ suite("SwiftTaskProvider Test Suite", () => {
     });
 
     suite("createSwiftTask", () => {
-        setup(async () => {
-            await waitForNoRunningTasks();
-        });
-
         test("Exit code on success", async () => {
             const task = createSwiftTask(
                 ["--help"],

--- a/test/integration-tests/tasks/TaskManager.test.ts
+++ b/test/integration-tests/tasks/TaskManager.test.ts
@@ -17,7 +17,6 @@ import * as assert from "assert";
 import { TaskManager } from "../../../src/tasks/TaskManager";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { activateExtensionForSuite } from "../utilities/testutilities";
-import { waitForNoRunningTasks } from "../../utilities/tasks";
 
 suite("TaskManager Test Suite", () => {
     let workspaceContext: WorkspaceContext;
@@ -29,10 +28,6 @@ suite("TaskManager Test Suite", () => {
             taskManager = workspaceContext.tasks;
             assert.notEqual(workspaceContext.folders.length, 0);
         },
-    });
-
-    setup(async () => {
-        await waitForNoRunningTasks();
     });
 
     // check running task will return expected value

--- a/test/integration-tests/tasks/TaskQueue.test.ts
+++ b/test/integration-tests/tasks/TaskQueue.test.ts
@@ -17,7 +17,6 @@ import * as assert from "assert";
 import { testAssetPath } from "../../fixtures";
 import { WorkspaceContext } from "../../../src/WorkspaceContext";
 import { SwiftExecOperation, TaskOperation, TaskQueue } from "../../../src/tasks/TaskQueue";
-import { waitForNoRunningTasks } from "../../utilities/tasks";
 import { activateExtensionForSuite } from "../utilities/testutilities";
 
 suite("TaskQueue Test Suite", () => {
@@ -30,10 +29,6 @@ suite("TaskQueue Test Suite", () => {
             assert.notEqual(workspaceContext.folders.length, 0);
             taskQueue = workspaceContext.folders[0].taskQueue;
         },
-    });
-
-    setup(async () => {
-        await waitForNoRunningTasks();
     });
 
     // check queuing task will return expected value


### PR DESCRIPTION
Handled before suite activation and deactivation now and think some of the before hook timeouts come from this