### PR TITLE
Fix package reset on Windows

### DIFF
--- a/src/commands/resetPackage.ts
+++ b/src/commands/resetPackage.ts
@@ -17,7 +17,6 @@ import { FolderContext } from "../FolderContext";
 import { createSwiftTask, SwiftTaskProvider } from "../tasks/SwiftTaskProvider";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { executeTaskWithUI } from "./utilities";
-import { Version } from "../utilities/version";
 
 /**
  * Executes a {@link vscode.Task task} to reset the complete cache/build directory.
@@ -50,8 +49,7 @@ export async function folderResetPackage(folderContext: FolderContext) {
 
     const languageClientManager = () =>
         folderContext.workspaceContext.languageClientManager.get(folderContext);
-    const shouldStop =
-        process.platform === "win32" && folderContext.swiftVersion.isLessThan(new Version(6, 1, 0));
+    const shouldStop = process.platform === "win32";
     if (shouldStop) {
         await vscode.window.withProgress(
             {

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -176,9 +176,12 @@ export class LanguageClientManager implements vscode.Disposable {
 
     // The language client stops asnyhronously, so we need to wait for it to stop
     // instead of doing it in dispose, which must be synchronous.
-    async stop() {
+    async stop(dispose: boolean = true) {
         if (this.languageClient && this.languageClient.state === State.Running) {
-            await this.languageClient.dispose();
+            await this.languageClient.stop(15000);
+            if (dispose) {
+                await this.languageClient.dispose();
+            }
         }
     }
 

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -23,7 +23,7 @@ import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/t
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities/tasks";
 import { createBuildAllTask } from "../../../src/tasks/SwiftTaskProvider";
 
-suite("Dependency Commmands Test Suite", function () {
+suite.only("Dependency Commmands Test Suite", function () {
     // full workflow's interaction with spm is longer than the default timeout
     // 3 minutes for each test should be more than enough
     this.timeout(3 * 60 * 1000);
@@ -54,7 +54,7 @@ suite("Dependency Commmands Test Suite", function () {
     });
 
     // Skipping: https://github.com/swiftlang/vscode-swift/issues/1316
-    suite.skip("Swift: Use Local Dependency", function () {
+    suite("Swift: Use Local Dependency", function () {
         let treeProvider: ProjectPanelProvider;
 
         setup(async () => {
@@ -107,10 +107,6 @@ suite("Dependency Commmands Test Suite", function () {
         }
 
         test("Swift: Reset Package Dependencies", async function () {
-            // spm reset after using local dependency is broken on windows
-            if (process.platform === "win32") {
-                this.skip();
-            }
             await useLocalDependencyTest();
 
             // spm reset

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -23,7 +23,7 @@ import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/t
 import { executeTaskAndWaitForResult, waitForNoRunningTasks } from "../../utilities/tasks";
 import { createBuildAllTask } from "../../../src/tasks/SwiftTaskProvider";
 
-suite.only("Dependency Commmands Test Suite", function () {
+suite("Dependency Commmands Test Suite", function () {
     // full workflow's interaction with spm is longer than the default timeout
     // 3 minutes for each test should be more than enough
     this.timeout(3 * 60 * 1000);


### PR DESCRIPTION
For versions of sourcekit-lsp prior to 6.1, the .build folder cannot be removed for package reset on Windows. To make this work stop the server and then restart it after the reset is done

Issue: #1210