### PR TITLE
Avoid use of instanceof

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,6 +15,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
+import { PackageNode } from "./ui/ProjectPanelProvider";
 import { SwiftToolchain } from "./toolchain/toolchain";
 import { debugSnippet, runSnippet } from "./SwiftSnippets";
 import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
@@ -181,27 +182,27 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             async () => await insertFunctionComment(ctx)
         ),
         vscode.commands.registerCommand(Commands.USE_LOCAL_DEPENDENCY, async (item, dep) => {
-            if (item.__isDependency) {
+            if (PackageNode.isPackageNode(item)) {
                 return await useLocalDependency(item.name, ctx, dep);
             }
         }),
         vscode.commands.registerCommand("swift.editDependency", async (item, folder) => {
-            if (item.__isDependency) {
+            if (PackageNode.isPackageNode(item)) {
                 return await editDependency(item.name, ctx, folder);
             }
         }),
         vscode.commands.registerCommand(Commands.UNEDIT_DEPENDENCY, async (item, folder) => {
-            if (item.__isDependency) {
+            if (PackageNode.isPackageNode(item)) {
                 return await uneditDependency(item.name, ctx, folder);
             }
         }),
         vscode.commands.registerCommand("swift.openInWorkspace", async item => {
-            if (item.__isDependency) {
+            if (PackageNode.isPackageNode(item)) {
                 return await openInWorkspace(item);
             }
         }),
         vscode.commands.registerCommand("swift.openExternal", item => {
-            if (item.__isDependency) {
+            if (PackageNode.isPackageNode(item)) {
                 return openInExternalEditor(item);
             }
         }),

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -15,7 +15,6 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
-import { PackageNode } from "./ui/ProjectPanelProvider";
 import { SwiftToolchain } from "./toolchain/toolchain";
 import { debugSnippet, runSnippet } from "./SwiftSnippets";
 import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
@@ -148,7 +147,7 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         ),
         vscode.commands.registerCommand(
             Commands.RESET_PACKAGE,
-            async () => await resetPackage(ctx)
+            async folder => await resetPackage(ctx, folder)
         ),
         vscode.commands.registerCommand("swift.runScript", async () => await runSwiftScript(ctx)),
         vscode.commands.registerCommand("swift.openPackage", async () => {
@@ -182,27 +181,27 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             async () => await insertFunctionComment(ctx)
         ),
         vscode.commands.registerCommand(Commands.USE_LOCAL_DEPENDENCY, async (item, dep) => {
-            if (item instanceof PackageNode) {
+            if (item.__isDependency) {
                 return await useLocalDependency(item.name, ctx, dep);
             }
         }),
-        vscode.commands.registerCommand("swift.editDependency", async item => {
-            if (item instanceof PackageNode) {
-                return await editDependency(item.name, ctx);
+        vscode.commands.registerCommand("swift.editDependency", async (item, folder) => {
+            if (item.__isDependency) {
+                return await editDependency(item.name, ctx, folder);
             }
         }),
-        vscode.commands.registerCommand(Commands.UNEDIT_DEPENDENCY, async item => {
-            if (item instanceof PackageNode) {
-                return await uneditDependency(item.name, ctx);
+        vscode.commands.registerCommand(Commands.UNEDIT_DEPENDENCY, async (item, folder) => {
+            if (item.__isDependency) {
+                return await uneditDependency(item.name, ctx, folder);
             }
         }),
         vscode.commands.registerCommand("swift.openInWorkspace", async item => {
-            if (item instanceof PackageNode) {
+            if (item.__isDependency) {
                 return await openInWorkspace(item);
             }
         }),
         vscode.commands.registerCommand("swift.openExternal", item => {
-            if (item instanceof PackageNode) {
+            if (item.__isDependency) {
                 return openInExternalEditor(item);
             }
         }),

--- a/src/commands/dependencies/edit.ts
+++ b/src/commands/dependencies/edit.ts
@@ -17,14 +17,19 @@ import { createSwiftTask } from "../../tasks/SwiftTaskProvider";
 import { FolderOperation, WorkspaceContext } from "../../WorkspaceContext";
 import { executeTaskWithUI } from "../utilities";
 import { packageName } from "../../utilities/tasks";
+import { FolderContext } from "../../FolderContext";
 
 /**
  * Setup package dependency to be edited
  * @param identifier Identifier of dependency we want to edit
  * @param ctx workspace context
  */
-export async function editDependency(identifier: string, ctx: WorkspaceContext) {
-    const currentFolder = ctx.currentFolder;
+export async function editDependency(
+    identifier: string,
+    ctx: WorkspaceContext,
+    folder: FolderContext | undefined
+) {
+    const currentFolder = folder ?? ctx.currentFolder;
     if (!currentFolder) {
         return;
     }

--- a/src/commands/dependencies/unedit.ts
+++ b/src/commands/dependencies/unedit.ts
@@ -23,8 +23,12 @@ import { FolderContext } from "../../FolderContext";
  * @param identifier Identifier of dependency
  * @param ctx workspace context
  */
-export async function uneditDependency(identifier: string, ctx: WorkspaceContext) {
-    const currentFolder = ctx.currentFolder;
+export async function uneditDependency(
+    identifier: string,
+    ctx: WorkspaceContext,
+    folder: FolderContext | undefined
+) {
+    const currentFolder = folder ?? ctx.currentFolder;
     if (!currentFolder) {
         ctx.outputChannel.log("currentFolder is not set.");
         return false;

--- a/src/commands/resetPackage.ts
+++ b/src/commands/resetPackage.ts
@@ -22,8 +22,8 @@ import { packageName } from "../utilities/tasks";
 /**
  * Executes a {@link vscode.Task task} to reset the complete cache/build directory.
  */
-export async function resetPackage(ctx: WorkspaceContext) {
-    const current = ctx.currentFolder;
+export async function resetPackage(ctx: WorkspaceContext, folder: FolderContext | undefined) {
+    const current = folder ?? ctx.currentFolder;
     if (!current) {
         return;
     }

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -69,6 +69,23 @@ async function getChildren(directoryPath: string, parentId?: string): Promise<Fi
 export class PackageNode {
     private id: string;
 
+    /**
+     * "instanceof" has a bad effect in our nightly tests when the VSIX
+     * bundled source is used. For example:
+     *
+     * ```
+     * vscode.commands.registerCommand(Commands.UNEDIT_DEPENDENCY, async (item, folder) => {
+     *  if (item instanceof PackageNode) {
+     *      return await uneditDependency(item.name, ctx, folder);
+     *  }
+     * }),
+     * ```
+     *
+     * So instead we'll check for this set boolean property. Even if the implementation of the
+     * {@link PackageNode} class changes, this property should not need to change
+     */
+    __isDependency = true;
+
     constructor(
         private dependency: ResolvedDependency,
         private childDependencies: (dependency: Dependency) => ResolvedDependency[],

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -84,7 +84,8 @@ export class PackageNode {
      * So instead we'll check for this set boolean property. Even if the implementation of the
      * {@link PackageNode} class changes, this property should not need to change
      */
-    __isDependency = true;
+    static isPackageNode = (item: { __isPackageNode?: boolean }) => item.__isPackageNode ?? false;
+    __isPackageNode = true;
 
     constructor(
         private dependency: ResolvedDependency,


### PR DESCRIPTION
instanceof causes issues in nightly because VSIX version and test version of the PackageNode class are different

Also allow passing folder context to package commands as are some random focus issues