### PR TITLE
Improve extension activation when subfolders are swift packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   ],
   "activationEvents": [
     "onLanguage:swift",
-    "workspaceContains:Package.swift",
-    "workspaceContains:compile_commands.json",
-    "workspaceContains:compile_flags.txt",
-    "workspaceContains:buildServer.json",
-    "onDebugResolve:swift-lldb"
+    "workspaceContains:**/Package.swift",
+    "workspaceContains:**/compile_commands.json",
+    "workspaceContains:**/compile_flags.txt",
+    "workspaceContains:**/buildServer.json",
+    "onDebugResolve:swift-lldb",
+    "onDebugResolve:swift"
   ],
   "main": "./dist/src/extension.js",
   "contributes": {


### PR DESCRIPTION
For cases that `swift.searchSubfoldersForPackages` is enabled

Also add the "swift" debug resolve activation for new launch type

Issue: #1634