### PR TITLE
Note in the readme the extension only works with SPM projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This extension adds language support for Swift to Visual Studio Code, providing 
 * Package dependency view
 * Test Explorer view
 
+> **Note**  
+> Most features of the Swift for Visual Studio Code extension only work with projects that build with Swift Package Manager. These projects will have a `Package.swift` file in their root folder. Support for Xcode projects (`.xcodeproj`) is limited.
+
 # Documentation
 
 The official documentation for this extension is [available on swift.org](https://docs.swift.org/vscode/documentation/userdocs).


### PR DESCRIPTION
Clarify that the extension is meant to work with Swift Package Manager based projects, and supporting Xcode projects is not well supported.

Fixes: #1636