### PR TITLE
Cleanup diagnostics for deleted or renamed files

### DIFF
--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -19,11 +19,11 @@ import { FolderContext } from "./FolderContext";
 import { TaskOperation } from "./tasks/TaskQueue";
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import debounce = require("lodash.debounce");
+import { validFileTypes } from "./utilities/filesystem";
 
 export class BackgroundCompilation implements vscode.Disposable {
     private workspaceFileWatcher?: vscode.FileSystemWatcher;
     private configurationEventDisposable?: vscode.Disposable;
-    private validFileTypes = ["swift", "c", "cpp", "h", "hpp", "m", "mm"];
     private disposables: vscode.Disposable[] = [];
 
     constructor(private folderContext: FolderContext) {
@@ -44,7 +44,7 @@ export class BackgroundCompilation implements vscode.Disposable {
     }
 
     private setupFileWatching() {
-        const fileTypes = this.validFileTypes.join(",");
+        const fileTypes = validFileTypes.join(",");
         const rootFolders = ["Sources", "Tests", "Snippets", "Plugins"].join(",");
         this.disposables.push(
             (this.workspaceFileWatcher = vscode.workspace.createFileSystemWatcher(

--- a/src/utilities/filesystem.ts
+++ b/src/utilities/filesystem.ts
@@ -15,6 +15,8 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 
+export const validFileTypes = ["swift", "c", "cpp", "h", "hpp", "m", "mm"];
+
 /**
  * Checks if a file, directory or symlink exists at the supplied path.
  * @param pathComponents The path to check for existence


### PR DESCRIPTION
When the file is deleted or renamed, remove it from the diagnostic collection. Extract the swift file types to a constant.

Issue: #1652