### PR TITLE
Make sure context is not provided to the package reset command handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Cleanup Swift diagnostics when the source file is moved or deleted ([#1653](https://github.com/swiftlang/vscode-swift/pull/1653))
 - Make sure newline starts with /// when splitting doc comment ([#1651](https://github.com/swiftlang/vscode-swift/pull/1651))
+- Fix error when running `Reset Package Dependencies` command from the Project view ([#1661](https://github.com/swiftlang/vscode-swift/pull/1661))
 
 ## 2.6.0 - 2025-06-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swift-vscode",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swift-vscode",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "hasInstallScript": true,
       "dependencies": {
         "@vscode/codicons": "^0.0.36",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swift-vscode",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "publisher": "swiftlang",
   "icon": "icon.png",
   "repository": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -148,7 +148,7 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         ),
         vscode.commands.registerCommand(
             Commands.RESET_PACKAGE,
-            async folder => await resetPackage(ctx, folder)
+            async (_ /* Ignore context */, folder) => await resetPackage(ctx, folder)
         ),
         vscode.commands.registerCommand("swift.runScript", async () => await runSwiftScript(ctx)),
         vscode.commands.registerCommand("swift.openPackage", async () => {

--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -115,6 +115,7 @@ suite("Dependency Commmands Test Suite @slow", function () {
             // spm reset
             const result = await vscode.commands.executeCommand(
                 Commands.RESET_PACKAGE,
+                undefined,
                 depsContext
             );
             expect(result).to.be.true;


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Issue happens when a tree item is clicked in the view tree, vscode then sends the last clicked item to the command as context, so just make sure we always ignore the context

Issue: #1660

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
