### PR TITLE
Fix test explorer tests not updating on document modification

### DIFF
--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -212,14 +212,17 @@ export class TestExplorer {
                     if (target && target.type === "test") {
                         testExplorer.lspTestDiscovery
                             .getDocumentTests(folder.swiftPackage, uri)
-                            .then(tests =>
+                            .then(tests => {
                                 TestDiscovery.updateTestsForTarget(
                                     testExplorer.controller,
                                     { id: target.c99name, label: target.name },
                                     tests,
                                     uri
-                                )
-                            )
+                                );
+                                testExplorer.onTestItemsDidChangeEmitter.fire(
+                                    testExplorer.controller
+                                );
+                            })
                             // Fallback to parsing document symbols for XCTests only
                             .catch(() => {
                                 const tests = parseTestsFromDocumentSymbols(

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -37,6 +37,7 @@ import { isValidWorkspaceFolder, searchForPackages } from "./utilities/workspace
 import { SwiftPluginTaskProvider } from "./tasks/SwiftPluginTaskProvider";
 import { SwiftTaskProvider } from "./tasks/SwiftTaskProvider";
 import { LLDBDebugConfigurationProvider } from "./debugger/debugAdapterFactory";
+import { TestExplorer } from "./TestExplorer/TestExplorer";
 
 /**
  * Context for whole workspace. Holds array of contexts for each workspace folder
@@ -79,7 +80,11 @@ export class WorkspaceContext implements vscode.Disposable {
     ) {
         this.statusItem = new StatusItem();
         this.buildStatus = new SwiftBuildStatus(this.statusItem);
-        this.languageClientManager = new LanguageClientToolchainCoordinator(this);
+        this.languageClientManager = new LanguageClientToolchainCoordinator(this, {
+            onDocumentSymbols: (folder, document, symbols) => {
+                TestExplorer.onDocumentSymbols(folder, document, symbols);
+            },
+        });
         this.tasks = new TaskManager(this);
         this.diagnostics = new DiagnosticsManager(this);
         this.taskProvider = new SwiftTaskProvider(this);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -42,6 +42,17 @@ import { LSPActiveDocumentManager } from "./didChangeActiveDocument";
 import { DidChangeActiveDocumentNotification } from "./extensions/DidChangeActiveDocumentRequest";
 import { lspClientOptions } from "./LanguageClientConfiguration";
 
+interface LanguageClientManageOptions {
+    /**
+     * Options for the LanguageClientManager
+     */
+    onDocumentSymbols?: (
+        folder: FolderContext,
+        document: vscode.TextDocument,
+        symbols: vscode.DocumentSymbol[] | null | undefined
+    ) => void;
+}
+
 /**
  * Manages the creation and destruction of Language clients as we move between
  * workspace folders
@@ -101,6 +112,7 @@ export class LanguageClientManager implements vscode.Disposable {
 
     constructor(
         public folderContext: FolderContext,
+        private options: LanguageClientManageOptions = {},
         private languageClientFactory: LanguageClientFactory = new LanguageClientFactory()
     ) {
         this.namedOutputChannels.set(
@@ -427,7 +439,9 @@ export class LanguageClientManager implements vscode.Disposable {
             workspaceFolder,
             this.activeDocumentManager,
             errorHandler,
-            this.documentSymbolWatcher
+            (document, symbols) => {
+                this.options.onDocumentSymbols?.(this.folderContext, document, symbols);
+            }
         );
 
         return {

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -32,6 +32,13 @@ export class LanguageClientToolchainCoordinator implements vscode.Disposable {
 
     public constructor(
         workspaceContext: WorkspaceContext,
+        private options: {
+            onDocumentSymbols?: (
+                folder: FolderContext,
+                document: vscode.TextDocument,
+                symbols: vscode.DocumentSymbol[] | null | undefined
+            ) => void;
+        } = {},
         languageClientFactory: LanguageClientFactory = new LanguageClientFactory() // used for testing only
     ) {
         this.subscriptions.push(
@@ -124,7 +131,7 @@ export class LanguageClientToolchainCoordinator implements vscode.Disposable {
         const versionString = folder.swiftVersion.toString();
         let client = this.clients.get(versionString);
         if (!client) {
-            client = new LanguageClientManager(folder, languageClientFactory);
+            client = new LanguageClientManager(folder, this.options, languageClientFactory);
             this.clients.set(versionString, client);
             // Callers that must restart when switching folders will call setLanguageClientFolder themselves.
             if (singleServerSupport) {

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -23,6 +23,7 @@ import {
     assertContainsTrimmed,
     assertTestControllerHierarchy,
     assertTestResults,
+    buildStateFromController,
     eventPromise,
     gatherTests,
     runTest,
@@ -50,6 +51,7 @@ import { executeTaskAndWaitForResult } from "../../utilities/tasks";
 import { createBuildAllTask } from "../../../src/tasks/SwiftTaskProvider";
 import { FolderContext } from "../../../src/FolderContext";
 import { lineBreakRegex } from "../../../src/utilities/tasks";
+import { randomString } from "../../../src/utilities/utilities";
 
 suite("Test Explorer Suite", function () {
     const MAX_TEST_RUN_TIME_MINUTES = 6;
@@ -79,6 +81,98 @@ suite("Test Explorer Suite", function () {
         },
         requiresLSP: true,
         requiresDebugger: true,
+    });
+
+    suite("Modifying", function () {
+        let sourceFile: string;
+        let originalSource: string;
+        beforeEach(async () => {
+            sourceFile = path.join(
+                folderContext.folder.fsPath,
+                "Tests",
+                "PackageTests",
+                "PackageTests.swift"
+            );
+            originalSource = fs.readFileSync(sourceFile, "utf8");
+        });
+
+        async function appendSource(newContent: string) {
+            await vscode.window.showTextDocument(vscode.Uri.file(sourceFile));
+            const edit = new vscode.WorkspaceEdit();
+            const document = await vscode.workspace.openTextDocument(sourceFile);
+            const lastLine = document.lineAt(document.lineCount - 1);
+            edit.insert(document.uri, lastLine.range.end, newContent);
+            await vscode.workspace.applyEdit(edit);
+            return document;
+        }
+
+        async function setSource(content: string) {
+            await vscode.window.showTextDocument(vscode.Uri.file(sourceFile));
+            const edit = new vscode.WorkspaceEdit();
+            const document = await vscode.workspace.openTextDocument(sourceFile);
+            edit.replace(
+                document.uri,
+                document.validateRange(new vscode.Range(0, 0, 10000000, 0)),
+                content
+            );
+            await vscode.workspace.applyEdit(edit);
+            return document;
+        }
+
+        type TestHierarchy = string | TestHierarchy[];
+
+        // Because we're at the whim of how often VS Code/the LSP provide document symbols
+        // we can't assume that changes to test items will be reflected in the next onTestItemsDidChange
+        // so poll until the condition is met.
+        async function validate(validator: (testItems: TestHierarchy) => boolean) {
+            let testItems: TestHierarchy = [];
+            const startTime = Date.now();
+            while (Date.now() - startTime < 5000) {
+                testItems = buildStateFromController(testExplorer.controller.items);
+                if (validator(testItems)) {
+                    return;
+                }
+                await new Promise(resolve => setTimeout(resolve, 100));
+            }
+            assert.fail("Expected test items to be updated, but they were not: " + testItems);
+        }
+
+        test("Test explorer updates when a test is added and removed", async () => {
+            const testName = `newTest${randomString()}()`;
+            const newTest = `\n@Test func ${testName} {\n    #expect(1 == 1)\n}\n`;
+            await Promise.all([
+                appendSource(newTest),
+                eventPromise(testExplorer.onTestItemsDidChange),
+            ]);
+            await validate(testItems => testItems[1].includes(testName));
+
+            await Promise.all([
+                setSource(originalSource),
+                eventPromise(testExplorer.onTestItemsDidChange),
+            ]);
+            await validate(testItems => !testItems[1].includes(testName));
+        });
+
+        test("Test explorer updates when a suite is added and removed", async () => {
+            const suiteName = `newSuite${randomString()}`;
+            const newSuite = `\n@Suite\nstruct ${suiteName} {\n    @Test\n    func testPassing() throws {\n        #expect(1 == 1)\n    }\n}\n`;
+            await Promise.all([
+                appendSource(newSuite),
+                eventPromise(testExplorer.onTestItemsDidChange),
+            ]);
+            await validate(testItems => testItems[1].includes(suiteName));
+
+            await Promise.all([
+                setSource(originalSource),
+                eventPromise(testExplorer.onTestItemsDidChange),
+            ]);
+            await validate(testItems => !testItems[1].includes(suiteName));
+        });
+
+        afterEach(async () => {
+            const document = await setSource(originalSource);
+            await document.save();
+        });
     });
 
     suite("Debugging", function () {

--- a/test/integration-tests/testexplorer/utilities.ts
+++ b/test/integration-tests/testexplorer/utilities.ts
@@ -81,6 +81,19 @@ export function testExplorerFor(
 type TestHierarchy = string | TestHierarchy[];
 
 /**
+ * Builds a tree of text items from a TestItemCollection
+ */
+export const buildStateFromController = (items: vscode.TestItemCollection): TestHierarchy =>
+    reduceTestItemChildren(
+        items,
+        (acc, item) => {
+            const children = buildStateFromController(item.children);
+            return [...acc, item.label, ...(children.length ? [children] : [])];
+        },
+        [] as TestHierarchy
+    );
+
+/**
  * Asserts that the test item hierarchy matches the description provided by a collection
  * of `TestControllerState`s.
  */
@@ -88,16 +101,6 @@ export function assertTestControllerHierarchy(
     controller: vscode.TestController,
     state: TestHierarchy
 ) {
-    const buildStateFromController = (items: vscode.TestItemCollection): TestHierarchy =>
-        reduceTestItemChildren(
-            items,
-            (acc, item) => {
-                const children = buildStateFromController(item.children);
-                return [...acc, item.label, ...(children.length ? [children] : [])];
-            },
-            [] as TestHierarchy
-        );
-
     assert.deepEqual(
         buildStateFromController(controller.items),
         state,

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -214,6 +214,7 @@ suite("LanguageClientManager Suite", () => {
         test("returns the same language client for the same folder", async () => {
             const factory = new LanguageClientToolchainCoordinator(
                 instance(mockedWorkspace),
+                {},
                 languageClientFactoryMock
             );
 
@@ -239,6 +240,7 @@ suite("LanguageClientManager Suite", () => {
             mockedWorkspace.folders.push(instance(newFolder));
             const factory = new LanguageClientToolchainCoordinator(
                 instance(mockedWorkspace),
+                {},
                 languageClientFactoryMock
             );
 
@@ -264,6 +266,7 @@ suite("LanguageClientManager Suite", () => {
             mockedWorkspace.folders.push(instance(newFolder));
             const factory = new LanguageClientToolchainCoordinator(
                 instance(mockedWorkspace),
+                {},
                 languageClientFactoryMock
             );
 
@@ -278,6 +281,7 @@ suite("LanguageClientManager Suite", () => {
     test("launches SourceKit-LSP on startup", async () => {
         const factory = new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
 
@@ -301,6 +305,7 @@ suite("LanguageClientManager Suite", () => {
         mockedConfig.swiftSDK = "arm64-apple-ios";
         const factory = new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
 
@@ -329,6 +334,7 @@ suite("LanguageClientManager Suite", () => {
 
         new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
         await waitForReturnedPromises(languageClientMock.start);
@@ -347,6 +353,7 @@ suite("LanguageClientManager Suite", () => {
 
         new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
         await waitForReturnedPromises(languageClientMock.start);
@@ -365,6 +372,7 @@ suite("LanguageClientManager Suite", () => {
 
         new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
         await waitForReturnedPromises(languageClientMock.start);
@@ -403,6 +411,7 @@ suite("LanguageClientManager Suite", () => {
 
         new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
         await waitForReturnedPromises(languageClientMock.start);
@@ -468,7 +477,11 @@ suite("LanguageClientManager Suite", () => {
 
     test("doesn't launch SourceKit-LSP if disabled by the user", async () => {
         mockedLspConfig.disable = true;
-        const sut = new LanguageClientManager(instance(mockedFolder), languageClientFactoryMock);
+        const sut = new LanguageClientManager(
+            instance(mockedFolder),
+            {},
+            languageClientFactoryMock
+        );
         await waitForReturnedPromises(languageClientMock.start);
 
         expect(sut.state).to.equal(State.Stopped);
@@ -480,6 +493,7 @@ suite("LanguageClientManager Suite", () => {
         mockedLspConfig.serverPath = "/path/to/my/custom/sourcekit-lsp";
         const factory = new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
 
@@ -531,6 +545,7 @@ suite("LanguageClientManager Suite", () => {
 
         new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
+            {},
             languageClientFactoryMock
         );
 
@@ -589,7 +604,7 @@ suite("LanguageClientManager Suite", () => {
                 return { dispose: () => {} };
             });
 
-            new LanguageClientManager(instance(mockedFolder), languageClientFactoryMock);
+            new LanguageClientManager(instance(mockedFolder), {}, languageClientFactoryMock);
             await waitForReturnedPromises(languageClientMock.start);
 
             const activeDocumentManager = new LSPActiveDocumentManager();
@@ -621,7 +636,7 @@ suite("LanguageClientManager Suite", () => {
                     document,
                 })
             );
-            new LanguageClientManager(instance(mockedFolder), languageClientFactoryMock);
+            new LanguageClientManager(instance(mockedFolder), {}, languageClientFactoryMock);
             await waitForReturnedPromises(languageClientMock.start);
 
             const activeDocumentManager = new LSPActiveDocumentManager();
@@ -692,6 +707,7 @@ suite("LanguageClientManager Suite", () => {
         test("doesn't launch SourceKit-LSP on startup", async () => {
             const sut = new LanguageClientManager(
                 instance(mockedFolder),
+                {},
                 languageClientFactoryMock
             );
             await waitForReturnedPromises(languageClientMock.start);
@@ -713,6 +729,7 @@ suite("LanguageClientManager Suite", () => {
             );
             const factory = new LanguageClientToolchainCoordinator(
                 instance(mockedWorkspace),
+                {},
                 languageClientFactoryMock
             );
 
@@ -750,6 +767,7 @@ suite("LanguageClientManager Suite", () => {
             );
             const factory = new LanguageClientToolchainCoordinator(
                 instance(mockedWorkspace),
+                {},
                 languageClientFactoryMock
             );
 


### PR DESCRIPTION
The LSP client was being created too early, before the imperative set of the `documentSymbolWatcher` on the client. Consequently we weren't making the `textDocument/tests` request when symbols updated in a test file.
