### PR TITLE
Re-add support for revision hash or local/editing keyword as dependency description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## {{releaseVersion}} - {{releaseDate}}
 
-## 2.6.1 - 2025-06-27
-
 ### Fixed
 
 - Fix test explorer tests not updating on document modification ([#1663](https://github.com/swiftlang/vscode-swift/pull/1663))
 - Fix improper parenting of tests w/ identical names in explorer ([#1664](https://github.com/swiftlang/vscode-swift/pull/1664))
 - Ensure document symbols are provided for folders in multi root workspaces ([#1668](https://github.com/swiftlang/vscode-swift/pull/1668))
+- Re-add support for revision hash or local/editing keyword in project panel dependency descriptions ([#1667](https://github.com/swiftlang/vscode-swift/pull/1667))
 
 ## 2.6.1 - 2025-06-27
 

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -61,6 +61,7 @@ export interface ResolvedDependency extends Dependency {
     type: string;
     path: string;
     location: string;
+    revision?: string;
 }
 
 /** Swift Package.resolved file */
@@ -409,6 +410,7 @@ export class SwiftPackage {
                 : "",
             type: workspaceStateDep ? this.dependencyType(workspaceStateDep) : "",
             location: workspaceStateDep ? workspaceStateDep.packageRef.location : "",
+            revision: workspaceStateDep?.state.checkoutState?.revision ?? "",
         };
     }
 

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -119,7 +119,7 @@ export class PackageNode {
     ) {
         this.id =
             (this.parentId ? `${this.parentId}->` : "") +
-            `${this.name}-${this.dependency.version ?? ""}`;
+            `${this.name}-${(this.dependency.version || this.dependency.revision?.substring(0, 7)) ?? ""}`;
     }
 
     get name(): string {

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -141,7 +141,7 @@ export class PackageNode {
     toTreeItem(): vscode.TreeItem {
         const item = new vscode.TreeItem(this.name, vscode.TreeItemCollapsibleState.Collapsed);
         item.id = this.id;
-        item.description = this.dependency.version;
+        item.description = this.getDescription();
         item.iconPath = new vscode.ThemeIcon(this.icon());
         item.contextValue = this.dependency.type;
         item.accessibilityInformation = { label: `Package ${this.name}` };
@@ -175,6 +175,20 @@ export class PackageNode {
 
         // Show dependencies first, then files.
         return [...childNodes, ...files];
+    }
+
+    getDescription(): string {
+        switch (this.type) {
+            case "local":
+                return "local";
+            case "editing":
+                return "editing";
+            default:
+                return (
+                    // show the version if used, otherwise show the partial commit hash
+                    (this.dependency.version || this.dependency.revision?.substring(0, 7)) ?? ""
+                );
+        }
     }
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Issue: https://github.com/swiftlang/vscode-swift/issues/1666

This MR makes a small change to how the `description` property of the dependency `vscode.TreeItem` gets determined. 
- For dependencies using a specific revision it will show the partial **_commit hash_** as the description
- For dependencies that are paths to a local pacakge is will show the _**local**_ keyword
- For dependencies that are edited local versions of a dependency it will show the _**editing**_ keyword

This is not 'new' functionality - `v2.0.2` and earlier of this extension had this functionality.

<img width="402" alt="Screenshot 2025-06-29 at 2 52 08 PM" src="https://github.com/user-attachments/assets/4528e0ca-7c97-40a0-834d-9b63abc179d1" />


## Code Changes
- Updated the `ResolvedDependency` interface to additionally have the `revision` value
- Added `getDescription` function to `PackageNode` to get the correct description value based on the package type

Additionally I also slightly modified the new `PackageNode.id` property to utilise the partial commit hash if no version variable was available. Prior to this change, for the specific revision and local packages the id was showing as "{packageName}-". I can remove this if needed.

## Testing
I did not add any tests for these changes. Existing suite passed locally. Based on the current suite I wasn't sure if this warranted additional tests - please lmk if I need to add some.

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
