### PR TITLE
Ensure document symbols are provided for folders in multi root workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+- Fix test explorer tests not updating on document modification ([#1663](https://github.com/swiftlang/vscode-swift/pull/1663))
+- Fix improper parenting of tests w/ identical names in explorer ([#1664](https://github.com/swiftlang/vscode-swift/pull/1664))
+- Ensure document symbols are provided for folders in multi root workspaces ([#1668](https://github.com/swiftlang/vscode-swift/pull/1668))
+
+## 2.6.1 - 2025-06-27
+
+### Fixed
+
 - Cleanup Swift diagnostics when the source file is moved or deleted ([#1653](https://github.com/swiftlang/vscode-swift/pull/1653))
 - Make sure newline starts with /// when splitting doc comment ([#1651](https://github.com/swiftlang/vscode-swift/pull/1651))
 - Capture diagnostics with `Swift: Capture Diagnostic Bundle` to a .zip file ([#1656](https://github.com/swiftlang/vscode-swift/pull/1656))

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -177,9 +177,9 @@ export class FolderContext implements vscode.Disposable {
     }
 
     /** Refresh the tests in the test explorer for this folder */
-    refreshTestExplorer() {
+    async refreshTestExplorer() {
         if (this.testExplorer?.controller.resolveHandler) {
-            void this.testExplorer.controller.resolveHandler(undefined);
+            return this.testExplorer.controller.resolveHandler(undefined);
         }
     }
 
@@ -210,6 +210,25 @@ export class FolderContext implements vscode.Disposable {
             return element.sources.find(file => file === relativeUri) !== undefined;
         });
         return target;
+    }
+
+    /**
+     * Called whenever we have new document symbols
+     */
+    onDocumentSymbols(
+        document: vscode.TextDocument,
+        symbols: vscode.DocumentSymbol[] | null | undefined
+    ) {
+        const uri = document?.uri;
+        if (
+            this.testExplorer &&
+            symbols &&
+            uri &&
+            uri.scheme === "file" &&
+            isPathInsidePath(uri.fsPath, this.folder.fsPath)
+        ) {
+            void this.testExplorer.getDocumentTests(this, uri, symbols);
+        }
     }
 }
 

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -164,7 +164,17 @@ export class TestExplorer {
         const targets = await folder.swiftPackage.getTargets(TargetType.test);
         const hasTestTargets = targets.length > 0;
         if (hasTestTargets && !folder.hasTestExplorer()) {
-            await folder.addTestExplorer().discoverTestsInWorkspace(token);
+            const testExplorer = folder.addTestExplorer();
+            if (
+                configuration.folder(folder.workspaceFolder).disableAutoResolve &&
+                process.platform === "win32" &&
+                folder.swiftVersion.isLessThan(new Version(5, 10, 0))
+            ) {
+                // On Windows 5.9 and earlier discoverTestsInWorkspace kicks off a build,
+                // which will perform a resolve.
+                return;
+            }
+            await testExplorer.discoverTestsInWorkspace(token);
         } else if (hasTestTargets && folder.hasTestExplorer()) {
             await folder.refreshTestExplorer();
         } else if (!hasTestTargets && folder.hasTestExplorer()) {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -37,7 +37,6 @@ import { isValidWorkspaceFolder, searchForPackages } from "./utilities/workspace
 import { SwiftPluginTaskProvider } from "./tasks/SwiftPluginTaskProvider";
 import { SwiftTaskProvider } from "./tasks/SwiftTaskProvider";
 import { LLDBDebugConfigurationProvider } from "./debugger/debugAdapterFactory";
-import { TestExplorer } from "./TestExplorer/TestExplorer";
 
 /**
  * Context for whole workspace. Holds array of contexts for each workspace folder
@@ -82,7 +81,7 @@ export class WorkspaceContext implements vscode.Disposable {
         this.buildStatus = new SwiftBuildStatus(this.statusItem);
         this.languageClientManager = new LanguageClientToolchainCoordinator(this, {
             onDocumentSymbols: (folder, document, symbols) => {
-                TestExplorer.onDocumentSymbols(folder, document, symbols);
+                folder.onDocumentSymbols(document, symbols);
             },
         });
         this.tasks = new TaskManager(this);

--- a/test/integration-tests/ExtensionActivation.test.ts
+++ b/test/integration-tests/ExtensionActivation.test.ts
@@ -116,7 +116,9 @@ suite("Extension Activation/Deactivation Tests", () => {
             assert(folder);
 
             const languageClient = workspaceContext.languageClientManager.get(folder);
-            const lspWorkspaces = languageClient.subFolderWorkspaces.map(({ fsPath }) => fsPath);
+            const lspWorkspaces = languageClient.subFolderWorkspaces.map(
+                ({ folder }) => folder.fsPath
+            );
             assertContains(lspWorkspaces, testAssetUri("cmake").fsPath);
         });
 
@@ -125,7 +127,9 @@ suite("Extension Activation/Deactivation Tests", () => {
             assert(folder);
 
             const languageClient = workspaceContext.languageClientManager.get(folder);
-            const lspWorkspaces = languageClient.subFolderWorkspaces.map(({ fsPath }) => fsPath);
+            const lspWorkspaces = languageClient.subFolderWorkspaces.map(
+                ({ folder }) => folder.fsPath
+            );
             assertContains(lspWorkspaces, testAssetUri("cmake-compile-flags").fsPath);
         });
     });

--- a/test/integration-tests/commands/runTestMultipleTimes.test.ts
+++ b/test/integration-tests/commands/runTestMultipleTimes.test.ts
@@ -25,7 +25,7 @@ suite("Test Multiple Times Command Test Suite", () => {
 
     activateExtensionForSuite({
         async setup(ctx) {
-            folderContext = await folderInRootWorkspace("diagnostics", ctx);
+            folderContext = await folderInRootWorkspace("defaultPackage", ctx);
             folderContext.addTestExplorer();
 
             const item = folderContext.testExplorer?.controller.createTestItem(


### PR DESCRIPTION
If the user is working in a multi root workspace document symbols would not be provided if they were for any folder except the first one added. This also prevented the test explorer from properly initializing.

Check to see if the folder being added is in the list of VS Code workspace folders and associate the folder with the onDocumentSymbols request from the LSP. 

Issue: #1669