### PR TITLE
Add macOS support for Swiftly toolchain management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add macOS support for Swiftly toolchain management ([#1673](https://github.com/swiftlang/vscode-swift/pull/1673))
 - Show revision hash or local/editing keyword in project panel dependency descriptions ([#1667](https://github.com/swiftlang/vscode-swift/pull/1667))
 
 ## 2.6.2 - 2025-07-02

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -254,9 +254,8 @@ export class SwiftToolchain {
      * @returns an array of toolchain paths
      */
     public static async getSwiftlyToolchainInstalls(): Promise<string[]> {
-        // Swiftly is only available on Linux right now
-        // TODO: Add support for macOS
-        if (process.platform !== "linux") {
+        // Swiftly is available on Linux and macOS
+        if (process.platform !== "linux" && process.platform !== "darwin") {
             return [];
         }
         try {

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -223,11 +223,12 @@ async function getQuickPickItems(
     }
     // Various actions that the user can perform (e.g. to install new toolchains)
     const actionItems: ActionItem[] = [];
-    if (process.platform === "linux") {
+    if (process.platform === "linux" || process.platform === "darwin") {
+        const platformName = process.platform === "linux" ? "Linux" : "macOS";
         actionItems.push({
             type: "action",
             label: "$(swift-icon) Install Swiftly for toolchain management...",
-            detail: "Install https://swiftlang.github.io/swiftly to manage your toolchains on Linux",
+            detail: `Install https://swiftlang.github.io/swiftly to manage your toolchains on ${platformName}`,
             run: installSwiftly,
         });
     }


### PR DESCRIPTION
## Description
Enabling swiftly integration with macOS

Issue: Fixes Issue #1672  

## Tasks
- [x] Required tests have been written
- [x] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
