### PR TITLE
Respect `files.exclude` values set to `false`

### DIFF
--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -43,13 +43,16 @@ const LOADING_ICON = "loading~spin";
  */
 function excludedFilesForProjectPanelExplorer(): string[] {
     const config = vscode.workspace.getConfiguration("files");
-    const vscodeExcludeList = config.get<{ [key: string]: boolean }>("exclude");
     const packageDepsExcludeList = configuration.excludePathsFromPackageDependencies;
-
     if (!Array.isArray(packageDepsExcludeList)) {
         throw new Error("Expected excludePathsFromPackageDependencies to be an array");
     }
-    return [...packageDepsExcludeList, ...Object.keys(vscodeExcludeList ?? {})];
+
+    const vscodeExcludeList = config.get<{ [key: string]: boolean }>("exclude") ?? {};
+    const vscodeFileTypesToExclude = Object.keys(vscodeExcludeList).filter(
+        key => vscodeExcludeList[key]
+    );
+    return [...packageDepsExcludeList, ...vscodeFileTypesToExclude];
 }
 
 /**

--- a/test/integration-tests/ui/ProjectPanelProvider.test.ts
+++ b/test/integration-tests/ui/ProjectPanelProvider.test.ts
@@ -361,7 +361,7 @@ suite("ProjectPanelProvider Test Suite", function () {
             let resetSettings: (() => Promise<void>) | undefined;
             beforeEach(async function () {
                 resetSettings = await updateSettings({
-                    "files.exclude": { "**/*.swift": true },
+                    "files.exclude": { "**/*.swift": true, "**/*.txt": false },
                     "swift.excludePathsFromPackageDependencies": ["**/*.md"],
                 });
             });
@@ -374,11 +374,11 @@ suite("ProjectPanelProvider Test Suite", function () {
 
                 const folders = await treeProvider.getChildren(dep);
                 const manifest = folders.find(n => n.name === "Package.swift") as FileNode;
-                expect(manifest).to.be.undefined;
+                expect(manifest, "Package.swift was not found").to.be.undefined;
                 const readme = folders.find(n => n.name === "README.md") as FileNode;
-                expect(readme).to.be.undefined;
+                expect(readme, "README.md was not found").to.be.undefined;
                 const licence = folders.find(n => n.name === "LICENSE.txt") as FileNode;
-                expect(licence).to.not.be.undefined;
+                expect(licence, "LICENSE.txt was not found").to.not.be.undefined;
             });
 
             afterEach(async () => {


### PR DESCRIPTION
The project panel would ignore all files of a given type regardless of if they their value was `true` or `false` in the setting. Only values of `true` should result in files being excluded.
