### PR TITLE
Cleanup: Remove log on missing .swift-version file

### DIFF
--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -154,9 +154,6 @@ export class PackageWatcher {
             const contents = await fs.readFile(versionFile);
             return Version.fromString(contents.toString().trim());
         } catch (error) {
-            this.workspaceContext.outputChannel.appendLine(
-                `Failed to read .swift-version file at ${versionFile}: ${error}`
-            );
             return undefined;
         }
     }

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -154,8 +154,13 @@ export class PackageWatcher {
             const contents = await fs.readFile(versionFile);
             return Version.fromString(contents.toString().trim());
         } catch (error) {
-            return undefined;
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+                this.workspaceContext.outputChannel.appendLine(
+                    `Failed to read .swift-version file at ${versionFile}: ${error}`
+                );
+            }
         }
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
In most cases this file won't exist, and that is OK. Omit the log pollution that prints the error when the .swift-version file can't be found.
