### PR TITLE
Disable indexing swift packages in subfolders on this repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
 
   // Disable for when opening files in this workspace
   "swift.disableAutoResolve": true,
-  "swift.autoGenerateLaunchConfigurations": false
+  "swift.autoGenerateLaunchConfigurations": false,
+  "swift.sourcekit-lsp.disable": true
 }


### PR DESCRIPTION
When developing in this repository if you have the Swift extension installed sourcekit-lsp will begin indexing the test projects in assets/test which can be disruptive when opening the project for the first time.
