### PR TITLE
Improve swift not found error logging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,7 +236,7 @@ async function createActiveToolchain(
     outputChannel: SwiftOutputChannel
 ): Promise<SwiftToolchain | undefined> {
     try {
-        const toolchain = await SwiftToolchain.create();
+        const toolchain = await SwiftToolchain.create(undefined, outputChannel);
         toolchain.logDiagnostics(outputChannel);
         contextKeys.updateKeysBasedOnActiveVersion(toolchain.swiftVersion);
         return toolchain;


### PR DESCRIPTION
If the swift binary can't be found log better messages to the Swift output channel for dianosing.
