### PR TITLE
Fix comment blocks getting incorrectly completed on fn decls

### DIFF
--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -60,13 +60,19 @@ class DocCommentCompletionProvider implements vscode.CompletionItemProvider {
             return;
         }
         // Fixes https://github.com/swiftlang/vscode-swift/issues/1648
-        const match = /^(\s*)(\/\/)?\s?(.+)?/.exec(document.lineAt(position.line).text);
+        const lineText = document.lineAt(position.line).text;
+        // Continue the comment if its a white space only line, or if VS Code has already continued
+        // the comment by adding a // on the new line.
+        const match =
+            lineText.trim().length === 0
+                ? [lineText, lineText, ""]
+                : /^(\s*)\/\/\s(.+)/.exec(lineText);
         if (match) {
             await vscode.window.activeTextEditor.edit(
                 edit => {
                     edit.replace(
                         new vscode.Range(position.line, 0, position.line, match[0].length),
-                        `${match[1]}/// ${match[3] ?? ""}`
+                        `${match[1]}/// ${match[2]}`
                     );
                 },
                 { undoStopBefore: false, undoStopAfter: true }

--- a/test/integration-tests/editor/CommentCompletion.test.ts
+++ b/test/integration-tests/editor/CommentCompletion.test.ts
@@ -290,6 +290,20 @@ suite("CommentCompletion Test Suite", () => {
 
             assert.strictEqual(newLine, "/// bbb", "New line should continue the comment block");
         });
+
+        test("Should not continue a comment on a line that has content", async () => {
+            const { document, positions } = await openDocument(`
+            /// aaa
+            public func foo(param: Int, a1️⃣) {}`);
+
+            const originalText = document.getText();
+            const position = positions["1️⃣"];
+            await provider.docCommentCompletion.provideCompletionItems(document, position);
+
+            const documentText = document.getText();
+
+            assert.deepEqual(documentText, originalText, "Document text should not change");
+        });
     });
 
     function expectedCompletionItem(snippet: string): vscode.CompletionItem {


### PR DESCRIPTION
A comment block may be continued when editing a function declaration. Fix and add a test case.
