### PR TITLE
Accept `Location` for `workspace/peekDocument`

### DIFF
--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -45,6 +45,7 @@ function initializationOptions(swiftVersion: Version): any {
         options = {
             "workspace/peekDocuments": {
                 supported: true, // workaround for client capability to handle `PeekDocumentsRequest`
+                peekLocation: true, // allow SourceKit-LSP to send `Location` instead of `DocumentUri` for the locations to peek.
             },
             "workspace/getReferenceDocument": {
                 supported: true, // the client can handle URIs with scheme `sourcekit-lsp:`

--- a/src/sourcekit-lsp/extensions/PeekDocumentsRequest.ts
+++ b/src/sourcekit-lsp/extensions/PeekDocumentsRequest.ts
@@ -15,7 +15,13 @@
 // We use namespaces to store request information just like vscode-languageclient
 /* eslint-disable @typescript-eslint/no-namespace */
 
-import { DocumentUri, Position, MessageDirection, RequestType } from "vscode-languageclient";
+import {
+    DocumentUri,
+    Position,
+    Location,
+    MessageDirection,
+    RequestType,
+} from "vscode-languageclient";
 
 /** Parameters used to make a {@link PeekDocumentsRequest}. */
 export interface PeekDocumentsParams {
@@ -30,9 +36,9 @@ export interface PeekDocumentsParams {
     position: Position;
 
     /**
-     * An array `DocumentUri` of the documents to appear inside the "peeked" editor
+     * An array `DocumentUri` or `Location` of the documents to appear inside the "peeked" editor
      */
-    locations: DocumentUri[];
+    locations: DocumentUri[] | Location[];
 }
 
 /** Response to indicate the `success` of the {@link PeekDocumentsRequest}. */

--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -88,13 +88,16 @@ export function activatePeekDocuments(client: langclient.LanguageClient): vscode
                 params.position.character
             );
 
-            const peekLocations = params.locations.map(
-                location =>
-                    new vscode.Location(
+            const peekLocations = params.locations.map(location => {
+                if (typeof location === "string") {
+                    // DocumentUri is a typedef of `string`, so effectively we are checking for DocumentUri here
+                    return new vscode.Location(
                         client.protocol2CodeConverter.asUri(location),
                         new vscode.Position(0, 0)
-                    )
-            );
+                    );
+                }
+                return client.protocol2CodeConverter.asLocation(location);
+            });
 
             await openPeekedEditorIn(peekURI, peekPosition, peekLocations);
 


### PR DESCRIPTION
This allows the peek window to scroll to a position within the peeked document.