### PR TITLE
Increase timeout for Toolchain tests

### DIFF
--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -205,7 +205,10 @@ suite("WorkspaceContext Test Suite", () => {
         });
     });
 
-    suite("Toolchain", () => {
+    suite("Toolchain", function () {
+        // Increase the timeout as this takes several seconds longer for the codeWorkspaceTests variant
+        this.timeout(60000);
+
         activateExtensionForSuite({
             async setup(ctx) {
                 workspaceContext = ctx;


### PR DESCRIPTION
Bump up the timeout for toolchain tests as the codeWorkspaceTest variant may sometimes take longer than 3 seconds to complete.