### PR TITLE
Fix up intermittently failing doc comment test

### DIFF
--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -60,7 +60,10 @@ class DocCommentCompletionProvider implements vscode.CompletionItemProvider {
         document: vscode.TextDocument,
         position: vscode.Position
     ) {
-        if (!vscode.window.activeTextEditor) {
+        const editor = vscode.window.visibleTextEditors.find(
+            e => e.document.uri.toString() === document.uri.toString()
+        );
+        if (!editor || editor.document.isClosed) {
             return;
         }
         // Fixes https://github.com/swiftlang/vscode-swift/issues/1648
@@ -72,7 +75,7 @@ class DocCommentCompletionProvider implements vscode.CompletionItemProvider {
                 ? [lineText, lineText, ""]
                 : /^(\s*)\/\/\s(.+)/.exec(lineText);
         if (match) {
-            await vscode.window.activeTextEditor.edit(
+            await editor.edit(
                 edit => {
                     edit.replace(
                         new vscode.Range(position.line, 0, position.line, match[0].length),
@@ -82,10 +85,7 @@ class DocCommentCompletionProvider implements vscode.CompletionItemProvider {
                 { undoStopBefore: false, undoStopAfter: true }
             );
             const newPosition = new vscode.Position(position.line, match[1].length + 4);
-            vscode.window.activeTextEditor.selection = new vscode.Selection(
-                newPosition,
-                newPosition
-            );
+            editor.selection = new vscode.Selection(newPosition, newPosition);
         }
     }
 }

--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -142,6 +142,11 @@ suite("SwiftTaskProvider Test Suite", () => {
         test("includes product debug task", async () => {
             const tasks = await vscode.tasks.fetchTasks({ type: "swift" });
             const task = tasks.find(t => t.name === "Build Debug PackageExe (defaultPackage)");
+            expect(
+                task,
+                'expected to find a task named "Build Debug PackageExe (defaultPackage)", instead found ' +
+                    tasks.map(t => t.name)
+            ).to.not.be.undefined;
             expect(task?.detail).to.include("swift build --product PackageExe");
         });
 
@@ -151,6 +156,11 @@ suite("SwiftTaskProvider Test Suite", () => {
                 new vscode.CancellationTokenSource().token
             );
             const task = tasks.find(t => t.name === "Build Release PackageExe (defaultPackage)");
+            expect(
+                task,
+                'expected to find a task named "Build Release PackageExe (defaultPackage)", instead found ' +
+                    tasks.map(t => t.name)
+            ).to.not.be.undefined;
             expect(task?.detail).to.include("swift build -c release --product PackageExe");
         });
 


### PR DESCRIPTION
These have a tendency to crash when accessing the active editor in a headless environment.
