### PR TITLE
Optimize clearing enqueued tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `Run multiple times...` and `Run until failure...` will now work when multiple tests are selected ([#1724](https://github.com/swiftlang/vscode-swift/pull/1724))
 - Provide the Swift environment variables when resolving a `swift-plugin` task ([#1727](https://github.com/swiftlang/vscode-swift/pull/1727))
+- Optimized test explorer for test runs with many test cases ([#1734](https://github.com/swiftlang/vscode-swift/pull/1734))
 
 ## 2.8.0 - 2025-07-14
 

--- a/test/integration-tests/testexplorer/utilities.ts
+++ b/test/integration-tests/testexplorer/utilities.ts
@@ -165,7 +165,9 @@ export function assertTestResults(
                 .sort(),
             skipped: testRun.runState.skipped.map(({ id }) => id).sort(),
             errored: testRun.runState.errored.map(({ id }) => id).sort(),
-            enqueued: testRun.runState.enqueued.map(({ id }) => id).sort(),
+            enqueued: Array.from(testRun.runState.enqueued)
+                .map(({ id }) => id)
+                .sort(),
             unknown: testRun.runState.unknown,
         },
         {


### PR DESCRIPTION
## Description
Refactor the enqueued tests list to be a Set so we can clear enqueued tests without the need to potentially traverse the full remaining list of enqueued tests.

Also avoid recreating the test item finder on every `get testItemFinder`, and store test items in the darwin test item finder in a Set as well for faster lookup.

Issue: #1728
