### PR TITLE
Notify user if configured $schema is out of date

### DIFF
--- a/package.json
+++ b/package.json
@@ -682,7 +682,7 @@
           "swift.checkLspConfigurationSchema": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "When opening a .sourckit-lsp/config.json configurationfile, whether or not to check if the $schema matches the version of Swift you are using.",
+            "markdownDescription": "When opening a .sourckit-lsp/config.json configuration file, whether or not to check if the $schema matches the version of Swift you are using.",
             "scope": "machine-overridable"
           }
         }

--- a/package.json
+++ b/package.json
@@ -674,6 +674,16 @@
             "default": "prompt",
             "markdownDescription": "Controls whether to open a swift project automatically after creating it.",
             "scope": "application"
+          },
+          "swift.lspConfigurationBranch": {
+            "type": "string",
+            "markdownDescription": "Set the branch to use when setting the `$schema` property of the SourceKit-LSP configuration. For example: \"release/6.1\" or \"main\". When this setting is unset, the extension will determine the branch based on the version of the toolchain that is in use."
+          },
+          "swift.checkLspConfigurationSchema": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "When opening a .sourckit-lsp/config.json configurationfile, whether or not to check if the $schema matches the version of Swift you are using.",
+            "scope": "machine-overridable"
           }
         }
       },
@@ -748,10 +758,6 @@
             "markdownDescription": "Disable SourceKit-LSP. This will turn off features like code completion, error diagnostics and jump-to-definition. Features like swift-testing test discovery will not work correctly.",
             "order": 6,
             "scope": "machine-overridable"
-          },
-          "swift.sourcekit-lsp.configurationBranch": {
-            "type": "string",
-            "markdownDescription": "Set the branch to use when setting the `$schema` property of the SourceKit-LSP configuration. For example: \"release/6.1\" or \"main\". When this setting is unset, the extension will determine the branch based on the version of the toolchain that is in use."
           },
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -569,9 +569,7 @@ export class WorkspaceContext implements vscode.Disposable {
      * one of those. If not then it searches up the tree to find the uppermost folder in the
      * workspace that contains a Package.swift
      */
-    private async getPackageFolder(
-        url: vscode.Uri
-    ): Promise<FolderContext | vscode.Uri | undefined> {
+    async getPackageFolder(url: vscode.Uri): Promise<FolderContext | vscode.Uri | undefined> {
         // is editor document in any of the current FolderContexts
         const folder = this.folders.find(context => {
             return isPathInsidePath(url.fsPath, context.folder.fsPath);

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -112,10 +112,12 @@ const schemaURL = (branch: string) =>
 async function checkURLExists(url: string): Promise<boolean> {
     try {
         const response = await fetch(url, { method: "HEAD" });
-        if (response.status >= 500) {
+        if (response.ok) {
+            return true;
+        } else if (response.status !== 404) {
             throw new Error(`Received exit code ${response.status} when trying to fetch ${url}`);
         }
-        return response.ok;
+        return false;
     } catch {
         return false;
     }

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import { join } from "path";
+import { basename, dirname, join } from "path";
 import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { selectFolder } from "../ui/SelectFolderQuickPick";
@@ -187,7 +187,10 @@ export async function handleSchemaUpdate(
 ) {
     if (
         !configuration.checkLspConfigurationSchema ||
-        !doc.uri.fsPath.endsWith("/.sourcekit-lsp/config.json")
+        !(
+            basename(dirname(doc.uri.fsPath)) === ".sourcekit-lsp" &&
+            basename(doc.uri.fsPath) === "config.json"
+        )
     ) {
         return;
     }

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -85,19 +85,24 @@ async function createSourcekitConfiguration(
         }
         await vscode.workspace.fs.createDirectory(sourcekitFolder);
     }
-    const url = await determineSchemaURL(folderContext);
-    await vscode.workspace.fs.writeFile(
-        sourcekitConfigFile,
-        Buffer.from(
-            JSON.stringify(
-                {
-                    $schema: url,
-                },
-                undefined,
-                2
+    try {
+        const url = await determineSchemaURL(folderContext);
+        await vscode.workspace.fs.writeFile(
+            sourcekitConfigFile,
+            Buffer.from(
+                JSON.stringify(
+                    {
+                        $schema: url,
+                    },
+                    undefined,
+                    2
+                )
             )
-        )
-    );
+        );
+    } catch (e) {
+        void vscode.window.showErrorMessage(`${e}`);
+        return false;
+    }
     return true;
 }
 
@@ -107,6 +112,9 @@ const schemaURL = (branch: string) =>
 async function checkURLExists(url: string): Promise<boolean> {
     try {
         const response = await fetch(url, { method: "HEAD" });
+        if (response.status >= 500) {
+            throw new Error(`Received exit code ${response.status} when trying to fetch ${url}`);
+        }
         return response.ok;
     } catch {
         return false;

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -152,8 +152,16 @@ async function checkDocumentSchema(doc: vscode.TextDocument, workspaceContext: W
         }
         return;
     }
-    const contents = Buffer.from(buffer).toString("utf-8");
-    const config = JSON.parse(contents);
+    let config;
+    try {
+        const contents = Buffer.from(buffer).toString("utf-8");
+        config = JSON.parse(contents);
+    } catch (error) {
+        workspaceContext.outputChannel.appendLine(
+            `Failed to parse JSON from  ${doc.uri.fsPath}: ${error}`
+        );
+        return;
+    }
     const schema = config.$schema;
     if (!schema) {
         return;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -55,8 +55,6 @@ export interface LSPConfiguration {
     readonly supportedLanguages: string[];
     /** Is SourceKit-LSP disabled */
     readonly disable: boolean;
-    /** Configuration branch to use when setting $schema */
-    readonly configurationBranch: string;
 }
 
 /** debugger configuration */
@@ -151,11 +149,6 @@ const configuration = {
                 return vscode.workspace
                     .getConfiguration("swift.sourcekit-lsp")
                     .get<boolean>("disable", false);
-            },
-            get configurationBranch(): string {
-                return vscode.workspace
-                    .getConfiguration("swift.sourcekit-lsp")
-                    .get<string>("configurationBranch", "");
             },
         };
     },
@@ -502,6 +495,22 @@ const configuration = {
         return vscode.workspace
             .getConfiguration("swift")
             .get<Record<string, boolean>>("excludePathsFromActivation", {});
+    },
+    get lspConfigurationBranch(): string {
+        return vscode.workspace.getConfiguration("swift").get<string>("lspConfigurationBranch", "");
+    },
+    get checkLspConfigurationSchema(): boolean {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<boolean>("checkLspConfigurationSchema", true);
+    },
+    set checkLspConfigurationSchema(value: boolean) {
+        void vscode.workspace
+            .getConfiguration("swift")
+            .update("checkLspConfigurationSchema", value)
+            .then(() => {
+                /* Put in worker queue */
+            });
     },
 };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { resolveFolderDependencies } from "./commands/dependencies/resolve";
 import { SelectedXcodeWatcher } from "./toolchain/SelectedXcodeWatcher";
 import configuration, { handleConfigurationChangeEvent } from "./configuration";
 import contextKeys from "./contextKeys";
+import { registerSourceKitSchemaWatcher } from "./commands/generateSourcekitConfiguration";
 
 /**
  * External API as exposed by the extension. Can be queried by other extensions
@@ -135,6 +136,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             workspaceContext.onDidChangeFolders(handleFolderEvent(outputChannel))
         );
         context.subscriptions.push(TestExplorer.observeFolders(workspaceContext));
+
+        context.subscriptions.push(registerSourceKitSchemaWatcher(workspaceContext));
 
         // setup workspace context with initial workspace folders
         void workspaceContext.addWorkspaceFolders();

--- a/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
+++ b/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
@@ -32,7 +32,7 @@ import {
 import { Version } from "../../../src/utilities/version";
 import { mockGlobalObject } from "../../MockUtils";
 
-suite.only("Generate SourceKit-LSP configuration Command", function () {
+suite("Generate SourceKit-LSP configuration Command", function () {
     let folderContext: FolderContext;
     let configFileUri: vscode.Uri;
     let workspaceContext: WorkspaceContext;

--- a/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
+++ b/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
@@ -24,20 +24,32 @@ import {
 } from "../utilities/testutilities";
 import { closeAllEditors } from "../../utilities/commands";
 import {
+    determineSchemaURL,
+    handleSchemaUpdate,
     sourcekitConfigFilePath,
     sourcekitFolderPath,
 } from "../../../src/commands/generateSourcekitConfiguration";
 import { Version } from "../../../src/utilities/version";
+import { mockGlobalObject } from "../../MockUtils";
 
-suite("Generate SourceKit-LSP configuration Command", function () {
+suite.only("Generate SourceKit-LSP configuration Command", function () {
     let folderContext: FolderContext;
+    let configFileUri: vscode.Uri;
     let workspaceContext: WorkspaceContext;
     let resetSettings: (() => Promise<void>) | undefined;
+
+    async function getSchema() {
+        const contents = Buffer.from(await vscode.workspace.fs.readFile(configFileUri)).toString(
+            "utf-8"
+        );
+        return JSON.parse(contents);
+    }
 
     activateExtensionForSuite({
         async setup(ctx) {
             workspaceContext = ctx;
             folderContext = await folderInRootWorkspace("defaultPackage", workspaceContext);
+            configFileUri = vscode.Uri.file(sourcekitConfigFilePath(folderContext));
             await workspaceContext.focusFolder(folderContext);
         },
     });
@@ -58,12 +70,7 @@ suite("Generate SourceKit-LSP configuration Command", function () {
     test("Calculates branch based on toolchain", async () => {
         const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
         expect(result).to.be.true;
-        const contents = Buffer.from(
-            await vscode.workspace.fs.readFile(
-                vscode.Uri.file(sourcekitConfigFilePath(folderContext))
-            )
-        ).toString("utf-8");
-        const config = JSON.parse(contents);
+        const config = await getSchema();
         const version = folderContext.swiftVersion;
         let branch: string;
         if (folderContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 1, 0))) {
@@ -79,16 +86,11 @@ suite("Generate SourceKit-LSP configuration Command", function () {
 
     test("Uses hardcoded path", async () => {
         resetSettings = await updateSettings({
-            "swift.sourcekit-lsp.configurationBranch": "release/6.1",
+            "swift.lspConfigurationBranch": "release/6.1",
         });
         const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
         expect(result).to.be.true;
-        const contents = Buffer.from(
-            await vscode.workspace.fs.readFile(
-                vscode.Uri.file(sourcekitConfigFilePath(folderContext))
-            )
-        ).toString("utf-8");
-        const config = JSON.parse(contents);
+        const config = await getSchema();
         expect(config).to.have.property(
             "$schema",
             `https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/release/6.1/config.schema.json`
@@ -97,19 +99,86 @@ suite("Generate SourceKit-LSP configuration Command", function () {
 
     test('Fallsback to "main" when path does not exist', async () => {
         resetSettings = await updateSettings({
-            "swift.sourcekit-lsp.configurationBranch": "totally-invalid-branch",
+            "swift.lspConfigurationBranch": "totally-invalid-branch",
         });
         const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
         expect(result).to.be.true;
-        const contents = Buffer.from(
-            await vscode.workspace.fs.readFile(
-                vscode.Uri.file(sourcekitConfigFilePath(folderContext))
-            )
-        ).toString("utf-8");
-        const config = JSON.parse(contents);
+        const config = await getSchema();
         expect(config).to.have.property(
             "$schema",
             `https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/main/config.schema.json`
         );
+    });
+
+    suite("handleSchemaUpdate", async () => {
+        const mockWindow = mockGlobalObject(vscode, "window");
+
+        test("Updates to new schema version", async () => {
+            await vscode.workspace.fs.writeFile(
+                configFileUri,
+                Buffer.from(
+                    JSON.stringify({
+                        $schema:
+                            "https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/main/config.schema.json",
+                    })
+                )
+            );
+            mockWindow.showInformationMessage.resolves("Yes" as any);
+            const document = await vscode.workspace.openTextDocument(configFileUri);
+
+            await handleSchemaUpdate(document, workspaceContext);
+
+            const config = await getSchema();
+            const version = folderContext.swiftVersion;
+            let branch: string;
+            if (folderContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 1, 0))) {
+                branch = version.dev ? "main" : `release/${version.major}.${version.minor}`;
+            } else {
+                branch = "main";
+            }
+            expect(config).to.have.property(
+                "$schema",
+                `https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/${branch}/config.schema.json`
+            );
+        });
+
+        test("Schema version still the same", async () => {
+            await vscode.workspace.fs.writeFile(
+                configFileUri,
+                Buffer.from(
+                    JSON.stringify({
+                        $schema: await determineSchemaURL(folderContext),
+                    })
+                )
+            );
+            mockWindow.showInformationMessage.resolves("Yes" as any);
+            const document = await vscode.workspace.openTextDocument(configFileUri);
+
+            await handleSchemaUpdate(document, workspaceContext);
+
+            expect(mockWindow.showInformationMessage).to.have.not.been.called;
+        });
+
+        test("Don't update schema version", async () => {
+            await vscode.workspace.fs.writeFile(
+                configFileUri,
+                Buffer.from(
+                    JSON.stringify({
+                        $schema:
+                            "https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/main/config.schema.json",
+                    })
+                )
+            );
+            mockWindow.showInformationMessage.resolves("No" as any);
+            const document = await vscode.workspace.openTextDocument(configFileUri);
+
+            await handleSchemaUpdate(document, workspaceContext);
+
+            const config = await getSchema();
+            expect(config).to.have.property(
+                "$schema",
+                "https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/main/config.schema.json"
+            );
+        });
     });
 });


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
This change will notify users when they open their .sourcekit-lsp/config.json file if the $schema property does not exist or if the value does not match the latest computed schema URL. There is a setting that disables this check and it is set if they click the "Don't Ask Again" button

Issue: #1208

## Tasks
- [X] Required tests have been written
- [X] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
