### PR TITLE
Optionally provide build tasks for library products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## {{releaseVersion}} - {{releaseDate}}
 
+### Added
+
+- New `swift.createTasksForLibraryProducts` setting that when enabled causes the extension to automatically create and provide tasks for library products ([#1741](https://github.com/swiftlang/vscode-swift/pull/1741))
+
 ## 2.10.0 - 2025-07-28
 
 ### Added
 
-- Added Swiftly toolchain management support `.swift-version` files, and integration with the toolchain selection UI ([#1717](https://github.com/swiftlang/vscode-swift/pull/1717)
+- Added Swiftly toolchain management support `.swift-version` files, and integration with the toolchain selection UI ([#1717](https://github.com/swiftlang/vscode-swift/pull/1717))
 - Added code lenses to run suites/tests, configurable with the `swift.showTestCodeLenses` setting ([#1698](https://github.com/swiftlang/vscode-swift/pull/1698))
 - New `swift.excludePathsFromActivation` setting to ignore specified sub-folders from being activated as projects ([#1693](https://github.com/swiftlang/vscode-swift/pull/1693))
 - New `swift.recordTestDuration` setting to disable capturing test durations, which can improve performance of heavy test runs ([#1745](https://github.com/swiftlang/vscode-swift/pull/1745))

--- a/assets/test/defaultPackage/Package.swift
+++ b/assets/test/defaultPackage/Package.swift
@@ -9,6 +9,10 @@ let package = Package(
         .library(
             name: "PackageLib",
             targets: ["PackageLib"]),
+        .library(
+            name: "PackageLib2",
+            type: .dynamic,
+            targets: ["PackageLib"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/assets/test/defaultPackage/Package@swift-6.0.swift
+++ b/assets/test/defaultPackage/Package@swift-6.0.swift
@@ -12,6 +12,10 @@ let package = Package(
         .library(
             name: "PackageLib",
             targets: ["PackageLib"]),
+        .library(
+            name: "PackageLib2",
+            type: .dynamic,
+            targets: ["PackageLib"]),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/package.json
+++ b/package.json
@@ -657,6 +657,12 @@
             ],
             "scope": "application"
           },
+          "swift.createTasksForLibraryProducts": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "When enabled, the extension will create \"swift\" build tasks for library products in the package manifest. Note that automatic library products will not be included.",
+            "scope": "machine-overridable"
+          },
           "swift.showCreateSwiftProjectInWelcomePage": {
             "type": "boolean",
             "default": true,

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -37,6 +37,10 @@ export interface Product {
     type: { executable?: null; library?: string[] };
 }
 
+export function isAutomatic(product: Product): boolean {
+    return (product.type.library || []).includes("automatic");
+}
+
 /** Swift Package Manager target */
 export interface Target {
     name: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -402,6 +402,12 @@ const configuration = {
             .getConfiguration("swift")
             .get<ShowBuildStatusOptions>("showBuildStatus", "swiftStatus");
     },
+    /** create build tasks for the library products of the package(s) */
+    get createTasksForLibraryProducts(): boolean {
+        return vscode.workspace
+            .getConfiguration("swift")
+            .get<boolean>("createTasksForLibraryProducts", false);
+    },
     /** background compilation */
     get backgroundCompilation(): boolean {
         return vscode.workspace

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -15,7 +15,7 @@
 import * as vscode from "vscode";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { FolderContext } from "../FolderContext";
-import { Product } from "../SwiftPackage";
+import { isAutomatic, Product } from "../SwiftPackage";
 import configuration, {
     ShowBuildStatusOptions,
     substituteVariablesInString,
@@ -424,6 +424,16 @@ export class SwiftTaskProvider implements vscode.TaskProvider {
             const executables = await folderContext.swiftPackage.executableProducts;
             for (const executable of executables) {
                 tasks.push(...createBuildTasks(executable, folderContext));
+            }
+
+            if (configuration.createTasksForLibraryProducts) {
+                const libraries = await folderContext.swiftPackage.libraryProducts;
+                for (const lib of libraries) {
+                    if (isAutomatic(lib)) {
+                        continue;
+                    }
+                    tasks.push(...createBuildTasks(lib, folderContext));
+                }
             }
         }
         return tasks;

--- a/userdocs/userdocs.docc/Articles/Features/automatic-task-creation.md
+++ b/userdocs/userdocs.docc/Articles/Features/automatic-task-creation.md
@@ -18,4 +18,4 @@ By default build tasks are only automatically created for executable products. I
 - **Build Debug \<Library\>**: Each library product in a Package.swift get a task for building a debug build.
 - **Build Release \<Library\>**: Each library product in a Package.swift get a task for building a release build.
 
-> ⚠️ Important: Tasks will not be created for automatic library products, as you cannot specify a `--product` option for automatic products when building.
+> ⚠️ Important: Tasks will not be created for automatic library products, as you cannot specify a `--product` option for automatic products when building. For more information see the [Swift Package Manager documentation for Product definitions](https://docs.swift.org/package-manager/PackageDescription/PackageDescription.html#product).

--- a/userdocs/userdocs.docc/Articles/Features/automatic-task-creation.md
+++ b/userdocs/userdocs.docc/Articles/Features/automatic-task-creation.md
@@ -5,9 +5,17 @@ Add tasks for common operations with your Package.
 For workspaces that contain a `Package.swift` file, the Swift extension adds the following tasks:
 
 - **Build All**: Build all targets in the Package.
-- **Build Debug <Executable>**: Each executable in a Package.swift get a task for building a debug build.
-- **Build Release <Executable>**: Each executable in a Package.swift get a task for building a release build.
+- **Build Debug \<Executable\>**: Each executable product in a Package.swift get a task for building a debug build.
+- **Build Release \<Executable\>**: Each executable product in a Package.swift get a task for building a release build.
 
 > 💡 Tip: Tasks use workflows common to all VS Code extensions. For more information see [the VS Code documentation for tasks](https://code.visualstudio.com/docs/editor/tasks).
 
 These tasks are available via the commands **Terminal ▸ Run Task...** and **Terminal ▸ Run Build Task...** in the command palette.
+
+## Create tasks for library targets
+
+By default build tasks are only automatically created for executable products. If you set the `swift.createTasksForLibraryProducts` setting to true, then additional tasks will be created:
+- **Build Debug \<Library\>**: Each library product in a Package.swift get a task for building a debug build.
+- **Build Release \<Library\>**: Each library product in a Package.swift get a task for building a release build.
+
+> ⚠️ Important: Tasks will not be created for automatic library products, as you cannot specify a `--product` option for automatic products when building.


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Introduce a new `swift.createTasksForLibraryProducts` setting that is false by default, but when enabled causes the extension to automatically create and provide tasks for library products. Any automatic library products will still be ignored as they'd just result in a warning:
```
warning: '--product' cannot be used with the automatic product 'PackageLib'; building the default target instead
```

Issue: #1646

## Tasks
- [X] Required tests have been written
- [x] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
