### PR TITLE
Fix error when running tests multiple times from the editor gutter

### DIFF
--- a/package.json
+++ b/package.json
@@ -975,6 +975,16 @@
       ],
       "commandPalette": [
         {
+          "command": "swift.runTestsMultipleTimes",
+          "group": "testExtras",
+          "when": "false"
+        },
+        {
+          "command": "swift.runTestsUntilFailure",
+          "group": "testExtras",
+          "when": "false"
+        },
+        {
           "command": "swift.generateLaunchConfigurations",
           "when": "swift.hasExecutableProduct"
         },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -38,7 +38,7 @@ import { resolveDependencies } from "./commands/dependencies/resolve";
 import { resetPackage } from "./commands/resetPackage";
 import { updateDependencies } from "./commands/dependencies/update";
 import { runPluginTask } from "./commands/runPluginTask";
-import { runTestMultipleTimes } from "./commands/testMultipleTimes";
+import { extractTestItemsAndCount, runTestMultipleTimes } from "./commands/testMultipleTimes";
 import { newSwiftFile } from "./commands/newFile";
 import { runAllTests } from "./commands/runAllTests";
 import { updateDependenciesViewList } from "./commands/dependencies/updateDepViewList";
@@ -280,43 +280,6 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             async () => await generateSourcekitConfiguration(ctx)
         ),
     ];
-}
-
-/**
- * Extracts an array of vscode.TestItem and count from the provided varargs. Effectively, this
- * converts a varargs function from accepting both numbers and test items to:
- *
- *     function (...testItems: vscode.TestItem[], count?: number): void;
- *
- * The VS Code testing view sends test items via varargs, but we have a couple testing commands that
- * also accept a final count parameter. We have to find the count parameter ourselves since JavaScript
- * only supports varargs at the end of an argument list.
- */
-function extractTestItemsAndCount(...args: (vscode.TestItem | number)[]): {
-    testItems: vscode.TestItem[];
-    count?: number;
-} {
-    const result = args.reduceRight<{
-        testItems: vscode.TestItem[];
-        count?: number;
-    }>(
-        (result, arg, index) => {
-            if (typeof arg === "number" && index === args.length - 1) {
-                result.count = arg;
-                return result;
-            } else if (typeof arg === "object") {
-                result.testItems.push(arg);
-                return result;
-            } else {
-                throw new Error(`Unexpected argument ${arg} at index ${index}`);
-            }
-        },
-        { testItems: [] }
-    );
-    if (result.testItems.length === 0) {
-        throw new Error("At least one TestItem must be provided");
-    }
-    return result;
 }
 
 /**

--- a/src/commands/testMultipleTimes.ts
+++ b/src/commands/testMultipleTimes.ts
@@ -96,19 +96,22 @@ export async function runTestMultipleTimes(
  * also accept a final count parameter. We have to find the count parameter ourselves since JavaScript
  * only supports varargs at the end of an argument list.
  */
-export function extractTestItemsAndCount(...args: (vscode.TestItem | number)[]): {
+export function extractTestItemsAndCount(
+    ...args: (vscode.TestItem | number | undefined | null)[]
+): {
     testItems: vscode.TestItem[];
     count?: number;
 } {
-    const result = args.reduceRight<{
+    const result = args.reduce<{
         testItems: vscode.TestItem[];
         count?: number;
     }>(
         (result, arg, index) => {
-            if (
-                (arg === undefined || arg === null || typeof arg === "number") &&
-                index === args.length - 1
-            ) {
+            if (arg === undefined || arg === null) {
+                return result;
+            }
+
+            if (typeof arg === "number" && index === args.length - 1) {
                 result.count = arg ?? undefined;
                 return result;
             } else if (typeof arg === "object") {

--- a/test/unit-tests/commands/runTestMultipleTimes.test.ts
+++ b/test/unit-tests/commands/runTestMultipleTimes.test.ts
@@ -1,0 +1,67 @@
+import * as vscode from "vscode";
+import { expect } from "chai";
+import { extractTestItemsAndCount } from "../../../src/commands/testMultipleTimes";
+
+suite("Run Tests Multiple Times", () => {
+    suite("extractTestItemsAndCount()", () => {
+        function createDummyTestItem(label: string): vscode.TestItem {
+            return { label } as vscode.TestItem;
+        }
+
+        test("handles empty arguments", () => {
+            const { testItems, count } = extractTestItemsAndCount();
+            expect(testItems).to.deep.equal([]);
+            expect(count).to.be.undefined;
+        });
+
+        test("handles test items with no count", () => {
+            const testItem1 = createDummyTestItem("Test Item 1");
+            const testItem2 = createDummyTestItem("Test Item 2");
+            const testItem3 = createDummyTestItem("Test Item 3");
+
+            const { testItems, count } = extractTestItemsAndCount(testItem1, testItem2, testItem3);
+            expect(testItems).to.deep.equal([testItem1, testItem2, testItem3]);
+            expect(count).to.be.undefined;
+        });
+
+        test("handles test items with count", () => {
+            const testItem1 = createDummyTestItem("Test Item 1");
+            const testItem2 = createDummyTestItem("Test Item 2");
+            const testItem3 = createDummyTestItem("Test Item 3");
+
+            const { testItems, count } = extractTestItemsAndCount(
+                testItem1,
+                testItem2,
+                testItem3,
+                17
+            );
+            expect(testItems).to.deep.equal([testItem1, testItem2, testItem3]);
+            expect(count).to.equal(17);
+        });
+
+        test("ignores undefined or null arguments", () => {
+            const testItem1 = createDummyTestItem("Test Item 1");
+            const testItem2 = createDummyTestItem("Test Item 2");
+            const testItem3 = createDummyTestItem("Test Item 3");
+
+            const { testItems, count } = extractTestItemsAndCount(
+                testItem1,
+                null,
+                testItem2,
+                testItem3,
+                undefined
+            );
+            expect(testItems).to.deep.equal([testItem1, testItem2, testItem3]);
+            expect(count).to.be.undefined;
+        });
+
+        test("throws an error if the count is not the last argument", () => {
+            const testItem1 = createDummyTestItem("Test Item 1");
+            const testItem2 = createDummyTestItem("Test Item 2");
+
+            expect(() => extractTestItemsAndCount(testItem1, 17, testItem2)).to.throw(
+                "Unexpected argument 17 at index 1"
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Description
The VS Code editor gutter menu actions for tests pass in an extra `undefined` argument to `Run tests multiple times` and `Run until failure`. Properly handle this in `extractTestItemsAndCount()`.

Issue: #1740

## Tasks
- [ ] Required tests have been written
- ~~[ ] Documentation has been updated~~
- ~~[ ] Added an entry to CHANGELOG.md if applicable~~

No need to update CHANGELOG as this is a bug that only exists in pre-release.