### PR TITLE
Fixed JSON parsing error while selecting toolchain

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -63,14 +63,15 @@ import { generateSourcekitConfiguration } from "./commands/generateSourcekitConf
 export type WorkspaceContextWithToolchain = WorkspaceContext & { toolchain: SwiftToolchain };
 
 export function registerToolchainCommands(
-    toolchain: SwiftToolchain | undefined
+    toolchain: SwiftToolchain | undefined,
+    cwd?: vscode.Uri
 ): vscode.Disposable[] {
     return [
         vscode.commands.registerCommand("swift.createNewProject", () =>
             createNewProject(toolchain)
         ),
         vscode.commands.registerCommand("swift.selectToolchain", () =>
-            showToolchainSelectionQuickPick(toolchain)
+            showToolchainSelectionQuickPick(toolchain, cwd)
         ),
         vscode.commands.registerCommand("swift.pickProcess", configuration =>
             pickProcess(configuration)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,7 +81,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
 
         context.subscriptions.push(new SwiftEnvironmentVariablesManager(context));
         context.subscriptions.push(SwiftTerminalProfileProvider.register());
-        context.subscriptions.push(...commands.registerToolchainCommands(toolchain));
+        context.subscriptions.push(
+            ...commands.registerToolchainCommands(toolchain, workspaceContext.currentFolder?.folder)
+        );
 
         // Watch for configuration changes the trigger a reload of the extension if necessary.
         context.subscriptions.push(

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -20,18 +20,17 @@ import * as vscode from "vscode";
 import { Version } from "../utilities/version";
 import { z } from "zod";
 
-const ListAvailableResult = z.object({
+const ListResult = z.object({
     toolchains: z.array(
         z.object({
             inUse: z.boolean(),
-            installed: z.boolean(),
             isDefault: z.boolean(),
-            name: z.string(),
             version: z.discriminatedUnion("type", [
                 z.object({
                     major: z.number(),
                     minor: z.number(),
                     patch: z.number().optional(),
+                    name: z.string(),
                     type: z.literal("stable"),
                 }),
                 z.object({
@@ -39,7 +38,7 @@ const ListAvailableResult = z.object({
                     minor: z.number(),
                     branch: z.string(),
                     date: z.string(),
-
+                    name: z.string(),
                     type: z.literal("snapshot"),
                 }),
             ]),
@@ -97,9 +96,9 @@ export class Swiftly {
         outputChannel?: vscode.OutputChannel
     ): Promise<string[]> {
         try {
-            const { stdout } = await execFile("swiftly", ["list-available", "--format=json"]);
-            const response = ListAvailableResult.parse(JSON.parse(stdout));
-            return response.toolchains.map(t => t.name);
+            const { stdout } = await execFile("swiftly", ["list", "--format=json"]);
+            const response = ListResult.parse(JSON.parse(stdout));
+            return response.toolchains.map(t => t.version.name);
         } catch (error) {
             outputChannel?.appendLine(`Failed to retrieve Swiftly installations: ${error}`);
             throw new Error(

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -101,9 +101,7 @@ export class Swiftly {
             return response.toolchains.map(t => t.version.name);
         } catch (error) {
             outputChannel?.appendLine(`Failed to retrieve Swiftly installations: ${error}`);
-            throw new Error(
-                `Failed to retrieve Swiftly installations from disk: ${(error as Error).message}`
-            );
+            return [];
         }
     }
 
@@ -141,6 +139,13 @@ export class Swiftly {
             cwd: cwd?.fsPath,
         });
         return inUse.trimEnd();
+    }
+
+    public static async use(version: string): Promise<void> {
+        if (!this.isSupported()) {
+            throw new Error("Swiftly is not supported on this platform");
+        }
+        await execFile("swiftly", ["use", version]);
     }
 
     /**

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -27,15 +27,15 @@ const ListResult = z.object({
             isDefault: z.boolean(),
             version: z.discriminatedUnion("type", [
                 z.object({
-                    major: z.number(),
-                    minor: z.number(),
+                    major: z.number().optional(),
+                    minor: z.number().optional(),
                     patch: z.number().optional(),
                     name: z.string(),
                     type: z.literal("stable"),
                 }),
                 z.object({
-                    major: z.number(),
-                    minor: z.number(),
+                    major: z.number().optional(),
+                    minor: z.number().optional(),
                     branch: z.string(),
                     date: z.string(),
                     name: z.string(),
@@ -134,7 +134,7 @@ export class Swiftly {
         return process.platform === "linux" || process.platform === "darwin";
     }
 
-    public static async inUseLocation(swiftlyPath: string, cwd?: vscode.Uri) {
+    public static async inUseLocation(swiftlyPath: string = "swiftly", cwd?: vscode.Uri) {
         const { stdout: inUse } = await execFile(swiftlyPath, ["use", "--print-location"], {
             cwd: cwd?.fsPath,
         });
@@ -180,6 +180,36 @@ export class Swiftly {
             }
         }
         return undefined;
+    }
+
+    /**
+     * Returns the home directory for Swiftly.
+     *
+     * @returns The path to the Swiftly home directory.
+     */
+    static getHomeDir(): string | undefined {
+        return process.env["SWIFTLY_HOME_DIR"];
+    }
+
+    /**
+     * Returns the directory where Swift binaries managed by Swiftly are installed.
+     * This is a placeholder method and should be implemented based on your environment.
+     *
+     * @returns The path to the Swiftly binaries directory.
+     */
+    static getBinDir(): string {
+        const overriddenBinDir = process.env["SWIFTLY_BIN_DIR"];
+        if (overriddenBinDir) {
+            return overriddenBinDir;
+        }
+
+        // If SWIFTLY_BIN_DIR is not set, use the default location based on SWIFTLY_HOME_DIR
+        // This assumes that the binaries are located in the "bin" subdirectory of SWIFTLY_HOME_DIR
+        const swiftlyHomeDir = Swiftly.getHomeDir();
+        if (!swiftlyHomeDir) {
+            throw new Error("Swiftly is not installed or SWIFTLY_HOME_DIR is not set.");
+        }
+        return path.join(swiftlyHomeDir, "bin");
     }
 
     /**

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -304,7 +304,22 @@ export async function showToolchainSelectionQuickPick(activeToolchain: SwiftTool
             }
         }
         // Update the toolchain path
-        const isUpdated = await setToolchainPath(selected.swiftFolderPath, developerDir);
+        let swiftPath = selected.swiftFolderPath;
+
+        // Handle Swiftly toolchains specially
+        if (selected.category === "swiftly") {
+            try {
+                // Run swiftly use <version> and get the path to the toolchain
+                await Swiftly.use(selected.label);
+                const inUseLocation = await Swiftly.inUseLocation("swiftly");
+                swiftPath = path.join(inUseLocation, "usr", "bin");
+            } catch (error) {
+                void vscode.window.showErrorMessage(`Failed to switch Swiftly toolchain: ${error}`);
+                return;
+            }
+        }
+
+        const isUpdated = await setToolchainPath(swiftPath, developerDir);
         if (isUpdated && selected.onDidSelect) {
             await selected.onDidSelect();
         }

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -38,50 +38,45 @@ suite("Swiftly Unit Tests", () => {
                 toolchains: [
                     {
                         inUse: true,
-                        installed: true,
                         isDefault: true,
-                        name: "swift-5.9.0-RELEASE",
                         version: {
                             major: 5,
                             minor: 9,
                             patch: 0,
+                            name: "swift-5.9.0-RELEASE",
                             type: "stable",
                         },
                     },
                     {
                         inUse: false,
-                        installed: true,
                         isDefault: false,
-                        name: "swift-5.8.0-RELEASE",
                         version: {
                             major: 5,
                             minor: 8,
                             patch: 0,
+                            name: "swift-5.8.0-RELEASE",
                             type: "stable",
                         },
                     },
                     {
                         inUse: false,
-                        installed: false,
                         isDefault: false,
-                        name: "swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
                         version: {
                             major: 5,
                             minor: 10,
                             branch: "development",
                             date: "2023-10-15",
+                            name: "swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
                             type: "snapshot",
                         },
                     },
                 ],
             };
 
-            mockUtilities.execFile
-                .withArgs("swiftly", ["list-available", "--format=json"])
-                .resolves({
-                    stdout: JSON.stringify(jsonOutput),
-                    stderr: "",
-                });
+            mockUtilities.execFile.withArgs("swiftly", ["list", "--format=json"]).resolves({
+                stdout: JSON.stringify(jsonOutput),
+                stderr: "",
+            });
 
             const result = await Swiftly.listAvailableToolchains();
 
@@ -93,7 +88,7 @@ suite("Swiftly Unit Tests", () => {
 
             expect(mockUtilities.execFile).to.have.been.calledWith("swiftly", ["--version"]);
             expect(mockUtilities.execFile).to.have.been.calledWith("swiftly", [
-                "list-available",
+                "list",
                 "--format=json",
             ]);
         });


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
In the swiftly toolchain version schema, there was a missing `name` attribute, which prevented it from parsing the value. In this fix, I have removed the `name` field from the top-level and added it at the object level. 

Issue: https://github.com/swiftlang/vscode-swift/issues/1739

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
