### PR TITLE
Add `swift.recordTestDuration` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added Swiftly toolchain management support `.swift-version` files, and integration with the toolchain selection UI ([#1717](https://github.com/swiftlang/vscode-swift/pull/1717)
 - Added code lenses to run suites/tests, configurable with the `swift.showTestCodeLenses` setting ([#1698](https://github.com/swiftlang/vscode-swift/pull/1698))
 - New `swift.excludePathsFromActivation` setting to ignore specified sub-folders from being activated as projects ([#1693](https://github.com/swiftlang/vscode-swift/pull/1693))
+- New `swift.recordTestDuration` setting to disable capturing test durations, which can improve performance of heavy test runs ([#1745](https://github.com/swiftlang/vscode-swift/pull/1745))
 - Add a `Generate SourceKit-LSP Configuration` command that creates the configuration file with versioned schema pre-populated ([#1726](https://github.com/swiftlang/vscode-swift/pull/1716))
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -615,6 +615,12 @@
                 "coverage"
               ]
             }
+          },
+          "swift.recordTestDuration": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Controls whether or not to record the duration of tests in the Test Explorer. This is used to show the duration of tests in the Test Explorer view. If you're experiencing performance issues when running a large number of tests that complete quickly, disabling this setting can make the UI more responsive.",
+            "scope": "machine-overridable"
           }
         }
       },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -297,6 +297,10 @@ const configuration = {
             .getConfiguration("swift")
             .get<boolean | ValidCodeLens[]>("showTestCodeLenses", true);
     },
+    /** Whether to record the duration of tests in the Test Explorer. */
+    get recordTestDuration(): boolean {
+        return vscode.workspace.getConfiguration("swift").get<boolean>("recordTestDuration", true);
+    },
     /** Files and directories to exclude from the Package Dependencies view. */
     get excludePathsFromPackageDependencies(): string[] {
         return vscode.workspace


### PR DESCRIPTION
When running a large test suite full of tests that complete very quickly, VS Code spends a lot of time updating the test explorer UI. For every test the tree is refreshed, and in a suite where thousands of tests complete very quickly this can make the UI unresponsive and increase the amount of time the test run takes.

The UI updates because the duration of the test item is different between runs, requiring the UI to change. As in the case described above, omitting the duration when passing or failing test items significantly improves performance.

Introduce the `swift.recordTestDuration` setting which, when set to false, will omit the duration when recording test results. The default is `true`, making this optimization opt-in.

This intended use is to opt out of duration recording on a per-project basis for projects that exhibit poor test explorer performance with many fast running tests.