### PR TITLE
Don't call install extensions in CI

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -102,8 +102,8 @@ module.exports = defineConfig({
                     },
                 },
             },
+            skipExtensionDependencies: install.length > 0,
             reuseMachineInstall: !isCIBuild,
-            installExtensions,
         },
         {
             label: "codeWorkspaceTests",
@@ -141,8 +141,8 @@ module.exports = defineConfig({
                     },
                 },
             },
+            skipExtensionDependencies: install.length > 0,
             reuseMachineInstall: !isCIBuild,
-            installExtensions,
         },
         {
             label: "unitTests",


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Don't call install extensions in the test jobs as that still seems to cause the crash https://github.com/swiftlang/vscode-swift/actions/runs/16583608499/job/46904736389

Issue: #1751

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
