### PR TITLE
Optionally add lldb-dap logs to Diagnostic Bundle

### DIFF
--- a/src/logging/SwiftLoggerFactory.ts
+++ b/src/logging/SwiftLoggerFactory.ts
@@ -19,7 +19,7 @@ import { SwiftOutputChannel } from "./SwiftOutputChannel";
 import { SwiftLogger } from "./SwiftLogger";
 
 export class SwiftLoggerFactory {
-    constructor(private logFolderUri: vscode.Uri) {}
+    constructor(public readonly logFolderUri: vscode.Uri) {}
 
     create(name: string, logFilename: string): SwiftLogger;
     create(name: string, logFilename: string, options: { outputChannel: true }): SwiftOutputChannel;

--- a/src/utilities/extensions.ts
+++ b/src/utilities/extensions.ts
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+export enum Extension {
+    CODELLDB = "vadimcn.vscode-lldb",
+    LLDBDAP = "llvm-vs-code-extensions.lldb-dap",
+}

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -26,6 +26,7 @@ import { Version } from "../../../src/utilities/version";
 import configuration from "../../../src/configuration";
 import { buildAllTaskName, resetBuildAllTaskCache } from "../../../src/tasks/SwiftTaskProvider";
 import { SwiftLogger } from "../../../src/logging/SwiftLogger";
+import { Extension } from "../../../src/utilities/extensions";
 
 export function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     const result = vscode.workspace.workspaceFolders?.at(0);
@@ -197,7 +198,7 @@ const extensionBootstrapper = (() => {
             // `vscode.extensions.getExtension<Api>("swiftlang.swift-vscode")` once.
             // Subsequent activations must be done through the returned API object.
             if (!activator) {
-                for (const depId of ["vadimcn.vscode-lldb", "llvm-vs-code-extensions.lldb-dap"]) {
+                for (const depId of [Extension.CODELLDB, Extension.LLDBDAP]) {
                     const dep = vscode.extensions.getExtension<Api>(depId);
                     if (!dep) {
                         throw new Error(`Unable to find extension "${depId}"`);


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
This change optionally includes the LLDB DAP extension logs in the diagnostic bundle. Updated language in the prompt so the user knows it is included.

Issue:  #1757

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
