### PR TITLE
Add commands to debug tests multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,16 @@
         "category": "Swift"
       },
       {
+        "command": "swift.debugTestsMultipleTimes",
+        "title": "Debug Multiple Times...",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.debugTestsUntilFailure",
+        "title": "Debug Until Failure...",
+        "category": "Swift"
+      },
+      {
         "command": "swift.pickProcess",
         "title": "Pick Process...",
         "category": "Swift"
@@ -976,6 +986,16 @@
           "command": "swift.runTestsUntilFailure",
           "group": "testExtras",
           "when": "testId in swift.tests"
+        },
+        {
+          "command": "swift.debugTestsMultipleTimes",
+          "group": "testExtras",
+          "when": "testId in swift.tests"
+        },
+        {
+          "command": "swift.debugTestsUntilFailure",
+          "group": "testExtras",
+          "when": "testId in swift.tests"
         }
       ],
       "testing/item/context": [
@@ -986,6 +1006,16 @@
         },
         {
           "command": "swift.runTestsUntilFailure",
+          "group": "testExtras",
+          "when": "testId in swift.tests"
+        },
+        {
+          "command": "swift.debugTestsMultipleTimes",
+          "group": "testExtras",
+          "when": "testId in swift.tests"
+        },
+        {
+          "command": "swift.debugTestsUntilFailure",
           "group": "testExtras",
           "when": "testId in swift.tests"
         }
@@ -1012,6 +1042,16 @@
         },
         {
           "command": "swift.runTestsUntilFailure",
+          "group": "testExtras",
+          "when": "false"
+        },
+        {
+          "command": "swift.debugTestsMultipleTimes",
+          "group": "testExtras",
+          "when": "false"
+        },
+        {
+          "command": "swift.debugTestsUntilFailure",
           "group": "testExtras",
           "when": "false"
         },

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -22,7 +22,7 @@ import {
 } from "./TestEventStreamReader";
 import { ITestRunState } from "./TestRunState";
 import { TestClass } from "../TestDiscovery";
-import { sourceLocationToVSCodeLocation } from "../../utilities/utilities";
+import { colorize, sourceLocationToVSCodeLocation } from "../../utilities/utilities";
 import { exec } from "child_process";
 import { lineBreakRegex } from "../../utilities/tasks";
 
@@ -649,15 +649,15 @@ export class SymbolRenderer {
             case TestSymbol.skip:
             case TestSymbol.difference:
             case TestSymbol.passWithKnownIssue:
-                return `${SymbolRenderer.ansiEscapeCodePrefix}90m${symbol}${SymbolRenderer.resetANSIEscapeCode}`;
+                return colorize(symbol, "grey");
             case TestSymbol.pass:
-                return `${SymbolRenderer.ansiEscapeCodePrefix}92m${symbol}${SymbolRenderer.resetANSIEscapeCode}`;
+                return colorize(symbol, "lightGreen");
             case TestSymbol.fail:
-                return `${SymbolRenderer.ansiEscapeCodePrefix}91m${symbol}${SymbolRenderer.resetANSIEscapeCode}`;
+                return colorize(symbol, "lightRed");
             case TestSymbol.warning:
-                return `${SymbolRenderer.ansiEscapeCodePrefix}93m${symbol}${SymbolRenderer.resetANSIEscapeCode}`;
+                return colorize(symbol, "lightYellow");
             case TestSymbol.attachment:
-                return `${SymbolRenderer.ansiEscapeCodePrefix}94m${symbol}${SymbolRenderer.resetANSIEscapeCode}`;
+                return colorize(symbol, "lightBlue");
             case TestSymbol.none:
             default:
                 return symbol;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -91,6 +91,8 @@ export enum Commands {
     UPDATE_DEPENDENCIES = "swift.updateDependencies",
     RUN_TESTS_MULTIPLE_TIMES = "swift.runTestsMultipleTimes",
     RUN_TESTS_UNTIL_FAILURE = "swift.runTestsUntilFailure",
+    DEBUG_TESTS_MULTIPLE_TIMES = "swift.debugTestsMultipleTimes",
+    DEBUG_TESTS_UNTIL_FAILURE = "swift.debugTestsUntilFailure",
     RESET_PACKAGE = "swift.resetPackage",
     USE_LOCAL_DEPENDENCY = "swift.useLocalDependency",
     UNEDIT_DEPENDENCY = "swift.uneditDependency",
@@ -144,7 +146,13 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             async (...args: (vscode.TestItem | number)[]) => {
                 const { testItems, count } = extractTestItemsAndCount(...args);
                 if (ctx.currentFolder) {
-                    return await runTestMultipleTimes(ctx.currentFolder, testItems, false, count);
+                    return await runTestMultipleTimes(
+                        ctx.currentFolder,
+                        testItems,
+                        false,
+                        TestKind.standard,
+                        count
+                    );
                 }
             }
         ),
@@ -153,7 +161,44 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             async (...args: (vscode.TestItem | number)[]) => {
                 const { testItems, count } = extractTestItemsAndCount(...args);
                 if (ctx.currentFolder) {
-                    return await runTestMultipleTimes(ctx.currentFolder, testItems, true, count);
+                    return await runTestMultipleTimes(
+                        ctx.currentFolder,
+                        testItems,
+                        true,
+                        TestKind.standard,
+                        count
+                    );
+                }
+            }
+        ),
+
+        vscode.commands.registerCommand(
+            Commands.DEBUG_TESTS_MULTIPLE_TIMES,
+            async (...args: (vscode.TestItem | number)[]) => {
+                const { testItems, count } = extractTestItemsAndCount(...args);
+                if (ctx.currentFolder) {
+                    return await runTestMultipleTimes(
+                        ctx.currentFolder,
+                        testItems,
+                        false,
+                        TestKind.debug,
+                        count
+                    );
+                }
+            }
+        ),
+        vscode.commands.registerCommand(
+            Commands.DEBUG_TESTS_UNTIL_FAILURE,
+            async (...args: (vscode.TestItem | number)[]) => {
+                const { testItems, count } = extractTestItemsAndCount(...args);
+                if (ctx.currentFolder) {
+                    return await runTestMultipleTimes(
+                        ctx.currentFolder,
+                        testItems,
+                        true,
+                        TestKind.debug,
+                        count
+                    );
                 }
             }
         ),

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -147,6 +147,29 @@ export async function execFile(
     });
 }
 
+enum Color {
+    red = 31,
+    green = 32,
+    yellow = 33,
+    blue = 34,
+    magenta = 35,
+    cyan = 36,
+    white = 37,
+    grey = 90,
+    lightRed = 91,
+    lightGreen = 92,
+    lightYellow = 93,
+    lightBlue = 94,
+}
+
+export function colorize(text: string, color: keyof typeof Color): string {
+    const colorCode = Color[color];
+    if (colorCode !== undefined) {
+        return `\x1b[${colorCode}m${text}\x1b[0m`;
+    }
+    return text;
+}
+
 export async function execFileStreamOutput(
     executable: string,
     args: string[],

--- a/test/integration-tests/commands/runTestMultipleTimes.test.ts
+++ b/test/integration-tests/commands/runTestMultipleTimes.test.ts
@@ -18,6 +18,7 @@ import { runTestMultipleTimes } from "../../../src/commands/testMultipleTimes";
 import { FolderContext } from "../../../src/FolderContext";
 import { TestRunProxy } from "../../../src/TestExplorer/TestRunner";
 import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
+import { TestKind } from "../../../src/TestExplorer/TestKind";
 
 suite("Test Multiple Times Command Test Suite", () => {
     let folderContext: FolderContext;
@@ -39,13 +40,24 @@ suite("Test Multiple Times Command Test Suite", () => {
     });
 
     test("Runs successfully after testing 0 times", async () => {
-        const runState = await runTestMultipleTimes(folderContext, [testItem], false, 0);
+        const runState = await runTestMultipleTimes(
+            folderContext,
+            [testItem],
+            false,
+            TestKind.standard,
+            0
+        );
         expect(runState).to.be.an("array").that.is.empty;
     });
 
     test("Runs successfully after testing 3 times", async () => {
-        const runState = await runTestMultipleTimes(folderContext, [testItem], false, 3, () =>
-            Promise.resolve(TestRunProxy.initialTestRunState())
+        const runState = await runTestMultipleTimes(
+            folderContext,
+            [testItem],
+            false,
+            TestKind.standard,
+            3,
+            () => Promise.resolve(TestRunProxy.initialTestRunState())
         );
 
         expect(runState).to.deep.equal([
@@ -61,13 +73,20 @@ suite("Test Multiple Times Command Test Suite", () => {
             failed: [{ test: testItem, message: new vscode.TestMessage("oh no") }],
         };
         let ctr = 0;
-        const runState = await runTestMultipleTimes(folderContext, [testItem], true, 3, () => {
-            ctr += 1;
-            if (ctr === 2) {
-                return Promise.resolve(failure);
+        const runState = await runTestMultipleTimes(
+            folderContext,
+            [testItem],
+            true,
+            TestKind.standard,
+            3,
+            () => {
+                ctr += 1;
+                if (ctr === 2) {
+                    return Promise.resolve(failure);
+                }
+                return Promise.resolve(TestRunProxy.initialTestRunState());
             }
-            return Promise.resolve(TestRunProxy.initialTestRunState());
-        });
+        );
 
         expect(runState).to.deep.equal([TestRunProxy.initialTestRunState(), failure]);
     });


### PR DESCRIPTION
Adds two new commands, `swift.debugTestsMultipleTimes` and `swift.debugTestsUntilFailure`. They behave the same as the existing run multiple and run until failure commands, except they use the debugging profile. When debugging multiple times a build is only performed for the first iteration, after which the resulting artifacts are run multiple times.

Also cleans up some of the multiple test run console output.

Issue: #1747