### PR TITLE
Run all tests when none are specified in TestRunRequest

### DIFF
--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -38,12 +38,26 @@ export class TestRunArguments {
         this.swiftTestArgs = this.annotateTestArgs(swiftTestArgs, isDebug);
     }
 
+    /**
+     * Returns true if there are XCTests specified in the request.
+     */
     public get hasXCTests(): boolean {
-        return this.xcTestArgs.length > 0;
+        return this.xcTestArgs.length > 0 || this.hasNoSpecifiedTests;
     }
 
+    /**
+     * Returns true if there are swift-testing tests specified in the request.
+     */
     public get hasSwiftTestingTests(): boolean {
-        return this.swiftTestArgs.length > 0;
+        return this.swiftTestArgs.length > 0 || this.hasNoSpecifiedTests;
+    }
+
+    /**
+     * Returns true if there are no tests specified in the request,
+     * which indicates that we should run all tests.
+     */
+    private get hasNoSpecifiedTests(): boolean {
+        return this.testItems.length === 0;
     }
 
     /**

--- a/test/integration-tests/testexplorer/TestRunArguments.test.ts
+++ b/test/integration-tests/testexplorer/TestRunArguments.test.ts
@@ -76,10 +76,7 @@ suite("TestRunArguments Suite", () => {
 
     function assertRunArguments(
         args: TestRunArguments,
-        expected: Omit<
-            Omit<Omit<TestRunArguments, "testItems">, "hasXCTests">,
-            "hasSwiftTestingTests"
-        > & { testItems: string[] }
+        expected: Partial<Omit<TestRunArguments, "testItems">> & { testItems: string[] }
     ) {
         // Order of testItems doesn't matter, that they contain the same elements.
         assert.deepStrictEqual(
@@ -132,12 +129,15 @@ suite("TestRunArguments Suite", () => {
             const xcTest = new TestRunArguments(runRequestByIds([xcTestId]), false);
             const swiftTestingTest = new TestRunArguments(runRequestByIds([swiftTestId]), false);
             const bothTests = new TestRunArguments(runRequestByIds([xcTestId, swiftTestId]), false);
+            const noTests = new TestRunArguments(runRequestByIds([]), false);
             assert.strictEqual(xcTest.hasXCTests, true);
             assert.strictEqual(xcTest.hasSwiftTestingTests, false);
             assert.strictEqual(swiftTestingTest.hasXCTests, false);
             assert.strictEqual(swiftTestingTest.hasSwiftTestingTests, true);
             assert.strictEqual(bothTests.hasXCTests, true);
             assert.strictEqual(bothTests.hasSwiftTestingTests, true);
+            assert.strictEqual(noTests.hasXCTests, true);
+            assert.strictEqual(noTests.hasSwiftTestingTests, true);
         });
 
         test("Single XCTest", () => {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
VS Code provides commands like `Tests: Run Tests` that can be executed before we have a list of tests from the LSP. When we receive an empty `TestRunRequest` today we gather up all the tests we know about and run those by creating the appropriate `--filter` arguments to pass to `swift test`.

To ensure we run all the tests whether the LSP has informed us of them or not, run `swift test` with no filter when we recieve an empty `vscode.TestRunRequest`.

Issue: #1764

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
