### PR TITLE
Focus root folder for packages w/ sub-packages

### DIFF
--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -336,15 +336,18 @@ export class WorkspaceContext implements vscode.Disposable {
                 await this.addWorkspaceFolder(folder);
             }
         }
+
         // If we don't have a current selected folder Start up language server by firing focus event
-        // on either null folder or the first folder if there is only one
+        // on the first root folder found in the workspace if there is only one.
         if (this.currentFolder === undefined) {
-            if (this.folders.length === 1) {
-                await this.focusFolder(this.folders[0]);
+            const rootFolders = this.folders.filter(folder => folder.isRootFolder);
+            if (rootFolders.length === 1) {
+                await this.focusFolder(rootFolders[0]);
             } else {
                 await this.focusFolder(null);
             }
         }
+
         await this.initialisationComplete();
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
When loading a workspace we check if there is only one folder added, and if so we focus it. Focusing a folder then kicks off things like package resolution and test discovery.

However, if a package contained sub-packages we treated this as a multi-root workspace and would not focus any. In this situation we actually want to focus the root folder.

If we're in a multi-root workspace then we maintain the old behaviour as its unclear what folder should be focused.

Issue: #1760

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
