### PR TITLE
Add `--pre-release` flag back to preview-package script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,22 @@
 
 ### Added
 
+- Prompt to restart `SourceKit-LSP` after changing `.sourcekit-lsp/config.json` files ([#1744](https://github.com/swiftlang/vscode-swift/issues/1744))
+- Prompt to cancel and replace the active test run if one is in flight ([#1774](https://github.com/swiftlang/vscode-swift/pull/1774))
+- A walkthrough for first time extension users ([#1560](https://github.com/swiftlang/vscode-swift/issues/1560))
+
+## 2.11.20250806 - 2025-08-06
+
+### Added
+
 - New `swift.createTasksForLibraryProducts` setting that when enabled causes the extension to automatically create and provide tasks for library products ([#1741](https://github.com/swiftlang/vscode-swift/pull/1741))
 - New `swift.outputChannelLogLevel` setting to control the verbosity of the `Swift` output channel ([#1746](https://github.com/swiftlang/vscode-swift/pull/1746))
 - New `swift.debugTestsMultipleTimes` and `swift.debugTestsUntilFailure` commands for debugging tests over multiple runs ([#1763](https://github.com/swiftlang/vscode-swift/pull/1763))
 - Optionally include LLDB DAP logs in the Swift diagnostics bundle ([#1768](https://github.com/swiftlang/vscode-swift/pull/1758))
-- Prompt to restart `SourceKit-LSP` after changing `.sourcekit-lsp/config.json` files ([#1744](https://github.com/swiftlang/vscode-swift/issues/1744))
-- Prompt to cancel and replace the active test run if one is in flight ([#1774](https://github.com/swiftlang/vscode-swift/pull/1774))
 
 ### Changed
+
 - Added log levels and improved Swift extension logging so a logfile is produced in addition to logging messages to the existing `Swift` output channel. Deprecated the `swift.diagnostics` setting in favour of the new `swift.outputChannelLogLevel` setting ([#1746](https://github.com/swiftlang/vscode-swift/pull/1746))
-- A walkthrough for first time extension users ([#1560](https://github.com/swiftlang/vscode-swift/issues/1560))
 
 ## 2.10.0 - 2025-07-28
 

--- a/scripts/lib/utilities.ts
+++ b/scripts/lib/utilities.ts
@@ -146,7 +146,11 @@ export async function updateChangelog(version: string): Promise<string> {
     return tempChangelog;
 }
 
-export async function packageExtension(version: string) {
+export interface PackageExtensionOptions {
+    preRelease?: boolean;
+}
+
+export async function packageExtension(version: string, options: PackageExtensionOptions = {}) {
     // Update version in a temporary CHANGELOG
     const changelogPath = await updateChangelog(version);
 
@@ -160,6 +164,7 @@ export async function packageExtension(version: string) {
         [
             "vsce",
             "package",
+            ...(options.preRelease === true ? ["--pre-release"] : []),
             "--allow-package-secrets",
             "sendgrid",
             "--no-update-package-json",

--- a/scripts/preview_package.ts
+++ b/scripts/preview_package.ts
@@ -41,5 +41,5 @@ main(async () => {
                 " The version in the package.json has probably been incorrectly set to an odd minor version."
         );
     }
-    await packageExtension(previewVersion);
+    await packageExtension(previewVersion, { preRelease: true });
 });


### PR DESCRIPTION
Recent changes to the packaging commands accidentally removed the `--pre-release` flag from our invocation of `vsce` for the `preview-package` script. This means that we accidentally released 2.11.20250806 as an official release rather than a pre-release.

This PR adds back the `--pre-release` flag and adds 2.11.20250806 to the `CHANGELOG` as an official release.