### PR TITLE
Remove WorkspaceContext from PackageWatcher/TestExplorer

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -49,7 +49,7 @@ export class FolderContext implements vscode.Disposable {
         public workspaceFolder: vscode.WorkspaceFolder,
         public workspaceContext: WorkspaceContext
     ) {
-        this.packageWatcher = new PackageWatcher(this, workspaceContext);
+        this.packageWatcher = new PackageWatcher(this, workspaceContext.logger);
         this.backgroundCompilation = new BackgroundCompilation(this);
         this.taskQueue = new TaskQueue(this);
         this.testRunManager = new TestRunManager();
@@ -112,6 +112,10 @@ export class FolderContext implements vscode.Disposable {
         return folderContext;
     }
 
+    get languageClientManager() {
+        return this.workspaceContext.languageClientManager.get(this);
+    }
+
     get name(): string {
         const relativePath = this.relativePath;
         if (relativePath.length === 0) {
@@ -169,7 +173,12 @@ export class FolderContext implements vscode.Disposable {
     /** Create Test explorer for this folder */
     addTestExplorer() {
         if (this.testExplorer === undefined) {
-            this.testExplorer = new TestExplorer(this);
+            this.testExplorer = new TestExplorer(
+                this,
+                this.workspaceContext.tasks,
+                this.workspaceContext.logger,
+                this.workspaceContext.onDidChangeSwiftFiles
+            );
         }
         return this.testExplorer;
     }

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -443,3 +443,16 @@ export function destructuredPromise<T>(): {
     return { promise: p, resolve: resolve!, reject: reject! };
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+/**
+ * Creates a composite disposable from multiple disposables.
+ * @param disposables The disposables to include.
+ * @returns A composite disposable that disposes all included disposables.
+ */
+export function compositeDisposable(...disposables: vscode.Disposable[]): vscode.Disposable {
+    return {
+        dispose: () => {
+            disposables.forEach(d => d.dispose());
+        },
+    };
+}


### PR DESCRIPTION
## Description
Pass the required dependencies to PackageWatcher and TestExplorer instead of having them pull from `folderContext.workspaceContext`.

This is more refactoring to move towards removing the reference to `WorkspaceContext` in `FolderContext`.

## Tasks
- ~[X] Required tests have been written~
- ~[X] Documentation has been updated~
- ~[X] Added an entry to CHANGELOG.md if applicable~
