### PR TITLE
Mark pending tests as skipped on test run cancel

### DIFF
--- a/src/TestExplorer/TestRunManager.ts
+++ b/src/TestExplorer/TestRunManager.ts
@@ -54,6 +54,7 @@ export class TestRunManager {
         const key = this.getTestRunKey(folder);
         const activeRun = this.activeTestRuns.get(key);
         if (activeRun) {
+            activeRun.testRun.skipPendingTests();
             activeRun.tokenSource.cancel();
         }
     }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -309,6 +309,18 @@ export class TestRunProxy {
         this.testRun?.errored(test, message, this.recordDuration ? duration : undefined);
     }
 
+    /**
+     * Skip any pending tests.
+     * Call this method when a test run is cancelled to mark the pending tests as skipped.
+     * Otherwise, pending tests will be marked as failing as we assume they crashed.
+     */
+    public skipPendingTests() {
+        this.runState.pending.forEach(test => {
+            this.skipped(test);
+        });
+        this.runState.pending = [];
+    }
+
     public async end() {
         // If the test run never started (typically due to a build error)
         // start it to flush any queued output, and then immediately end it.


### PR DESCRIPTION

## Description
When cancelling an in progress test run, mark the tests that were in flight at the time of cancellation as skipped instead of failed.

## Tasks
- [X] ~Required tests have been written~
- [X] Documentation has been updated
- [X] ~Added an entry to CHANGELOG.md if applicable~
