### PR TITLE
Provide single argument example

### DIFF
--- a/package.json
+++ b/package.json
@@ -829,7 +829,7 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `[\"--experimental-feature\", \"show-macro-expansions\"]`",
+            "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `--experimental-feature=show-macro-expansions`",
             "order": 2
           },
           "swift.sourcekit-lsp.supported-languages": {
@@ -919,7 +919,7 @@
             "items": {
               "type": "string"
             },
-            "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `[\"--experimental-feature\", \"show-macro-expansions\"]`",
+            "markdownDescription": "Arguments to pass to SourceKit-LSP. Keys and values should be provided as individual entries in the list. e.g. `--experimental-feature=show-macro-expansions`",
             "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.serverArguments#` instead."
           },
           "sourcekit-lsp.trace.server": {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Provide a single argument as an example, instead of array to avoid confusion

Issue: #1775

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
