### PR TITLE
Add new commands for walkthrough

### DIFF
--- a/assets/walkthrough/previewDocs.md
+++ b/assets/walkthrough/previewDocs.md
@@ -1,6 +1,6 @@
 # Preview Documentation
 ![Preview documentation](./images/previewDocumentation.gif)
 
-You can preview [documentation written using DocC](https://www.swift.org/documentation/docc/) directly in VS Code by using the Preview Swift Documentation button at the top right of an editor, or by invoking `Swift: Preview Documentation` in the command palette in a `.docc` bundle.
+You can preview [documentation written using DocC](https://www.swift.org/documentation/docc/) directly in VS Code by using the Preview Swift Documentation button at the top right of an editor, or by invoking `Swift: Preview Documentation` in the command palette in a `.docc` bundle. The preview window will update as you open different Markdown files or Swift source files that contains documentation comments.
 
 Note: This feature requires Swift 6.2 or later.

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
           {
             "id": "documentation",
             "title": "Preview DocC documentation",
-            "description": "Preview documentation written in DocC.",
+            "description": "Preview documentation written in [DocC](https://www.swift.org/documentation/docc/).",
             "media": {
               "markdown": "assets/walkthrough/previewDocs.md"
             }
@@ -102,7 +102,7 @@
           {
             "id": "swift-commands",
             "title": "Swift commands",
-            "description": "Explore commands available in the Command Palette prefixed with ``> Swift:``\n See documentation for [available commands](https://docs.swift.org/vscode/documentation/userdocs/commands/). \n[Open Command Palette](command:workbench.action.showCommands)",
+            "description": "Explore commands available in the Command Palette prefixed with ``> Swift:``\n See documentation for [available commands](https://docs.swift.org/vscode/documentation/userdocs/commands/). \n[Show Swift Commands](command:swift.showCommands)",
             "media": {
               "markdown": "assets/walkthrough/swiftCommands.md"
             }
@@ -119,7 +119,7 @@
           {
             "id": "customize",
             "title": "Customize settings",
-            "description": "Customize language and extension settings. \n[Open Settings](command:workbench.action.openSettings)",
+            "description": "The Swift extensions contributes numerous settings that you can configure to customize how your project builds and how the extension operates.\n[Configure Swift Settings](command:swift.configureSettings)",
             "media": {
               "markdown": "assets/walkthrough/customizeSettings.md"
             }
@@ -194,6 +194,16 @@
       }
     ],
     "commands": [
+      {
+        "command": "swift.showCommands",
+        "title": "Show Commands",
+        "category": "Swift"
+      },
+      {
+        "command": "swift.configureSettings",
+        "title": "Configure Settings",
+        "category": "Swift"
+      },
       {
         "command": "swift.generateLaunchConfigurations",
         "title": "Generate Launch Configurations",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -335,6 +335,19 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
             Commands.GENERATE_SOURCEKIT_CONFIG,
             async () => await generateSourcekitConfiguration(ctx)
         ),
+        vscode.commands.registerCommand(
+            "swift.showCommands",
+            async () =>
+                await vscode.commands.executeCommand("workbench.action.quickOpen", ">Swift: ")
+        ),
+        vscode.commands.registerCommand(
+            "swift.configureSettings",
+            async () =>
+                await vscode.commands.executeCommand(
+                    "workbench.action.openSettings",
+                    "@ext:swiftlang.swift-vscode "
+                )
+        ),
     ];
 }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Add new commands to show the available Swift extension commands and settings so the walkthrough button can be more targeted 

Issue: #1560

## Tasks
- [X] ~Required tests have been written~
- [X] Documentation has been updated
- [X] Added an entry to CHANGELOG.md if applicable
