### PR TITLE
Don't debug further tests when stopping the debug session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Prompt to cancel and replace the active test run if one is in flight ([#1774](https://github.com/swiftlang/vscode-swift/pull/1774))
 - A walkthrough for first time extension users ([#1560](https://github.com/swiftlang/vscode-swift/issues/1560))
 
+### Fixed
+
+- Don't start debugging XCTest cases if the swift-testing debug session was stopped ([#1797](https://github.com/swiftlang/vscode-swift/pull/1797))
+
 ## 2.11.20250806 - 2025-08-06
 
 ### Added

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -700,6 +700,10 @@ export class TestRunner {
             compositeToken.token
         );
 
+        // If the user terminates a debugging session for swift-testing
+        // we want to prevent XCTest from starting.
+        const terminationListener = runner.onDebugSessionTerminated(() => compositeToken.cancel());
+
         // Register the test run with the manager
         folderContext.registerTestRun(runner.testRun, compositeToken);
 
@@ -708,6 +712,8 @@ export class TestRunner {
 
         // Run the tests
         await runner.runHandler();
+
+        terminationListener.dispose();
 
         // Run the post-run handler if provided
         if (postRunHandler) {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Similar to #1790, if your debugging all tests in a project with a mix of XCTest and swift-testing suites, if the user stops a debug session for the swift-testing tests, then the XCTest debug session should not then startup

Issue: #1002

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
