### PR TITLE
Trigger parameter hints on accepting a function-like completion item

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -525,6 +525,16 @@ const configuration = {
     get outputChannelLogLevel(): string {
         return vscode.workspace.getConfiguration("swift").get("outputChannelLogLevel", "info");
     },
+    parameterHintsEnabled(documentUri: vscode.Uri): boolean {
+        const enabled = vscode.workspace
+            .getConfiguration("editor.parameterHints", {
+                uri: documentUri,
+                languageId: "swift",
+            })
+            .get<boolean>("enabled");
+
+        return enabled === true;
+    },
 };
 
 const vsCodeVariableRegex = new RegExp(/\$\{(.+?)\}/g);


### PR DESCRIPTION
## Description

We're working on implementing signature help in SourceKit-LSP (https://github.com/swiftlang/sourcekit-lsp/pull/2250) and we faced a problem in VS Code where signature help wasn't triggered after accepting a completion item for a function, method, subscript, initializer, or enum case with associated values that would've normally had signature help if the user manually typed the `(` after the signature name.

Here's a demo of the issue with a development version of SourceKit-LSP:

https://github.com/user-attachments/assets/d44f2a95-ca78-40e7-a44f-b5a09ec61d58

To fix this, we added a `provideCompletionItem` middleware that inspects completion items that might have signature help (functions, methods (includes subscripts), initializers, and enum cases) and injects an `editor.action.triggerParameterHints` command (if no other command was present). This results in signature help working pretty well with completion as shown in the video below.

https://github.com/user-attachments/assets/81901cf8-f37d-49be-a2a8-b7f5b8480097

## Tasks
- [x] Required tests have been written
- [x] Documentation has been updated (N/A)
- [x] Added an entry to CHANGELOG.md if applicable