### PR TITLE
Set env var to preserve test case encoding w/ swift testing

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -340,7 +340,7 @@ export class TestingConfigurationFactory {
                             DYLD_FRAMEWORK_PATH: frameworkPath,
                             DYLD_LIBRARY_PATH: libraryPath,
                             SWT_SF_SYMBOLS_ENABLED: "0",
-                            SWT_ENABLE_EXPERIMENTAL_EVENT_STREAM_TEST_CASE_ENCODING: "1",
+                            SWT_EXPERIMENTAL_EVENT_STREAM_FIELDS_ENABLED: "1",
                         };
 
                         // Toolchains that contain https://github.com/swiftlang/swift-package-manager/commit/844bd137070dcd18d0f46dd95885ef7907ea0697
@@ -394,7 +394,7 @@ export class TestingConfigurationFactory {
                                 ...this.testEnv,
                                 ...this.sanitizerRuntimeEnvironment,
                                 SWT_SF_SYMBOLS_ENABLED: "0",
-                                SWT_ENABLE_EXPERIMENTAL_EVENT_STREAM_TEST_CASE_ENCODING: "1",
+                                SWT_EXPERIMENTAL_EVENT_STREAM_FIELDS_ENABLED: "1",
                             },
                             // For coverage we need to rebuild so do the build/test all in one step,
                             // otherwise we do a build, then test, to give better progress.


### PR DESCRIPTION
Description
https://github.com/swiftlang/swift-testing/pull/1287 gates the `_testCase` field behind the experimental version number check, which will be tied to the swift version of the client, supplied by vs code.

Set the `SWT_ENABLE_EXPERIMENTAL_EVENT_STREAM_TEST_CASE_ENCODING` flag to allow any version of swift-testing to continue to work with the extension.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
