### PR TITLE
Add support for selecting Swift snapshot branch for toolchain installation

### DIFF
--- a/src/commands/installSwiftlyToolchain.ts
+++ b/src/commands/installSwiftlyToolchain.ts
@@ -162,7 +162,19 @@ export async function installSwiftlySnapshotToolchain(ctx: WorkspaceContext): Pr
         return;
     }
 
-    const availableToolchains = await Swiftly.listAvailable(ctx.logger);
+    // Prompt user to enter the branch for snapshot toolchains
+    const branch = await vscode.window.showInputBox({
+        title: "Enter Swift Snapshot Branch",
+        prompt: "Enter the branch name to list snapshot toolchains (e.g., 'main-snapshot', '6.1-snapshot')",
+        placeHolder: "main-snapshot",
+        value: "main-snapshot",
+    });
+
+    if (!branch) {
+        return; // User cancelled input
+    }
+
+    const availableToolchains = await Swiftly.listAvailable(ctx.logger, branch);
 
     if (availableToolchains.length === 0) {
         ctx.logger?.debug("No toolchains available for installation via Swiftly.");

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -67,8 +67,8 @@ const StableVersion = z.object({
 export type StableVersion = z.infer<typeof StableVersion>;
 
 const SnapshotVersion = z.object({
-    major: z.number(),
-    minor: z.number(),
+    major: z.union([z.number(), z.undefined()]),
+    minor: z.union([z.number(), z.undefined()]),
     branch: z.string(),
     date: z.string(),
     name: z.string(),

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -353,6 +353,75 @@ suite("Swiftly Unit Tests", () => {
             const result = await Swiftly.listAvailable();
             expect(result).to.deep.equal([]);
         });
+
+        test("should handle snapshot toolchains without major/minor fields", async () => {
+            mockedPlatform.setValue("darwin");
+
+            mockUtilities.execFile.withArgs("swiftly", ["--version"]).resolves({
+                stdout: "1.1.0\n",
+                stderr: "",
+            });
+
+            const snapshotResponse = {
+                toolchains: [
+                    {
+                        inUse: false,
+                        installed: false,
+                        isDefault: false,
+                        version: {
+                            type: "snapshot",
+                            branch: "main",
+                            date: "2025-08-26",
+                            name: "main-snapshot-2025-08-26",
+                        },
+                    },
+                    {
+                        inUse: false,
+                        installed: true,
+                        isDefault: false,
+                        version: {
+                            type: "snapshot",
+                            branch: "main",
+                            date: "2025-08-25",
+                            name: "main-snapshot-2025-08-25",
+                        },
+                    },
+                ],
+            };
+
+            mockUtilities.execFile
+                .withArgs("swiftly", ["list-available", "--format=json", "main-snapshot"])
+                .resolves({
+                    stdout: JSON.stringify(snapshotResponse),
+                    stderr: "",
+                });
+
+            const result = await Swiftly.listAvailable(undefined, "main-snapshot");
+            expect(result).to.deep.equal([
+                {
+                    inUse: false,
+                    installed: false,
+                    isDefault: false,
+                    version: {
+                        type: "snapshot",
+                        branch: "main",
+                        date: "2025-08-26",
+                        name: "main-snapshot-2025-08-26",
+                    },
+                },
+                {
+                    inUse: false,
+                    installed: true,
+                    isDefault: false,
+                    version: {
+                        type: "snapshot",
+                        branch: "main",
+                        date: "2025-08-25",
+                        name: "main-snapshot-2025-08-25",
+                    },
+                },
+            ]);
+        });
     });
 
     suite("Post-Install", () => {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Add the branch parameter functionality (main-snapshot) for installing swiftly toolchains snapshot from quickPick

Issue: 1778
Reference: https://github.com/swiftlang/vscode-swift/pull/1780#discussion_r2304450969
## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
