### PR TITLE
Log the current Swift extension version on activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
             "swift-vscode-extension.log"
         );
         context.subscriptions.push(logger);
-        logger.info("Activating Swift for Visual Studio Code...");
+        logger.info(
+            `Activating Swift for Visual Studio Code ${context.extension.packageJSON.version}...`
+        );
 
         checkAndWarnAboutWindowsSymlinks(logger);
 


### PR DESCRIPTION
## Description

I noticed we don't actually print the current extension version anywhere in the logs, making the Capture Diagnostics command less useful.

Print the version of the extension the user is running in the log line printed during extension activation.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
