### PR TITLE
Support swift-testing issue severity

### DIFF
--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -155,6 +155,8 @@ interface IssueRecorded extends BaseEvent, TestCaseEvent {
     issue: {
         isKnown: boolean;
         sourceLocation: SourceLocation;
+        isFailure?: boolean;
+        severity?: string;
     };
 }
 
@@ -162,6 +164,7 @@ export enum TestSymbol {
     default = "default",
     skip = "skip",
     passWithKnownIssue = "passWithKnownIssue",
+    passWithWarnings = "passWithWarnings",
     fail = "fail",
     pass = "pass",
     difference = "difference",
@@ -377,6 +380,10 @@ export class SwiftTestingOutputParser {
         const additionalDetails = details
             .map(message => MessageRenderer.render(message))
             .join("\n");
+
+        if (payload.issue.isFailure === false) {
+            return;
+        }
 
         issues.forEach(message => {
             runState.recordIssue(
@@ -601,6 +608,7 @@ export class SymbolRenderer {
                     return "\u{25CA}"; // Unicode: LOZENGE
                 case TestSymbol.skip:
                 case TestSymbol.passWithKnownIssue:
+                case TestSymbol.passWithWarnings:
                 case TestSymbol.fail:
                     return "\u{279C}"; // Unicode: HEAVY ROUND-TIPPED RIGHTWARDS ARROW
                 case TestSymbol.pass:
@@ -622,6 +630,7 @@ export class SymbolRenderer {
                     return "\u{25C7}"; // Unicode: WHITE DIAMOND
                 case TestSymbol.skip:
                 case TestSymbol.passWithKnownIssue:
+                case TestSymbol.passWithWarnings:
                 case TestSymbol.fail:
                     return "\u{279C}"; // Unicode: HEAVY ROUND-TIPPED RIGHTWARDS ARROW
                 case TestSymbol.pass:

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -541,11 +541,17 @@ export class TestingConfigurationFactory {
             );
         }
 
+        // Starting in 6.3 the version string should match the toolchain version.
+        let versionString = "0";
+        if (this.ctx.toolchain.swiftVersion.isGreaterThanOrEqual(new Version(6, 3, 0))) {
+            versionString = `${this.ctx.toolchain.swiftVersion.major}.${this.ctx.toolchain.swiftVersion.minor}`;
+        }
+
         const swiftTestingArgs = [
             ...this.ctx.toolchain.buildFlags.withAdditionalFlags(args),
             "--enable-swift-testing",
-            "--event-stream-version",
-            "0",
+            "--experimental-event-stream-version",
+            versionString,
             "--event-stream-output-path",
             this.swiftTestingArguments.fifoPipePath,
         ];


### PR DESCRIPTION
## Description
Add support for swift-testing issue severity, added in https://github.com/swiftlang/swift-testing/pull/1279

If an issue is recorded with a severity that does not meet the threshold for a failure then don't record the issue.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
