### PR TITLE
Add Invoke-Program to Windows pull request CI runs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -68,7 +68,7 @@ jobs:
         VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}
         GITHUB_REPOSITORY=${{github.repository}}
       windows_pre_build_command: . .github\workflows\scripts\windows\setup.ps1
-      windows_build_command: scripts\test_windows.ps1
+      windows_build_command: Invoke-Program scripts\test_windows.ps1
       enable_windows_docker: false
 
   soundness:


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description

Windows PR checks were not correctly receiving the exit code from the build script. #1800 had fixed our nightly runs, but missed adding the same to pull_request.yml.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
