### PR TITLE
Inject logger directly into FolderContext

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -55,7 +55,8 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
         public linuxMain: LinuxMain,
         public swiftPackage: SwiftPackage,
         public workspaceFolder: vscode.WorkspaceFolder,
-        public workspaceContext: WorkspaceContext
+        public workspaceContext: WorkspaceContext,
+        public logger: SwiftLogger
     ) {
         this.packageWatcher = new PackageWatcher(this, workspaceContext.logger);
         this.backgroundCompilation = new BackgroundCompilation(this);
@@ -151,7 +152,8 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
             linuxMain,
             swiftPackage,
             workspaceFolder,
-            workspaceContext
+            workspaceContext,
+            workspaceContext.logger
         );
 
         // List the package's dependencies without blocking folder creation
@@ -164,7 +166,7 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
                     void vscode.window.showErrorMessage(
                         `Failed to load ${folderContext.name}/Package.swift: ${error.message}`
                     );
-                    workspaceContext.logger.info(
+                    folderContext.logger.info(
                         `Failed to load Package.swift: ${error.message}`,
                         folderContext.name
                     );
@@ -245,7 +247,7 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
             this.testExplorer = new TestExplorer(
                 this,
                 this.workspaceContext.tasks,
-                this.workspaceContext.logger,
+                this.logger,
                 this.workspaceContext.onDidChangeSwiftFiles.bind(this.workspaceContext)
             );
             this.testExplorerResolver?.(this.testExplorer);

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -387,7 +387,7 @@ export class LanguageClientManager implements vscode.Disposable {
                             );
                         }
                     }
-                    this.folderContext.workspaceContext.logger.error(reason);
+                    this.folderContext.logger.error(reason);
                 });
             await this.restartedPromise;
         }
@@ -524,13 +524,13 @@ export class LanguageClientManager implements vscode.Disposable {
             });
         });
         if (client.clientOptions.workspaceFolder) {
-            this.folderContext.workspaceContext.logger.info(
+            this.folderContext.logger.info(
                 `SourceKit-LSP setup for ${FolderContext.uriName(
                     client.clientOptions.workspaceFolder.uri
                 )}`
             );
         } else {
-            this.folderContext.workspaceContext.logger.info(`SourceKit-LSP setup`);
+            this.folderContext.logger.info(`SourceKit-LSP setup`);
         }
 
         client.onNotification(SourceKitLogMessageNotification.type, params => {
@@ -567,7 +567,7 @@ export class LanguageClientManager implements vscode.Disposable {
                     // do nothing, the experimental capability is not supported
                 }
             } catch (reason) {
-                this.folderContext.workspaceContext.logger.error(
+                this.folderContext.logger.error(
                     `Error starting SourceKit-LSP in startClient: ${reason}`
                 );
                 if (this.languageClient?.state === State.Running) {

--- a/test/integration-tests/FolderContext.test.ts
+++ b/test/integration-tests/FolderContext.test.ts
@@ -63,7 +63,7 @@ suite("FolderContext Error Handling Test Suite", () => {
             "Should fallback to global toolchain when user dismisses dialog"
         );
 
-        const errorLogs = workspaceContext.logger.logs.filter(
+        const errorLogs = folderContext.logger.logs.filter(
             log =>
                 log.includes("Failed to discover Swift toolchain") &&
                 log.includes("package2") &&
@@ -118,10 +118,10 @@ suite("FolderContext Error Handling Test Suite", () => {
         );
 
         // Assert: Should log both failure and success
-        const failureLogs = workspaceContext.logger.logs.filter(log =>
+        const failureLogs = folderContext.logger.logs.filter(log =>
             log.includes("Failed to discover Swift toolchain for package2")
         );
-        const successLogs = workspaceContext.logger.logs.filter(log =>
+        const successLogs = folderContext.logger.logs.filter(log =>
             log.includes("Successfully created toolchain for package2 after user selection")
         );
 
@@ -161,12 +161,12 @@ suite("FolderContext Error Handling Test Suite", () => {
             "Should retry toolchain creation after user selection"
         );
 
-        const initialFailureLogs = workspaceContext.logger.logs.filter(log =>
+        const initialFailureLogs = folderContext.logger.logs.filter(log =>
             log.includes(
                 "Failed to discover Swift toolchain for package2: Error: Initial toolchain failure"
             )
         );
-        const retryFailureLogs = workspaceContext.logger.logs.filter(log =>
+        const retryFailureLogs = folderContext.logger.logs.filter(log =>
             log.includes(
                 "Failed to create toolchain for package2 even after user selection: Error: Retry toolchain failure"
             )

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -140,6 +140,7 @@ suite("LanguageClientManager Suite", () => {
             ),
             swiftVersion: new Version(6, 0, 0),
             toolchain: instance(mockedToolchain),
+            logger: instance(mockLogger),
         });
         mockedWorkspace = mockObject<WorkspaceContext>({
             globalToolchain: instance(mockedToolchain),
@@ -252,6 +253,8 @@ suite("LanguageClientManager Suite", () => {
                 },
                 workspaceContext: instance(mockedWorkspace),
                 swiftVersion: mockedFolder.swiftVersion,
+                toolchain: instance(mockedToolchain),
+                logger: instance(mockLogger),
             });
             mockedWorkspace.folders.push(instance(newFolder));
             const factory = new LanguageClientToolchainCoordinator(
@@ -268,6 +271,14 @@ suite("LanguageClientManager Suite", () => {
         });
 
         test("returns the a new language client for folders with different toolchains", async () => {
+            const differentToolchain = mockObject<SwiftToolchain>({
+                swiftVersion: new Version(6, 1, 0),
+                buildFlags: mockedBuildFlags as unknown as BuildFlags,
+                getToolchainExecutable: mockFn(s =>
+                    s.withArgs("sourcekit-lsp").returns("/path/to/toolchain/bin/sourcekit-lsp")
+                ),
+            });
+
             const newFolder = mockObject<FolderContext>({
                 isRootFolder: false,
                 folder: vscode.Uri.file("/folder11"),
@@ -278,6 +289,8 @@ suite("LanguageClientManager Suite", () => {
                 },
                 workspaceContext: instance(mockedWorkspace),
                 swiftVersion: new Version(6, 1, 0),
+                toolchain: instance(differentToolchain),
+                logger: instance(mockLogger),
             });
             mockedWorkspace.folders.push(instance(newFolder));
             const factory = new LanguageClientToolchainCoordinator(
@@ -290,7 +303,7 @@ suite("LanguageClientManager Suite", () => {
             const sut2 = factory.get(instance(newFolder));
 
             expect(sut1).to.not.equal(sut2, "Expected different LanguageClients to be returned");
-            expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnce;
+            expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledTwice;
         });
     });
 
@@ -412,6 +425,8 @@ suite("LanguageClientManager Suite", () => {
             },
             workspaceContext: instance(mockedWorkspace),
             swiftVersion: new Version(6, 0, 0),
+            toolchain: instance(mockedToolchain),
+            logger: instance(mockLogger),
         });
         const folder2 = mockObject<FolderContext>({
             isRootFolder: false,
@@ -423,6 +438,8 @@ suite("LanguageClientManager Suite", () => {
             },
             workspaceContext: instance(mockedWorkspace),
             swiftVersion: new Version(6, 0, 0),
+            toolchain: instance(mockedToolchain),
+            logger: instance(mockLogger),
         });
 
         new LanguageClientToolchainCoordinator(
@@ -914,6 +931,7 @@ suite("LanguageClientManager Suite", () => {
                 workspaceContext: instance(mockedWorkspace),
                 workspaceFolder,
                 toolchain: instance(mockedToolchain),
+                logger: instance(mockLogger),
             });
             mockedFolder.swiftVersion = mockedToolchain.swiftVersion;
             mockedWorkspace = mockObject<WorkspaceContext>({
@@ -932,6 +950,7 @@ suite("LanguageClientManager Suite", () => {
                 workspaceContext: instance(mockedWorkspace),
                 toolchain: instance(mockedToolchain),
                 swiftVersion: mockedToolchain.swiftVersion,
+                logger: instance(mockLogger),
             });
             folder2 = mockObject<FolderContext>({
                 isRootFolder: false,
@@ -944,6 +963,7 @@ suite("LanguageClientManager Suite", () => {
                 workspaceContext: instance(mockedWorkspace),
                 toolchain: instance(mockedToolchain),
                 swiftVersion: mockedToolchain.swiftVersion,
+                logger: instance(mockLogger),
             });
         });
 


### PR DESCRIPTION
## Description
This change moves toward decoupling FolderContext from WorkspaceContext by making logger dependency explicit rather than accessed through context chain. Part of broader effort to remove FolderContext dependency on WorkspaceContext.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
