### PR TITLE
Mock settings writes in ToolchainSelection tests

### DIFF
--- a/test/unit-tests/ui/ToolchainSelection.test.ts
+++ b/test/unit-tests/ui/ToolchainSelection.test.ts
@@ -32,6 +32,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
     const mockedVSCodeWindow = mockGlobalObject(vscode, "window");
     const mockedVSCodeCommands = mockGlobalObject(vscode, "commands");
     const mockedVSCodeEnv = mockGlobalObject(vscode, "env");
+    const mockedVSCodeWorkspace = mockGlobalObject(vscode, "workspace");
     let mockLogger: SwiftLogger;
 
     setup(() => {
@@ -56,6 +57,15 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
         mockedVSCodeCommands.executeCommand.resolves(undefined);
         mockedVSCodeEnv.openExternal.resolves(true);
+
+        // Mock workspace configuration to prevent actual settings writes
+        const mockConfiguration = {
+            update: stub().resolves(),
+            inspect: stub().returns({}),
+            get: stub().returns(undefined),
+            has: stub().returns(false),
+        };
+        mockedVSCodeWorkspace.getConfiguration.returns(mockConfiguration);
 
         // Mock SwiftToolchain static methods
         stub(SwiftToolchain, "findXcodeInstalls").resolves([]);


### PR DESCRIPTION
## Description
The `should show open dialog for folder selection` test would write the selected toolchain value into settings. This would break the integration tests if you ran them after the unit tests because the location of `swift` would be incorrect.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
