### PR TITLE
Ignore .husky in soundness script

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -102,6 +102,7 @@ EOF
             \( \! -path './dist/*' -a \
             \( \! -path './assets/*' -a \
             \( \! -path './coverage/*' -a \
+            \( \! -path './.husky/*' -a \
             \( "${matching_files[@]}" \) \
             \) \) \) \) \) \) \)
     } | while read -r line; do


### PR DESCRIPTION
## Description
If you run the soundness script after installing dependencies the .husky folder is included, which contains auto generated and .gitignored code we shouldn't check for soundness.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
