### PR TITLE
Fix withKnownIssue not marking test as skipped in nightly toolchains

### DIFF
--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -381,7 +381,7 @@ export class SwiftTestingOutputParser {
             .map(message => MessageRenderer.render(message))
             .join("\n");
 
-        if (payload.issue.isFailure === false) {
+        if (payload.issue.isFailure === false && !payload.issue.isKnown) {
             return;
         }
 


### PR DESCRIPTION
## Description
With the introduction of issue severity, the issue payload contains the flag `isFailure`. If this is false, we were assuming that the issue didn't meet the severity threshold.

However if an issue is skipped with `withKnownIssue`, `isFailure` would be false but `isKnown` is true. In this case we still want to record the issue and have the test be marked as skipped.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
