### PR TITLE
Support system toolchains from Swiftly

### DIFF
--- a/src/commands/installSwiftlyToolchain.ts
+++ b/src/commands/installSwiftlyToolchain.ts
@@ -16,16 +16,16 @@ import { QuickPickItem } from "vscode";
 
 import { WorkspaceContext } from "../WorkspaceContext";
 import {
-    AvailableToolchain,
     Swiftly,
     SwiftlyProgressData,
+    SwiftlyToolchain,
     isSnapshotVersion,
     isStableVersion,
 } from "../toolchain/swiftly";
 import { showReloadExtensionNotification } from "../ui/ReloadExtension";
 
 interface SwiftlyToolchainItem extends QuickPickItem {
-    toolchain: AvailableToolchain;
+    toolchain: SwiftlyToolchain;
 }
 
 async function downloadAndInstallToolchain(selected: SwiftlyToolchainItem, ctx: WorkspaceContext) {
@@ -225,7 +225,7 @@ export async function installSwiftlySnapshotToolchain(ctx: WorkspaceContext): Pr
 /**
  * Sorts toolchains by version with most recent first
  */
-function sortToolchainsByVersion(toolchains: AvailableToolchain[]): AvailableToolchain[] {
+function sortToolchainsByVersion(toolchains: SwiftlyToolchain[]): SwiftlyToolchain[] {
     return toolchains.sort((a, b) => {
         // First sort by type (stable before snapshot)
         if (a.version.type !== b.version.type) {


### PR DESCRIPTION
## Description
Swiftly `1.1.0-dev` adds the concept of a `system` toolchain. This broke the parsing logic for `swiftly list --format=json` causing Swiftly toolchains to no longer appear during toolchain selection.

I've also added tests to make it less likely for us to break on these kinds of Swiftly changes in the future.

Issue: #1845

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~

This part of Swiftly support has not been released yet. So, no changelog update is needed.
