### PR TITLE
Prompt to automatically install missing toolchain

### DIFF
--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -100,6 +100,25 @@ export async function showToolchainError(folder?: vscode.Uri): Promise<boolean> 
     return false;
 }
 
+/**
+ * Shows a dialog asking user permission to install a missing Swiftly toolchain
+ * @param version The toolchain version to install
+ * @param folder Optional folder context for the error
+ * @returns Promise<boolean> true if user agrees to install, false otherwise
+ */
+export async function showMissingToolchainDialog(
+    version: string,
+    folder?: vscode.Uri
+): Promise<boolean> {
+    const folderName = folder ? `${FolderContext.uriName(folder)}: ` : "";
+    const message =
+        `${folderName}Swift version ${version} is required but not installed. ` +
+        `Would you like to automatically install it using Swiftly?`;
+
+    const choice = await vscode.window.showWarningMessage(message, "Install Toolchain", "Cancel");
+    return choice === "Install Toolchain";
+}
+
 export async function selectToolchain() {
     await vscode.commands.executeCommand(Commands.SELECT_TOOLCHAIN);
 }


### PR DESCRIPTION
## Description
If a .swift-version exists in a project that specifies a toolchain the user doesn't have installed, prompt them to install it on extension launch.

If they cancel the dialog, fall back to using whatever toolchain is already installed, basically ignoring the .swift-version for this activation or until the .swift-version is changed again.

Issue: #1852

## Tasks
- [X] Required tests have been written
- [X] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
