### PR TITLE
Adjust timeouts to resolve Windows test failures

### DIFF
--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -112,7 +112,7 @@ suite("SwiftTaskProvider Test Suite", () => {
                 expect(task?.detail).to.include("swift build --build-tests");
             });
 
-            tag("large").test("executes", async () => {
+            tag("medium").test("executes", async () => {
                 const task = await getBuildAllTask();
                 assert(task);
                 const exitPromise = waitForEndTaskProcess(task);
@@ -138,7 +138,7 @@ suite("SwiftTaskProvider Test Suite", () => {
                 expect(task?.detail).to.include("swift build --show-bin-path");
             });
 
-            test("executes", async () => {
+            tag("medium").test("executes", async () => {
                 const task = await getBuildAllTask();
                 assert(task);
                 const exitPromise = waitForEndTaskProcess(task);

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -68,7 +68,7 @@ const extensionBootstrapper = (() => {
         let restoreSettings: (() => Promise<void>) | undefined;
         before("Activate Swift Extension", async function () {
             // Allow enough time for the extension to activate
-            this.timeout(120_000);
+            this.timeout(180_000);
 
             // Make sure that CodeLLDB is installed for debugging related tests
             if (!vscode.extensions.getExtension("vadimcn.vscode-lldb")) {


### PR DESCRIPTION
## Description
Some tests that run the build all command are timing out during setup on Windows (and more specifically Swift 6.0). Adjusted the timeout to 3 minutes to give them plenty of time to finish.

Tagged a couple of the SwiftTaskProvider tests as `"medium"` as well since they failed a couple times on the 2 second timeouot.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
