### PR TITLE
Allow setting the Swiftly toolchain at the workspace level

### DIFF
--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -270,9 +270,9 @@ export class Swiftly {
             if (!Array.isArray(installedToolchains)) {
                 return [];
             }
-            return installedToolchains
-                .filter((toolchain): toolchain is string => typeof toolchain === "string")
-                .map(toolchain => path.join(swiftlyHomeDir, "toolchains", toolchain));
+            return installedToolchains.filter(
+                (toolchain): toolchain is string => typeof toolchain === "string"
+            );
         } catch (error) {
             logger?.error(`Failed to retrieve Swiftly installations: ${error}`);
             throw new Error(

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -103,14 +103,14 @@ suite("Swiftly Unit Tests", () => {
     });
 
     suite("list()", () => {
-        test("should return toolchain names from list-available command for version 1.1.0", async () => {
+        test("should return toolchain names from list command for version 1.1.0", async () => {
             // Mock version check to return 1.1.0
             mockUtilities.execFile.withArgs("swiftly", ["--version"]).resolves({
                 stdout: "1.1.0\n",
                 stderr: "",
             });
 
-            // Mock list-available command with JSON output
+            // Mock list command with JSON output
             const jsonOutput = {
                 toolchains: [
                     {
@@ -270,6 +270,26 @@ suite("Swiftly Unit Tests", () => {
                 "list",
                 "--format=json",
             ]);
+        });
+
+        test("should return toolchain names from the configuration file for version 1.0.1", async () => {
+            // Mock version check to return 1.0.1
+            mockUtilities.execFile.withArgs("swiftly", ["--version"]).resolves({
+                stdout: "1.0.1\n",
+                stderr: "",
+            });
+
+            // Swiftly home directory contains a config.json
+            mockedEnv.setValue({ SWIFTLY_HOME_DIR: "/home/.swiftly" });
+            mockFS({
+                "/home/.swiftly/config.json": JSON.stringify({
+                    installedToolchains: ["swift-5.9.0", "swift-6.0.0"],
+                }),
+            });
+
+            const result = await Swiftly.list();
+
+            expect(result).to.deep.equal(["swift-5.9.0", "swift-6.0.0"]);
         });
 
         test("should return empty array when platform is not supported", async () => {

--- a/test/unit-tests/toolchain/toolchain.test.ts
+++ b/test/unit-tests/toolchain/toolchain.test.ts
@@ -15,7 +15,6 @@ import { expect } from "chai";
 import * as mockFS from "mock-fs";
 import * as path from "path";
 
-import { Swiftly } from "@src/toolchain/swiftly";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
 import * as utilities from "@src/utilities/utilities";
 import { Version } from "@src/utilities/version";
@@ -297,108 +296,6 @@ suite("SwiftToolchain Unit Test Suite", () => {
 
             mockedPlatform.setValue("win32");
             await expect(SwiftToolchain.findXcodeInstalls()).to.eventually.be.empty;
-        });
-    });
-
-    suite("getSwiftlyToolchainInstalls()", () => {
-        const mockedEnv = mockGlobalValue(process, "env");
-
-        test("returns installed toolchains on Linux", async () => {
-            mockedPlatform.setValue("linux");
-            const mockHomeDir = "/home/user/.swiftly";
-            mockedEnv.setValue({ SWIFTLY_HOME_DIR: mockHomeDir });
-
-            mockFS({
-                [path.join(mockHomeDir, "config.json")]: JSON.stringify({
-                    installedToolchains: ["swift-5.9.0", "swift-6.0.0"],
-                }),
-            });
-
-            const toolchains = await Swiftly.list();
-            expect(toolchains).to.deep.equal([
-                path.join(mockHomeDir, "toolchains", "swift-5.9.0"),
-                path.join(mockHomeDir, "toolchains", "swift-6.0.0"),
-            ]);
-        });
-
-        test("returns installed toolchains on macOS", async () => {
-            mockedPlatform.setValue("darwin");
-            const mockHomeDir = "/Users/user/.swiftly";
-            mockedEnv.setValue({ SWIFTLY_HOME_DIR: mockHomeDir });
-
-            mockFS({
-                [path.join(mockHomeDir, "config.json")]: JSON.stringify({
-                    installedToolchains: ["swift-5.9.0", "swift-6.0.0"],
-                }),
-            });
-
-            const toolchains = await Swiftly.list();
-            expect(toolchains).to.deep.equal([
-                path.join(mockHomeDir, "toolchains", "swift-5.9.0"),
-                path.join(mockHomeDir, "toolchains", "swift-6.0.0"),
-            ]);
-        });
-
-        test("returns empty array when SWIFTLY_HOME_DIR is not set", async () => {
-            mockedPlatform.setValue("linux");
-            mockedEnv.setValue({});
-
-            const toolchains = await Swiftly.list();
-            expect(toolchains).to.be.empty;
-        });
-
-        test("returns empty array when config file does not exist", async () => {
-            mockedPlatform.setValue("linux");
-            const mockHomeDir = "/home/user/.swiftly";
-            mockedEnv.setValue({ SWIFTLY_HOME_DIR: mockHomeDir });
-
-            mockFS({});
-
-            await expect(Swiftly.list()).to.be.rejected.then(error => {
-                expect(error.message).to.include(
-                    "Failed to retrieve Swiftly installations from disk"
-                );
-            });
-        });
-
-        test("returns empty array when config has no installedToolchains", async () => {
-            mockedPlatform.setValue("linux");
-            const mockHomeDir = "/home/user/.swiftly";
-            mockedEnv.setValue({ SWIFTLY_HOME_DIR: mockHomeDir });
-
-            mockFS({
-                [path.join(mockHomeDir, "config.json")]: JSON.stringify({
-                    someOtherProperty: "value",
-                }),
-            });
-
-            const toolchains = await Swiftly.list();
-            expect(toolchains).to.be.empty;
-        });
-
-        test("returns empty array on Windows", async () => {
-            mockedPlatform.setValue("win32");
-            const toolchains = await Swiftly.list();
-            expect(toolchains).to.be.empty;
-        });
-
-        test("filters out non-string toolchain entries", async () => {
-            mockedPlatform.setValue("linux");
-            const mockHomeDir = "/home/user/.swiftly";
-            mockedEnv.setValue({ SWIFTLY_HOME_DIR: mockHomeDir });
-
-            mockFS({
-                [path.join(mockHomeDir, "config.json")]: JSON.stringify({
-                    installedToolchains: ["swift-5.9.0", null, "swift-6.0.0", 123, "swift-6.1.0"],
-                }),
-            });
-
-            const toolchains = await Swiftly.list();
-            expect(toolchains).to.deep.equal([
-                path.join(mockHomeDir, "toolchains", "swift-5.9.0"),
-                path.join(mockHomeDir, "toolchains", "swift-6.0.0"),
-                path.join(mockHomeDir, "toolchains", "swift-6.1.0"),
-            ]);
         });
     });
 });


### PR DESCRIPTION
## Description
Respect the user's configuration selection when invoking `swiftly use`. If the user selects the workspace configuration then the toolchain will be updated via the `.swift-version` file in the workspace (and if one isn't there it will be created). For global toolchains the `--global-default` option will be set so that the toolchain gets updated globally.

Issue: #1848

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~

Swiftly is a new feature that hasn't made it into a release yet. No need to update change log.
