### PR TITLE
Ensure the extension activates with a .bsp folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "workspaceContains:**/compile_commands.json",
     "workspaceContains:**/compile_flags.txt",
     "workspaceContains:**/buildServer.json",
+    "workspaceContains:**/.bsp/*.json",
     "onDebugResolve:swift-lldb",
     "onDebugResolve:swift"
   ],

--- a/src/utilities/filesystem.ts
+++ b/src/utilities/filesystem.ts
@@ -49,6 +49,19 @@ export async function fileExists(...pathComponents: string[]): Promise<boolean> 
 }
 
 /**
+ * Checks if a folder exists at the supplied path.
+ * @param pathComponents The folder path to check for existence
+ * @returns Whether or not the folder exists at the path
+ */
+export async function folderExists(...pathComponents: string[]): Promise<boolean> {
+    try {
+        return (await fs.stat(path.join(...pathComponents))).isDirectory();
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
  * Return whether a file/folder is inside a folder.
  * @param subpath child file/folder
  * @param parent parent folder


### PR DESCRIPTION
## Description
A .bsp folder was considered a valid workspace folder, but the extension activation events in the package.json were not configured to search for it, meaning another valid file/folder for activation had to be present. If that was the case, then the .bsp folder would be discovered correctly, but not if it was the only file/folder in the folder that would activate the extension.

Add it to the list of valid activation file types. Also clean up this code path a bit, ignoring common folders we shouldn't search for projects.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
