### PR TITLE
Always disable GPU when running tests

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -43,6 +43,7 @@ const launchArgs = [
     "--disable-telemetry",
     "--disable-gpu",
     "--disable-gpu-sandbox",
+    "--disable-chromium-sandbox",
     "--no-xshm",
 ];
 if (dataDir) {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Keep seeing crashes from gpu source so found threads suggesting we disable cpu always

`[5284:1002/004226.092232:ERROR:gpu/command_buffer/service/gles2_cmd_decoder_passthrough.cc:1095] [GroupMarkerNotSet(crbug.com/242999)!:A0B0190774120000]Automatic fallback to software WebGL has been deprecated. Please use the --enable-unsafe-swiftshader (about:flags#enable-unsafe-swiftshader) flag to opt in to lower security guarantees for trusted content.
Internal debugger error: Not supported in noDebug mode.: CodeExpectedError: Internal debugger error: Not supported in noDebug mode.`

Issue: n/a

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
