### PR TITLE
Ask where to use newly installed Swiftly toolchain

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -30,10 +30,7 @@ import { useLocalDependency } from "./commands/dependencies/useLocal";
 import { generateLaunchConfigurations } from "./commands/generateLaunchConfigurations";
 import { generateSourcekitConfiguration } from "./commands/generateSourcekitConfiguration";
 import { insertFunctionComment } from "./commands/insertFunctionComment";
-import {
-    installSwiftlySnapshotToolchain,
-    installSwiftlyToolchain,
-} from "./commands/installSwiftlyToolchain";
+import { promptToInstallSwiftlyToolchain } from "./commands/installSwiftlyToolchain";
 import { newSwiftFile } from "./commands/newFile";
 import { openDocumentation } from "./commands/openDocumentation";
 import { openEducationalNote } from "./commands/openEducationalNote";
@@ -356,11 +353,11 @@ export function register(ctx: WorkspaceContext): vscode.Disposable[] {
         ),
         vscode.commands.registerCommand(
             Commands.INSTALL_SWIFTLY_TOOLCHAIN,
-            async () => await installSwiftlyToolchain(ctx)
+            async () => await promptToInstallSwiftlyToolchain(ctx, "stable")
         ),
         vscode.commands.registerCommand(
             Commands.INSTALL_SWIFTLY_SNAPSHOT_TOOLCHAIN,
-            async () => await installSwiftlySnapshotToolchain(ctx)
+            async () => await promptToInstallSwiftlyToolchain(ctx, "snapshot")
         ),
     ];
 }

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -21,8 +21,7 @@ import * as Stream from "stream";
 import * as vscode from "vscode";
 import { z } from "zod/v4/mini";
 
-// Import the reusable installation function
-import { installSwiftlyToolchainVersion } from "../commands/installSwiftlyToolchain";
+import { installSwiftlyToolchainWithProgress } from "../commands/installSwiftlyToolchain";
 import { ContextKeys } from "../contextKeys";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { showMissingToolchainDialog } from "../ui/ToolchainSelection";
@@ -153,8 +152,7 @@ export function parseSwiftlyMissingToolchainError(
 export async function handleMissingSwiftlyToolchain(
     version: string,
     logger?: SwiftLogger,
-    folder?: vscode.Uri,
-    token?: vscode.CancellationToken
+    folder?: vscode.Uri
 ): Promise<boolean> {
     logger?.info(`Attempting to handle missing toolchain: ${version}`);
 
@@ -167,7 +165,7 @@ export async function handleMissingSwiftlyToolchain(
 
     // Use the existing installation function without showing reload notification
     // (since we want to continue the current operation)
-    return await installSwiftlyToolchainVersion(version, logger, false, token);
+    return await installSwiftlyToolchainWithProgress(version, logger);
 }
 
 export class Swiftly {
@@ -532,7 +530,6 @@ export class Swiftly {
         const installArgs = [
             "install",
             version,
-            "--use",
             "--assume-yes",
             "--post-install-file",
             postInstallFilePath,

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -505,7 +505,7 @@ export async function removeToolchainPath() {
     await swiftSettings.update("path", undefined, vscode.ConfigurationTarget.Workspace);
 }
 
-async function askWhereToSetToolchain(): Promise<vscode.ConfigurationTarget | undefined> {
+export async function askWhereToSetToolchain(): Promise<vscode.ConfigurationTarget | undefined> {
     if (!vscode.workspace.workspaceFolders) {
         return vscode.ConfigurationTarget.Global;
     }


### PR DESCRIPTION
## Description
The `--use` argument for `Swiftly install` doesn't seem to have a good way of telling Swiftly to install as a global default toolchain. Instead of this, we will simply do a `swiftly use` after the install, asking the user where they want to use the new toolchain (workspace vs global). This also means that `installSwiftlyToolchainWithProgress()` no longer needs to show the reload message since installation no longer does a `use` by default.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
