### PR TITLE
Ensure that the .swift-version file exists before calling `swiftly use`

### DIFF
--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -25,6 +25,7 @@ import { installSwiftlyToolchainWithProgress } from "../commands/installSwiftlyT
 import { ContextKeys } from "../contextKeys";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { showMissingToolchainDialog } from "../ui/ToolchainSelection";
+import { touch } from "../utilities/filesystem";
 import { findBinaryPath } from "../utilities/shell";
 import { ExecFileError, execFile, execFileStreamOutput } from "../utilities/utilities";
 import { Version } from "../utilities/version";
@@ -339,6 +340,7 @@ export class Swiftly {
         const options: ExecFileOptions = {};
         if (cwd) {
             options.cwd = cwd;
+            await touch(path.join(cwd, ".swift-version"));
         } else {
             useArgs.push("--global-default");
         }

--- a/src/utilities/filesystem.ts
+++ b/src/utilities/filesystem.ts
@@ -49,6 +49,18 @@ export async function fileExists(...pathComponents: string[]): Promise<boolean> 
 }
 
 /**
+ * Checks if a file exists on disk and, if it doesn't, creates it. If the file does exist
+ * then this function does nothing.
+ * @param path The path to the file.
+ */
+export async function touch(path: string): Promise<void> {
+    if (!(await fileExists(path))) {
+        const handle = await fs.open(path, "a");
+        await handle.close();
+    }
+}
+
+/**
  * Return whether a file/folder is inside a folder.
  * @param subpath child file/folder
  * @param parent parent folder

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -85,6 +85,8 @@ suite("Swiftly Unit Tests", () => {
         });
 
         test("sets the toolchain in cwd if it is provided", async () => {
+            // CWD exists
+            mockFS({ "/home/user/project": mockFS.directory() });
             // Mock version check to return 1.0.1
             mockUtilities.execFile.withArgs("swiftly", ["--version"]).resolves({
                 stdout: "1.1.0\n",
@@ -100,6 +102,8 @@ suite("Swiftly Unit Tests", () => {
                 ["use", "-y", "6.1.0"],
                 match.has("cwd", "/home/user/project")
             );
+            const stats = await fs.stat("/home/user/project/.swift-version");
+            expect(stats.isFile(), "Expected .swift-version file to be created").to.be.true;
         });
     });
 


### PR DESCRIPTION
## Description
Some instances of Swiftly do not actually create the `.swift-version` file when `swiftly use` is called. They will only modify an existing `.swift-version` file. This is definitely an issue with Swiftly itself, but we can at least mitigate the problem in the Swift extension until we can determine a proper fix.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
