### PR TITLE
Log FolderContext creation stack

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -37,6 +37,7 @@ export class FolderContext implements vscode.Disposable {
     private testExplorerResolver?: (testExplorer: TestExplorer) => void;
     private packageWatcher: PackageWatcher;
     private testRunManager: TestRunManager;
+    public creationStack?: string;
 
     /**
      * FolderContext constructor
@@ -56,6 +57,10 @@ export class FolderContext implements vscode.Disposable {
         this.backgroundCompilation = new BackgroundCompilation(this);
         this.taskQueue = new TaskQueue(this);
         this.testRunManager = new TestRunManager();
+
+        // In order to track down why a FolderContext may be created when we don't want one,
+        // capture the stack so we can log it if we find a duplicate.
+        this.creationStack = new Error().stack;
 
         // Tests often need to wait for the test explorer to be created before they can run.
         // This promise resolves when the test explorer is created, allowing them to wait for it before starting.

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -467,8 +467,10 @@ export class WorkspaceContext implements vscode.Disposable {
         // find context with root folder
         const index = this.folders.findIndex(context => context.folder.fsPath === folder.fsPath);
         if (index !== -1) {
+            const existingFolder = this.folders[index];
             this.logger.warn(`Adding package folder ${folder} twice: ${Error().stack}`);
-            return this.folders[index];
+            this.logger.warn(`Existing folder was created by ${existingFolder.creationStack}`);
+            return existingFolder;
         }
         const folderContext = await FolderContext.create(folder, workspaceFolder, this);
         this.folders.push(folderContext);


### PR DESCRIPTION
## Description
When a duplicate folder context is created in a test this typically indicates the test is set up incorrectly. Capture the stack trace at the time of creation, and then log it when a duplicate folder is created.

## Tasks
- [x] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
