### PR TITLE
Tests - Activate extension for each test in Dependency Command Tests

### DIFF
--- a/test/integration-tests/commands/dependency.test.ts
+++ b/test/integration-tests/commands/dependency.test.ts
@@ -25,7 +25,7 @@ import { testAssetUri } from "../../fixtures";
 import { tag } from "../../tags";
 import { waitForNoRunningTasks } from "../../utilities/tasks";
 import {
-    activateExtensionForSuite,
+    activateExtensionForTest,
     findWorkspaceFolder,
     folderInRootWorkspace,
 } from "../utilities/testutilities";
@@ -34,7 +34,7 @@ tag("large").suite("Dependency Commands Test Suite", function () {
     let depsContext: FolderContext;
     let workspaceContext: WorkspaceContext;
 
-    activateExtensionForSuite({
+    activateExtensionForTest({
         async setup(ctx) {
             workspaceContext = ctx;
             depsContext = findWorkspaceFolder("dependencies", workspaceContext)!;


### PR DESCRIPTION
## Description
To ensure we're creating a fresh `ProjectPanelProvider` for every test, use `activateExtensionForTest` to set up the test environment for each test instead of once for the suite.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
