### PR TITLE
Tests - Use relativePath to determine if we've already added a folder

### DIFF
--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -508,9 +508,12 @@ export const folderInRootWorkspace = async (
     workspaceContext: WorkspaceContext
 ): Promise<FolderContext> => {
     const workspaceFolder = getRootWorkspaceFolder();
-    let folder = workspaceContext.folders.find(f => f.workspaceFolder.name === `test/${name}`);
+    let folder = workspaceContext.folders.find(f => f.relativePath === name);
     if (!folder) {
+        workspaceContext.logger.info(`${name} not found, adding folder ${name} to workspace`);
         folder = await workspaceContext.addPackageFolder(testAssetUri(name), workspaceFolder);
+    } else {
+        workspaceContext.logger.info(`${name} found, reusing existing folder`);
     }
 
     // Folders that aren't packages (i.e. assets/tests/scripts) wont generate build tasks.


### PR DESCRIPTION
## Description
Checking the VS Code workspaceFolder's name against a constructed name is unrelable, leading to the same folder being attempted to be created multiple times.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
