### PR TITLE
Add .npmrc with default registry configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Description
This is useful when a users default registry is not the public one

## Tasks
- [x] Required tests have been written
- [x] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
