### PR TITLE
Have dependabot ignore eslint-plugin-mocha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       - dependency-name: "@types/svgicons2svgfont"
       - dependency-name: "octokit"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-mocha"
+        update-types: ["version-update:semver-major"]
       # Newer versions of fantasticon are broken on Windows.
       # https://github.com/tancredi/fantasticon/issues/470
       - dependency-name: "fantasticon"


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Can't bump major version as it conflicts with peer dependencies

Issue: #1886

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
