### PR TITLE
Fix source mapping in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/semver": "^7.7.1",
         "@types/sinon": "^17.0.4",
         "@types/sinon-chai": "^3.2.12",
+        "@types/source-map-support": "^0.5.10",
         "@types/svg2ttf": "^5.0.3",
         "@types/svgicons2svgfont": "^10.0.5",
         "@types/ttf2woff": "^2.0.4",
@@ -2369,6 +2370,16 @@
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.0"
+      }
     },
     "node_modules/@types/svg2ttf": {
       "version": "5.0.3",
@@ -13255,6 +13266,15 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
+    },
+    "@types/source-map-support": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
+      "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.0"
+      }
     },
     "@types/svg2ttf": {
       "version": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -2035,6 +2035,7 @@
     "@types/semver": "^7.7.1",
     "@types/sinon": "^17.0.4",
     "@types/sinon-chai": "^3.2.12",
+    "@types/source-map-support": "^0.5.10",
     "@types/svg2ttf": "^5.0.3",
     "@types/svgicons2svgfont": "^10.0.5",
     "@types/ttf2woff": "^2.0.4",


### PR DESCRIPTION
## Description
Tests that use `mock-fs` were breaking `source-map-support` because it tries to read files off of disk which will not exist for the duration of the test. When installing `source-map-support` for our tests, we will now override `retrieveFile()` which will bypass `mock-fs` to retrieve the actual file on disk.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
