### PR TITLE
Use current folder to find active toolchain for toolchain selection

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -65,16 +65,19 @@ import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
 export type WorkspaceContextWithToolchain = WorkspaceContext & { toolchain: SwiftToolchain };
 
 export function registerToolchainCommands(
-    toolchain: SwiftToolchain | undefined,
-    logger: SwiftLogger,
-    cwd?: vscode.Uri
+    ctx: WorkspaceContext | undefined,
+    logger: SwiftLogger
 ): vscode.Disposable[] {
     return [
         vscode.commands.registerCommand("swift.createNewProject", () =>
-            createNewProject(toolchain)
+            createNewProject(ctx?.globalToolchain)
         ),
         vscode.commands.registerCommand("swift.selectToolchain", () =>
-            showToolchainSelectionQuickPick(toolchain, logger, cwd)
+            showToolchainSelectionQuickPick(
+                ctx?.currentFolder?.toolchain ?? ctx?.globalToolchain,
+                logger,
+                ctx?.currentFolder?.folder
+            )
         ),
         vscode.commands.registerCommand("swift.pickProcess", configuration =>
             pickProcess(configuration)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         // properly configured.
         if (!toolchain) {
             // In order to select a toolchain we need to register the command first.
-            const subscriptions = commands.registerToolchainCommands(undefined, logger, undefined);
+            const subscriptions = commands.registerToolchainCommands(undefined, logger);
             const chosenRemediation = await showToolchainError();
             subscriptions.forEach(sub => sub.dispose());
 
@@ -101,11 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Api> {
         context.subscriptions.push(new SwiftEnvironmentVariablesManager(context));
         context.subscriptions.push(SwiftTerminalProfileProvider.register());
         context.subscriptions.push(
-            ...commands.registerToolchainCommands(
-                toolchain,
-                workspaceContext.logger,
-                workspaceContext.currentFolder?.folder
-            )
+            ...commands.registerToolchainCommands(workspaceContext, workspaceContext.logger)
         );
 
         // Watch for configuration changes the trigger a reload of the extension if necessary.


### PR DESCRIPTION
## Description
Have toolchain commands use the WorkspaceContext to find the most relevant toolchain either in the current folder or at a global level.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
