### PR TITLE
Don't block waiting for debug configurations

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -217,8 +217,9 @@ function handleFolderEvent(logger: SwiftLogger): (event: FolderEvent) => Promise
 
         switch (operation) {
             case FolderOperation.add:
-                // Create launch.json files based on package description.
-                await debug.makeDebugConfigurations(folder);
+                // Create launch.json files based on package description, don't block execution.
+                void debug.makeDebugConfigurations(folder);
+
                 if (await folder.swiftPackage.foundPackage) {
                     // do not await for this, let packages resolve in parallel
                     void folderAdded(folder, workspace);
@@ -226,8 +227,9 @@ function handleFolderEvent(logger: SwiftLogger): (event: FolderEvent) => Promise
                 break;
 
             case FolderOperation.packageUpdated:
-                // Create launch.json files based on package description.
-                await debug.makeDebugConfigurations(folder);
+                // Create launch.json files based on package description, don't block execution.
+                void debug.makeDebugConfigurations(folder);
+
                 if (
                     (await folder.swiftPackage.foundPackage) &&
                     !configuration.folder(folder.workspaceFolder).disableAutoResolve


### PR DESCRIPTION
## Description

When a folder is added to the workspace context we were awaiting the `makeDebugConfigurations` method. This method generates launch configurations in the launch.json. If the method finds it needs to update existing launch configurations, it puts of a warning message dialog prompting the user for action.

Because we were awaiting this method, the dialog blocks folder addition and in turn prevents sourcekit-lsp and other extension features from activating for the folder until the dialog is dismissed.

Because nothing relies on the result of `makeDebugConfigurations`, simply kick off the work but don't await it.

Issue: #1912

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
