### PR TITLE
Ignore ./github-workflows folder in soundness.sh

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -104,8 +104,9 @@ EOF
             \( \! -path './coverage/*' -a \
             \( \! -path './.husky/*' -a \
             \( \! -path './src/typings/*' -a \
-            \( "${matching_files[@]}" \) \
-            \) \) \) \) \) \) \) \) \)
+            \( \! -path './github-workflows/*' -a \
+            \( "${matching_files[@]}" \
+            \) \) \) \) \) \) \) \) \) \) \)
     } | while read -r line; do
       if [[ "$(replace_acceptable_years < "$line" | head -n "$expected_lines" | shasum)" != "$expected_sha" ]]; then
         printf "\033[0;31mmissing headers in file '%s'!\033[0m\n" "$line"


### PR DESCRIPTION
## Description
Looks like the github-workflows folder is now in the workspace. Avoid scanning it with soundness.sh

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
