### PR TITLE
Remove --no-xshm argument from test runner

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -45,7 +45,6 @@ const launchArgs = [
     "--disable-gpu-sandbox",
     "--disable-chromium-sandbox",
     "--disable-extension=vscode.git",
-    "--no-xshm",
 ];
 if (dataDir) {
     launchArgs.push("--user-data-dir", dataDir);


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Removed so now get a warning in test output. This option never helped fix the original CI issue anyway

Issue: N/A

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
