### PR TITLE
Remove Swift > Clean Build Folder menu item in swift editor area

### DIFF
--- a/package.json
+++ b/package.json
@@ -1423,11 +1423,6 @@
           "command": "swift.debugSnippet",
           "group": "1_file@5",
           "when": "swift.fileIsSnippet"
-        },
-        {
-          "command": "swift.cleanBuild",
-          "group": "2_pkg@1",
-          "when": "swift.hasPackage"
         }
       ],
       "view/title": [


### PR DESCRIPTION
Right clicking the editor area of a Swift file would show a Swift menu entry that just contained Clean Build Folder. This doesn't make much sense to have here, so clean it up.

To clean the build folder use the "Swift > Clean Build Folder" command from the command pallete.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [ ] Added an entry to CHANGELOG.md if applicable
