### PR TITLE
Adopt 7 day cooldown before upgrading dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     allow:
       - dependency-type: direct


### PR DESCRIPTION
In an effort to reduce the risk of a supply chain attack, add a 7-day cooldown between when a new version of a dependency is released and when Dependabot creates a PR upgrading to it.

Most malicious packages are detected by package vendors (in our case, npm) relatively quickly. The damage is done in the window between when a malicious package is released and when it is identified and taken down.

By adding a cooldown, we narrow the window where a malicious package can be introduced. Ideally, within 7 days this window shrinks to zero and we have no potential exposure at all. At minimum, this cooldown reduces the window where we're vulnerable.

For a more detailed explanation of how this helps, see: https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
