### PR TITLE
Parallelize package init and test discovery operations

### DIFF
--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -85,20 +85,17 @@ export class LSPTestDiscovery {
         swiftPackage: SwiftPackage,
         input: LSPTestItem[]
     ): Promise<TestDiscovery.TestClass[]> {
-        let result: TestDiscovery.TestClass[] = [];
-        for (const item of input) {
-            const location = client.protocol2CodeConverter.asLocation(item.location);
-            result = [
-                ...result,
-                {
+        return Promise.all(
+            input.map(async item => {
+                const location = client.protocol2CodeConverter.asLocation(item.location);
+                return {
                     ...item,
                     id: await this.transformId(item, location, swiftPackage),
                     children: await this.transformToTestClass(client, swiftPackage, item.children),
                     location,
-                },
-            ];
-        }
-        return result;
+                };
+            })
+        );
     }
 
     /**


### PR DESCRIPTION
Some package initialization and test discovery operations could be parallelized to gain some modest speedups at no cost.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
