### PR TITLE
Don't follow the swiftly symlink when determining in use toolchain

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -571,7 +571,7 @@ export class SwiftToolchain {
 
             if (path.basename(realSwift) === "swiftly") {
                 try {
-                    const inUse = await Swiftly.inUseLocation(realSwift, cwd);
+                    const inUse = await Swiftly.inUseLocation("swiftly", cwd);
                     if (inUse) {
                         realSwift = path.join(inUse, "usr", "bin", "swift");
                         isSwiftlyManaged = true;


### PR DESCRIPTION
When swiftly is installed via Homebrew it is added to the path at a location like `/opt/homebrew/bin/swiftly`, which is a symlink to the brew cellar located at `/opt/homebrew/bin/Cellar/swiftly/1.1.0/bin/`

When printing the in use toolchain location with `swiftly use --print-location` we were launching swiftly with the realpath of the symlink, which caused Swiftly to print the "swiftly is unlinked" warning message before printing the toolchain location.

The extension went on to take this message and parse it as a path, causing the extension activation to hang.

Instead of using this realpath when invoking swiftly to get the toolchain path, if we determine the use is using swiftly just invoke it normally using `swiftly` instead of using the full path.

Issue: #1966

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [ ] Added an entry to CHANGELOG.md if applicable
