### PR TITLE
Temporarily disable failing CodeLLDB tests on linux

### DIFF
--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -160,7 +160,11 @@ tag("large").suite("Test Explorer Suite", function () {
             let resetSettings: (() => Promise<void>) | undefined;
             beforeEach(async function () {
                 // CodeLLDB on windows doesn't print output and so cannot be parsed
-                if (process.platform === "win32") {
+                if (
+                    process.platform === "win32" ||
+                    (process.platform === "linux" &&
+                        folderContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 2, 0)))
+                ) {
                     this.skip();
                 }
 


### PR DESCRIPTION
## Description
CodeLLDB is failing to debug on nightlies, likely this is an interaction between its LLDB and the toolchain; doesn't look like an extension issue. Temporarily skip until its resolved.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
