### PR TITLE
Use `vscode.Disposable.from` instead of `compositeDisposable`

### DIFF
--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -21,7 +21,7 @@ import { SwiftLogger } from "../logging/SwiftLogger";
 import { buildOptions, getBuildAllTask } from "../tasks/SwiftTaskProvider";
 import { TaskManager } from "../tasks/TaskManager";
 import { SwiftExecOperation, TaskOperation } from "../tasks/TaskQueue";
-import { compositeDisposable, getErrorDescription } from "../utilities/utilities";
+import { getErrorDescription } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { parseTestsFromDocumentSymbols } from "./DocumentSymbolTestDiscovery";
 import { LSPTestDiscovery } from "./LSPTestDiscovery";
@@ -208,7 +208,7 @@ export class TestExplorer {
             }
         });
 
-        return compositeDisposable(endProcessDisposable, didChangeSwiftFileDisposable);
+        return vscode.Disposable.from(endProcessDisposable, didChangeSwiftFileDisposable);
     }
 
     /**
@@ -229,7 +229,7 @@ export class TestExplorer {
                     break;
             }
         });
-        return compositeDisposable(tokenSource, disposable);
+        return vscode.Disposable.from(tokenSource, disposable);
     }
 
     /**

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -55,12 +55,7 @@ export function registerDebugger(workspaceContext: WorkspaceContext): vscode.Dis
         register();
     }
 
-    return {
-        dispose: () => {
-            configurationEvent.dispose();
-            subscriptions.map(sub => sub.dispose());
-        },
-    };
+    return vscode.Disposable.from(configurationEvent, ...subscriptions);
 }
 
 /**

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -54,11 +54,7 @@ export function registerLoggingDebugAdapterTracker(): vscode.Disposable {
     ];
 
     // Return a disposable that cleans everything up.
-    return {
-        dispose() {
-            subscriptions.forEach(sub => sub.dispose());
-        },
-    };
+    return vscode.Disposable.from(...subscriptions);
 }
 
 /**

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -457,16 +457,3 @@ export function destructuredPromise<T>(): {
     return { promise: p, resolve: resolve!, reject: reject! };
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-/**
- * Creates a composite disposable from multiple disposables.
- * @param disposables The disposables to include.
- * @returns A composite disposable that disposes all included disposables.
- */
-export function compositeDisposable(...disposables: vscode.Disposable[]): vscode.Disposable {
-    return {
-        dispose: () => {
-            disposables.forEach(d => d.dispose());
-        },
-    };
-}


### PR DESCRIPTION
## Description

Clean up the codebase so that it uses the built in `vscode.Disposable.from` to dispose multiple disposables at the same time. This replaces our own `compositeDisposable` method.

Docs here: https://code.visualstudio.com/api/references/vscode-api#Disposable

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
