### PR TITLE
Don't use realpath when trying to identify swiftly binary

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -576,7 +576,7 @@ export class SwiftToolchain {
                 };
             }
             // Check if the swift binary is managed by swiftly
-            if (await Swiftly.isManagedBySwiftly(realSwiftBinaryPath)) {
+            if (await Swiftly.isManagedBySwiftly(swiftBinaryPath)) {
                 const swiftlyToolchainPath = await Swiftly.getActiveToolchain(extensionRoot, cwd);
                 return {
                     toolchainPath: path.resolve(swiftlyToolchainPath, "usr"),


### PR DESCRIPTION
## Description
If `swiftly` is installed via homebrew then the shims in `SWIFTLY_HOME_DIR` will be symlinks that point to `/opt/homebrew` breaking the swiftly check which results in toolchain detection failing. Don't use `realpath` when checking whether or not the toolchain is managed by `swiftly`.

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
