### PR TITLE
Disable failing test running on Windows nightly-main

### DIFF
--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -150,7 +150,24 @@ tag("large").suite("Test Explorer Suite", function () {
                 }
             });
 
-            test("Debugs specified XCTest test", runXCTest);
+            test("Debugs specified XCTest test", async function () {
+                // This test is failing consistently on Windows nightly-main (6.3-dev).
+                // Skip it until a fix is made.
+                //
+                // GitHub Issue: https://github.com/swiftlang/vscode-swift/issues/1986
+                if (
+                    workspaceContext.globalToolchain.swiftVersion.dev &&
+                    workspaceContext.globalToolchain.swiftVersion.isGreaterThanOrEqual({
+                        major: 6,
+                        minor: 3,
+                        patch: 0,
+                    })
+                ) {
+                    this.skip();
+                }
+                await runXCTest.call(this);
+            });
+
             test("Debugs specified swift-testing test", async function () {
                 await runSwiftTesting.call(this);
             });


### PR DESCRIPTION
## Description
Debugging an XCTest no longer updates the test status correctly. This is only happening on Windows with Swift 6.3-dev. I'm disabling the test until we can determine the root cause.

Issue: #1986 

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
