### PR TITLE
Pin the swiftlang/github-workflows configurations to 0.0.2

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
   tests_release:
     name: Test Release
     needs: package
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
     with:
       needs_token: true
       # Linux
@@ -87,7 +87,7 @@ jobs:
   tests_insiders:
     name: Test Insiders
     needs: package
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
     with:
       needs_token: true
       # Linux

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
   tests:
     name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
     needs: package
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
     with:
       needs_token: true
       # Linux
@@ -76,7 +76,7 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.2
     with:
       # Pending https://github.com/swiftlang/vscode-swift/pull/1176
       license_header_check_enabled: false


### PR DESCRIPTION
## Description
The [github-workflows repository](https://github.com/swiftlang/github-workflows) has started tagging releases. Main is no longer expected to be 100% stable. This PR pins us to version 0.0.2 to avoid failures on the new Linux aarch64 jobs.

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
