### PR TITLE
Only attempt to run xcode-select on macOS

### DIFF
--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -566,7 +566,10 @@ export class SwiftToolchain {
             // swift may be a symbolic link
             const realSwiftBinaryPath = await fs.realpath(swiftBinaryPath);
             // Check if the swift binary is managed by xcrun
-            if (await this.isXcrunShim(realSwiftBinaryPath, logger)) {
+            if (
+                process.platform === "darwin" &&
+                (await this.isXcrunShim(realSwiftBinaryPath, logger))
+            ) {
                 const { stdout } = await execFile("xcrun", ["--find", "swift"], {
                     env: configuration.swiftEnvironmentVariables,
                 });


### PR DESCRIPTION
## Description
The extension was attempting to launch `xcode-select` on Linux and Windows which will never work. Check the platform before using `xcode-select`.

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
