### PR TITLE
Ignore `--scratch-path` when calling `swift package plugin --list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - When editing .sourcekit-lsp/config.json use the JSON schema from the toolchain ([#1979](https://github.com/swiftlang/vscode-swift/pull/1979))
 
+### Fixed
+
+- Omit `--scratch-path` when enumerating plugins with `swift package plugin --list` ([#1996](https://github.com/swiftlang/vscode-swift/pull/1996))
+
 ## 2.14.2 - 2025-12-07
 
 ### Fixed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -222,10 +222,9 @@ function handleFolderEvent(logger: SwiftLogger): (event: FolderEvent) => Promise
     // function called when a folder is added. I broke this out so we can trigger it
     // without having to await for it.
     async function folderAdded(folder: FolderContext, workspace: WorkspaceContext) {
-        if (
-            !configuration.folder(folder.workspaceFolder).disableAutoResolve ||
-            configuration.backgroundCompilation.enabled
-        ) {
+        const disableAutoResolve = configuration.folder(folder.workspaceFolder).disableAutoResolve;
+        const backgroundCompilationEnabled = configuration.backgroundCompilation.enabled;
+        if (!disableAutoResolve || backgroundCompilationEnabled) {
             // if background compilation is set then run compile at startup unless
             // this folder is a sub-folder of the workspace folder. This is to avoid
             // kicking off compile for multiple projects at the same time

--- a/test/unit-tests/toolchain/BuildFlags.test.ts
+++ b/test/unit-tests/toolchain/BuildFlags.test.ts
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import { expect } from "chai";
+import { beforeEach } from "mocha";
 import * as sinon from "sinon";
 
 import configuration from "@src/configuration";
@@ -242,6 +243,13 @@ suite("BuildFlags Test Suite", () => {
 
     suite("withAdditionalFlags", () => {
         const sdkConfig = mockGlobalValue(configuration, "sdk");
+        const buildPathConfig = mockGlobalValue(configuration, "buildPath");
+
+        beforeEach(() => {
+            buildPathConfig.setValue("");
+            sdkConfig.setValue("");
+            sandboxConfig.setValue(false);
+        });
 
         test("package", () => {
             for (const sub of ["dump-symbol-graph", "diagnose-api-breaking-changes", "resolve"]) {
@@ -282,6 +290,29 @@ suite("BuildFlags Test Suite", () => {
                 "-disable-sandbox",
                 "init",
             ]);
+        });
+
+        test("package plugin", () => {
+            buildPathConfig.setValue("");
+            sdkConfig.setValue("");
+            expect(
+                buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin"])
+            ).to.deep.equal(["package", "plugin", "my-plugin"]);
+
+            buildPathConfig.setValue("/some/build/path");
+            expect(
+                buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin", "--verbose"])
+            ).to.deep.equal(["package", "plugin", "my-plugin", "--verbose"]);
+
+            sdkConfig.setValue("/some/full/path/to/sdk");
+            expect(
+                buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin"])
+            ).to.deep.equal(["package", "plugin", "my-plugin"]);
+
+            sandboxConfig.setValue(true);
+            expect(
+                buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin"])
+            ).to.deep.equal(["package", "plugin", "my-plugin"]);
         });
 
         test("build", () => {


### PR DESCRIPTION
If the user has a `swift.buildPath` set, and they've got backgroundCompilation turned on, the extension will attempt to list their package's plugins with a `--scratch-path`, which `swift package plugin --list` does not accept. This causes the command to fail.

Omit this argument from the command.

## Tasks
- [X] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
