### PR TITLE
Pin VS Code version for testing

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -80,7 +80,7 @@ if (vsixPath) {
     extensionDependencies.push("vadimcn.vscode-lldb", "llvm-vs-code-extensions.lldb-dap");
 }
 
-const vscodeVersion = process.env["VSCODE_VERSION"] ?? "stable";
+const vscodeVersion = process.env["VSCODE_VERSION"] ?? "1.106.3";
 log("Running tests against VS Code version " + vscodeVersion);
 
 const installConfigs = [];


### PR DESCRIPTION
## Description
The latest builds of VS Code (1.107.x) have been crashing while running integration tests for Linux 5.9-jammy. I'm pinning the VS Code version for our tests to 1.106.3 to get them running again.

Issue: #2008

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
