### PR TITLE
Fix SwiftPM's dropdown showing on projects disabling the SwiftPM integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix the wrong toolchain being shown as selected when using swiftly v1.0.1 ([#2014](https://github.com/swiftlang/vscode-swift/pull/2014))
+- Fix extension displaying SwiftPM's project view and automatic build tasks even when `disableSwiftPMIntegration` was true ([#2011](https://github.com/swiftlang/vscode-swift/pull/2011))
 
 ## 2.14.3 - 2025-12-15
 

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -180,10 +180,16 @@ export interface PackagePlugin {
 type SwiftPackageState = PackageContents | Error | undefined;
 
 function isPackage(state: SwiftPackageState): state is PackageContents {
+    if (state === undefined) {
+        return false;
+    }
     return (state as PackageContents).products !== undefined;
 }
 
 function isError(state: SwiftPackageState): state is Error {
+    if (state === undefined) {
+        return false;
+    }
     return state instanceof Error;
 }
 
@@ -262,14 +268,9 @@ export class SwiftPackage {
         toolchain: SwiftToolchain,
         disableSwiftPMIntegration: boolean = false
     ): Promise<SwiftPackageState> {
-        // When SwiftPM integration is disabled, return empty package structure
+        // When SwiftPM integration is disabled, return undefined to disable all features
         if (disableSwiftPMIntegration) {
-            return {
-                name: path.basename(folder.fsPath),
-                products: [],
-                dependencies: [],
-                targets: [],
-            };
+            return undefined;
         }
 
         try {

--- a/test/integration-tests/SwiftPackage.test.ts
+++ b/test/integration-tests/SwiftPackage.test.ts
@@ -81,21 +81,21 @@ tag("medium").suite("SwiftPackage Test Suite", function () {
         assert.strictEqual(spmPackage.resolved.pins[0].identity, "swift-log");
     });
 
-    test("Disabled SwiftPM integration returns empty package", async () => {
+    test("Disabled SwiftPM integration returns undefined package", async () => {
         const spmPackage = await SwiftPackage.create(
             testAssetUri("package2"),
             toolchain,
             true // disableSwiftPMIntegration
         );
-        assert.strictEqual(await spmPackage.isValid, true);
-        assert.strictEqual(await spmPackage.name, "package2"); // derived from folder name
+        assert.strictEqual(await spmPackage.isValid, false);
+        assert.strictEqual(await spmPackage.foundPackage, false);
         assert.strictEqual((await spmPackage.executableProducts).length, 0);
         assert.strictEqual((await spmPackage.libraryProducts).length, 0);
         assert.strictEqual((await spmPackage.dependencies).length, 0);
         assert.strictEqual((await spmPackage.targets).length, 0);
     });
 
-    test("Reload with disabled SwiftPM integration returns empty package", async () => {
+    test("Reload with disabled SwiftPM integration returns undefined package", async () => {
         const spmPackage = await SwiftPackage.create(testAssetUri("package2"), toolchain, false);
         // First verify it loaded normally
         assert.strictEqual(await spmPackage.isValid, true);
@@ -103,7 +103,8 @@ tag("medium").suite("SwiftPackage Test Suite", function () {
 
         // Now reload with disabled integration
         await spmPackage.reload(toolchain, true);
-        assert.strictEqual(await spmPackage.isValid, true);
+        assert.strictEqual(await spmPackage.isValid, false);
+        assert.strictEqual(await spmPackage.foundPackage, false);
         assert.strictEqual((await spmPackage.libraryProducts).length, 0);
         assert.strictEqual((await spmPackage.dependencies).length, 0);
         assert.strictEqual((await spmPackage.targets).length, 0);


### PR DESCRIPTION
## Description

We use a BSP with `disableSwiftPMIntegration` set to true, but we still had a couple of SwiftPM features showing around. This seemed to be because the extension was returning an empty package instead of `undefined` like it would if the package happened to not exist at all. Making it return `undefined` fixed the issue.

<img width="441" height="61" alt="Screenshot 2025-12-18 at 09 11 13" src="https://github.com/user-attachments/assets/57db5320-e2b4-4d4e-b1ae-67963c5ea329" />
<img width="589" height="57" alt="Screenshot 2025-12-18 at 09 29 50" src="https://github.com/user-attachments/assets/ce10ec7b-4c6d-429a-a2aa-53d102c37be7" />

## Tasks
- [x] Required tests have been written
- [x] Added an entry to CHANGELOG.md if applicable
