### PR TITLE
updated Launch Configuration Executable path

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -655,11 +655,6 @@ export class TestingConfigurationFactory {
         return this.ctx.toolchain.getToolchainExecutable("swift");
     }
 
-    private get buildDirectory(): string {
-        const { folder } = getFolderAndNameSuffix(this.ctx, this.expandEnvVariables);
-        return BuildFlags.buildDirectoryFromWorkspacePath(folder, true);
-    }
-
     private get artifactFolderForTestKind(): string {
         const mode = isRelease(this.testKind) ? "release" : "debug";
         const triple = this.ctx.toolchain.unversionedTriple;
@@ -683,7 +678,7 @@ export class TestingConfigurationFactory {
             this.ctx.workspaceContext.logger.warn(
                 `Failed to get build binary path for tests, falling back to legacy path construction: ${error}`
             );
-            return path.join(this.buildDirectory, this.artifactFolderForTestKind);
+            return path.join(this.artifactFolderForTestKind);
         }
     }
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
I have added getBuildBinarypath method which uses swift-build --show-bin-path for dynamic path resolution.

Fixes: #1830 

Proof Manifests: 
`kartik@Macbook-4 test % swift build --show-bin-path 
/Users/kartik/oss/vscode-swift/assets/test/.build/arm64-apple-macosx/debug `

`kartik@Macbook-4 test % swift build --show-bin-path --build-system swiftbuild
/Users/kartik/oss/vscode-swift/assets/test/.build/arm64-apple-macosx/Products/Debug`

`kartik@Macbook-4 test % swift build --show-bin-path --configuration release
/Users/kartik/oss/vscode-swift/assets/test/.build/arm64-apple-macosx/release`

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
