### PR TITLE
Fix cleaning up workspace folders w/ multiple folders present

### DIFF
--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -108,8 +108,6 @@ export class PackageWatcher {
         watcher.onDidDelete(async () => await this.handleWorkspaceStateChange());
 
         if (await fileExists(uri.fsPath)) {
-            // TODO: Remove this
-            this.logger.info("Loading initial workspace-state.json");
             await this.handleWorkspaceStateChange();
         }
 
@@ -195,10 +193,6 @@ export class PackageWatcher {
      */
     private async handleWorkspaceStateChange() {
         await this.folderContext.reloadWorkspaceState();
-        // TODO: Remove this
-        this.logger.info(
-            `Package watcher state updated workspace-state.json: ${JSON.stringify(this.folderContext.swiftPackage.workspaceState, null, 2)}`
-        );
         await this.folderContext.fireEvent(FolderOperation.workspaceStateUpdated);
     }
 }

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -515,7 +515,7 @@ export class WorkspaceContext implements vscode.Disposable {
     async removeWorkspaceFolder(workspaceFolder: vscode.WorkspaceFolder) {
         for (const folder of this.folders) {
             if (folder.workspaceFolder !== workspaceFolder) {
-                return;
+                continue;
             }
             // if current folder is this folder send unfocus event by setting
             // current folder to undefined


### PR DESCRIPTION
If a `WorkspaceContext` has multiple folders and `removeWorkspaceFolder` is called, if the first folder in the list isn't the one we're looking for the function returns intead of continues.

Continue searching for the target folder instead of returning early.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
