### PR TITLE
Unpin the version of VS Code used for tests

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -57,7 +57,7 @@ if (process.env["VSCODE_SWIFT_VSIX"]) {
     installExtensions.push(vsixPath);
 }
 
-const vscodeVersion = process.env["VSCODE_VERSION"] ?? "1.105.1";
+const vscodeVersion = process.env["VSCODE_VERSION"] ?? "stable";
 log("Running tests against VS Code version " + vscodeVersion);
 
 const env = {


### PR DESCRIPTION
## Description
We had to pin our version of VS Code for testing due to crashes on Linux. Move back to stable so that we can test against the latest VS Code releases.

Issue: #2012 

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
