### PR TITLE
Fix disableSwiftPM not working after #2028

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -155,7 +155,7 @@ export class FolderContext implements vscode.Disposable {
 
         // List the package's dependencies without blocking folder creation
         void swiftPackage
-            .loadPackageState(folderContext)
+            .loadPackageState(folderContext, configuration.disableSwiftPMIntegration)
             .then(async () => await swiftPackage.error)
             .catch(error => error)
             .then(async error => {
@@ -203,7 +203,7 @@ export class FolderContext implements vscode.Disposable {
 
     /** reload swift package for this folder */
     async reload() {
-        await this.swiftPackage.reload(this);
+        await this.swiftPackage.reload(this, configuration.disableSwiftPMIntegration);
     }
 
     /** reload Package.resolved for this folder */


### PR DESCRIPTION
[2028](https://github.com/swiftlang/vscode-swift/pull/2028) was not passing the disableSwiftPM flag to the new functions, so this was not working on the latest master.