### PR TITLE
Install Python 3.9 when using Swift 6.1 and lower

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
   tests:
     name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
     needs: package
-    uses: plemarquand/github-workflows/.github/workflows/swift_package_test.yml@install-python-59-on-older-toolchains
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
       needs_token: true
       # Linux


### PR DESCRIPTION
Update the GitHub workflow for PRs to one that installs Python 3.9 for Swift 6.1 and lower.

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
