### PR TITLE
Pin pull_request workflow to 0.0.6

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -48,7 +48,7 @@ jobs:
   tests:
     name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
     needs: package
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       needs_token: true
       # Linux


### PR DESCRIPTION
Pin it back now that a stable release has been cut that fixes the Windows 6.1 and lower issues we were seeing

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
