### PR TITLE
Move back to esbenp.prettier-vscode for formatting in VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["dbaeumer.vscode-eslint", "prettier.prettier-vscode"]
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
 
   // Configure Prettier
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "prettier.prettier-vscode",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
 
   // Disable for when opening files in this workspace
   "swift.disableAutoResolve": true,


### PR DESCRIPTION
## Description
The Prettier extension for VS Code has decided to retain the old `esbenp.prettier-vscode` extension ID (see the [comment from the maintainer](https://github.com/prettier/prettier-vscode/issues/3872#issuecomment-3662898646)). The new extension has been deprecated and VS Code will no longer install it. Switch our recommended extensions and settings back to the old extension ID.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
