### PR TITLE
Fix path when installing swiftly on Linux

### DIFF
--- a/src/commands/installSwiftly.ts
+++ b/src/commands/installSwiftly.ts
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -146,7 +145,7 @@ export async function handleMissingSwiftly(
     }
 
     // Install toolchains
-    const swiftlyPath = path.join(os.homedir(), ".swiftly", "bin", "swiftly");
+    const swiftlyPath = path.join(Swiftly.defaultHomeDir(), "bin/swiftly");
     for (const version of swiftVersions) {
         await installSwiftlyToolchainWithProgress(version, extensionRoot, logger, swiftlyPath);
     }

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -183,6 +183,19 @@ export async function handleMissingSwiftlyToolchain(
 export class Swiftly {
     public static cancellationMessage = "Installation cancelled by user";
 
+    public static defaultHomeDir(): string {
+        switch (process.platform) {
+            case "linux": {
+                if (process.env["XDG_DATA_HOME"]) {
+                    return path.join(process.env["XDG_DATA_HOME"], "swiftly");
+                }
+                return path.join(os.homedir(), ".local/share/swiftly");
+            }
+            default:
+                return path.join(os.homedir(), ".swiftly");
+        }
+    }
+
     /**
      * Downloads and installs Swiftly for the current platform
      */


### PR DESCRIPTION
## Description
Toolchain installation after installing swiftly failed on Linux because the path to swiftly is different depending on the platform. Update the logic that determines the swiftly location.

Issue: #2025

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
