### PR TITLE
Update the nightly and insiders builds to use swift_package_test.yml@0.0.6

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
   tests_release:
     name: Test Release
     needs: package
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       needs_token: true
       # Linux
@@ -87,7 +87,7 @@ jobs:
   tests_insiders:
     name: Test Insiders
     needs: package
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.2
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.6
     with:
       needs_token: true
       # Linux


### PR DESCRIPTION
## Description
PRs were using 0.0.6, which install the correct version of python for a given swift toolchain, but nightly and insiders builds were still stuck on 0.0.2

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
