### PR TITLE
bump version number to 2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## {{releaseVersion}} - {{releaseDate}}
 
+## 2.16.0 - 2026-01-28
+
 ### Added
 
 - Show progress when describing/listing dependencies on package load ([#2028](https://github.com/swiftlang/vscode-swift/pull/2028))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swift-vscode",
-  "version": "2.16.0-dev",
+  "version": "2.18.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swift-vscode",
-      "version": "2.16.0-dev",
+      "version": "2.18.0-dev",
       "hasInstallScript": true,
       "dependencies": {
         "@vscode/codicons": "^0.0.44",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "swift-vscode",
   "displayName": "Swift",
   "description": "Swift Language Support for Visual Studio Code.",
-  "version": "2.16.0-dev",
+  "version": "2.18.0-dev",
   "api-version": "0.1.0",
   "publisher": "swiftlang",
   "icon": "icon.png",


### PR DESCRIPTION
## Description
2.16.0 has been released. Update the version number to 2.18.0-dev and mark the release in the changelog.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
