### PR TITLE
Made the IDE name a variable

### DIFF
--- a/src/commands/installSwiftly.ts
+++ b/src/commands/installSwiftly.ts
@@ -100,15 +100,16 @@ export async function installSwiftlyWithProgress(logger?: SwiftLogger): Promise<
 }
 
 async function promptToRestartVSCode(): Promise<void> {
+    const editorName = vscode.env.appName;
     const selection = await vscode.window.showInformationMessage(
-        "Restart VS Code",
+        `Restart ${editorName}`,
         {
             modal: true,
-            detail: "You must restart Visual Studio Code in order for the swiftly installation to take effect.",
+            detail: `You must restart ${editorName} in order for the Swiftly installation to take effect.`,
         },
-        "Quit Visual Studio Code"
+        `Quit ${editorName}`
     );
-    if (selection === "Quit Visual Studio Code") {
+    if (selection === `Quit ${editorName}`) {
         await vscode.commands.executeCommand(Workbench.ACTION_QUIT);
     }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Now that the Swift extension is on the Open VSX Marketplace (🎉), VS Code is not the only IDE that will use our extension. Instead of saying "VS Code" in the Swiftly install pop up, we should say the name of whichever Open VSX editor is in use. 

Thankfully, the name of the editor is easy to access. `vscode.env.appName` points to the name of the editor. 

Issue: https://github.com/swiftlang/vscode-swift/issues/2076

## Tasks
- [ ] Required tests have been written
- No automated tests were written, but these manual tests were performed:
    - Installed Swiftly on macOS using Cursor — confirmed that the correct name was given in the popup: 
        <img width="292" height="186" alt="Screenshot 2026-02-02 at 3 41 52 PM" src="https://github.com/user-attachments/assets/286f416a-a89f-46d2-82ba-3662f330fe68" />
    - Installed Swiftly on macOS using VS Code — confirmed that the correct name was given in the popup:
            <img width="309" height="220" alt="Screenshot 2026-02-02 at 3 44 38 PM" src="https://github.com/user-attachments/assets/ddfb6b2b-b14a-47d6-ac4c-dc3408da8fc7" />
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
