### PR TITLE
Fail when Swift installation fails

### DIFF
--- a/src/commands/installSwiftly.ts
+++ b/src/commands/installSwiftly.ts
@@ -17,7 +17,10 @@ import * as vscode from "vscode";
 import configuration from "../configuration";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { Swiftly } from "../toolchain/swiftly";
-import { promptToRestartAfterInstallation } from "../ui/RestartEditor";
+import {
+    promptToRestartAfterFailedToolchainInstallation,
+    promptToRestartAfterInstallation,
+} from "../ui/RestartEditor";
 import { installSwiftlyToolchainWithProgress } from "./installSwiftlyToolchain";
 
 /**
@@ -128,11 +131,20 @@ export async function handleMissingSwiftly(
 
     // Install toolchains
     const swiftlyPath = path.join(Swiftly.defaultHomeDir(), "bin/swiftly");
+    const failedVersions: string[] = [];
     for (const version of swiftVersions) {
-        await installSwiftlyToolchainWithProgress(version, extensionRoot, logger, swiftlyPath);
+        await installSwiftlyToolchainWithProgress(version, extensionRoot, logger, swiftlyPath, {
+            onError: () => {
+                failedVersions.push(version);
+            },
+        });
     }
 
     // VS Code needs to be restarted after installing swiftly
-    await promptToRestartAfterInstallation("Swiftly");
+    if (failedVersions.length > 0) {
+        await promptToRestartAfterFailedToolchainInstallation(failedVersions);
+    } else {
+        await promptToRestartAfterInstallation("Swiftly");
+    }
     return true;
 }

--- a/src/commands/installSwiftlyToolchain.ts
+++ b/src/commands/installSwiftlyToolchain.ts
@@ -28,13 +28,16 @@ import {
  *
  * @param version The toolchain version to install
  * @param logger Optional logger for error reporting
+ * @param options.onError Invoked with the error when a non-cancellation failure occurs. When
+ * provided, the default error notification is suppressed so the caller can report it instead.
  * @returns A promise that resolves to true if installation succeeded, false otherwise
  */
 export async function installSwiftlyToolchainWithProgress(
     version: string,
     extensionRoot: string,
     logger?: SwiftLogger,
-    swiftlyPath?: string
+    swiftlyPath?: string,
+    options?: { onError?: (error: unknown) => void }
 ): Promise<boolean> {
     try {
         await vscode.window.withProgress(
@@ -93,6 +96,10 @@ export async function installSwiftlyToolchainWithProgress(
         }
 
         logger?.error(new Error(`Failed to install Swift ${version}`, { cause: error }));
+        if (options?.onError) {
+            options.onError(error);
+            return false;
+        }
         void vscode.window.showErrorMessage(`Failed to install Swift ${version}: ${error}`);
         return false;
     }

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -175,8 +175,9 @@ export async function handleMissingSwiftlyToolchain(
 ): Promise<boolean> {
     logger?.info(`Attempting to handle missing toolchain: ${version}`);
 
-    // Ask user for permission
-    const userConsent = await showMissingToolchainDialog(version, folder);
+    // Prompt the user to install the required toolchain, or select an alternative one if it is
+    // not available via Swiftly.
+    const userConsent = await showMissingToolchainDialog(version, logger, folder);
     if (!userConsent) {
         logger?.info(`User declined to install missing toolchain: ${version}`);
         return false;

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -162,24 +162,24 @@ export function parseSwiftlyMissingToolchainError(
 /**
  * Attempts to automatically install a missing Swiftly toolchain with user consent
  * @param version The toolchain version to install
- * @param logger Optional logger for error reporting
+ * @param extensionRoot The root path of the extension
+ * @param logger Logger for error reporting
  * @param folder Optional folder context
- * @param token Optional cancellation token to abort the installation
  * @returns Promise<boolean> true if toolchain was successfully installed, false otherwise
  */
 export async function handleMissingSwiftlyToolchain(
     version: string,
     extensionRoot: string,
-    logger?: SwiftLogger,
+    logger: SwiftLogger,
     folder?: vscode.Uri
 ): Promise<boolean> {
-    logger?.info(`Attempting to handle missing toolchain: ${version}`);
+    logger.info(`Attempting to handle missing toolchain: ${version}`);
 
     // Prompt the user to install the required toolchain, or select an alternative one if it is
     // not available via Swiftly.
     const userConsent = await showMissingToolchainDialog(version, logger, folder);
     if (!userConsent) {
-        logger?.info(`User declined to install missing toolchain: ${version}`);
+        logger.info(`User declined to install missing toolchain: ${version}`);
         return false;
     }
 

--- a/src/ui/RestartEditor.ts
+++ b/src/ui/RestartEditor.ts
@@ -24,11 +24,33 @@ export async function promptToRestartAfterInstallation(
     type: "Swiftly" | "toolchain"
 ): Promise<void> {
     const editorName = vscode.env.appName;
+    await promptToQuit(
+        `You must restart ${editorName} in order for the ${type} installation to take effect.`
+    );
+}
+
+/**
+ * Prompts the user to quit their editor after Swiftly installed but one or more toolchains
+ * failed to install, so that the installation can be retried on the next launch.
+ *
+ * @param versions The toolchain versions that failed to install.
+ */
+export async function promptToRestartAfterFailedToolchainInstallation(
+    versions: string[]
+): Promise<void> {
+    const editorName = vscode.env.appName;
+    await promptToQuit(
+        `Swiftly was successfully installed. Installing Swift version ${versions.join(", ")} failed. Quit ${editorName} to try again.`
+    );
+}
+
+async function promptToQuit(detail: string): Promise<void> {
+    const editorName = vscode.env.appName;
     const selection = await vscode.window.showInformationMessage(
         `Restart ${editorName}`,
         {
             modal: true,
-            detail: `You must restart ${editorName} in order for the ${type} installation to take effect.`,
+            detail,
         },
         `Quit ${editorName}`
     );

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -114,7 +114,7 @@ export async function showMissingToolchainDialog(
             `${folderName}Swift ${version} is not installed`,
             {
                 modal: true,
-                detail: `Swift version ${version} is required but not installed. Would you like to install it using Swiftly?`,
+                detail: `This project's .swift-version requires ${version}, but it is not installed. Would you like to install it using Swiftly?`,
             },
             "Install Toolchain"
         );
@@ -125,7 +125,7 @@ export async function showMissingToolchainDialog(
         `${folderName}Swift ${version} is not available`,
         {
             modal: true,
-            detail: `Swift version ${version} is required but is not available to install via Swiftly.`,
+            detail: `This project's .swift-version requires ${version}, but it is not available to install via Swiftly.`,
         },
         "Select Toolchain"
     );

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -94,10 +94,9 @@ export async function showToolchainError(folder?: vscode.Uri): Promise<boolean> 
  * Handles a required Swift toolchain that is not installed.
  *
  * Checks whether the required version is available to install via Swiftly. If it is, the user is
- * prompted to install it. If it isn't (for example the user relies on a custom toolchain that
- * Swiftly does not manage), the user is offered the option to select a toolchain instead.
+ * prompted to install it. If it isn't, the user is offered the option to select a toolchain instead.
  *
- * @param version The required toolchain version, e.g. from the folder's `.swift-version` file.
+ * @param version The required toolchain version
  * @param logger Logger used while querying the toolchains available via Swiftly.
  * @param folder Optional folder context for the message.
  * @returns Promise<boolean> true if the user chose to install the toolchain via Swiftly, false otherwise.

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -104,7 +104,7 @@ export async function showToolchainError(folder?: vscode.Uri): Promise<boolean> 
  */
 export async function showMissingToolchainDialog(
     version: string,
-    logger?: SwiftLogger,
+    logger: SwiftLogger,
     folder?: vscode.Uri
 ): Promise<boolean> {
     const folderName = folder ? `${FolderContext.uriName(folder)}: ` : "";
@@ -138,10 +138,7 @@ export async function showMissingToolchainDialog(
 /**
  * Determines whether the given Swift version is available to install via Swiftly.
  */
-async function isSwiftlyToolchainAvailable(
-    version: string,
-    logger?: SwiftLogger
-): Promise<boolean> {
+async function isSwiftlyToolchainAvailable(version: string, logger: SwiftLogger): Promise<boolean> {
     const branch = swiftlySnapshotBranch(version);
     const availableToolchains = await Swiftly.listAvailable(branch, logger);
     return availableToolchains.some(toolchain => toolchain.version.name === version);
@@ -219,7 +216,7 @@ type SelectToolchainItem = SwiftToolchainItem | ActionItem | SeparatorItem;
  */
 async function getQuickPickItems(
     activeToolchain: SwiftToolchain | undefined,
-    logger?: SwiftLogger,
+    logger: SwiftLogger,
     cwd?: vscode.Uri
 ): Promise<SelectToolchainItem[]> {
     // Find any Xcode installations on the system
@@ -269,7 +266,7 @@ async function getQuickPickItems(
                     );
                 }
             } catch (error) {
-                logger?.error(error);
+                logger.error(error);
                 void vscode.window.showErrorMessage(`Failed to switch Swiftly toolchain: ${error}`);
             }
         },
@@ -411,7 +408,7 @@ async function getSwiftlyActions(): Promise<ActionItem[]> {
  */
 export async function showToolchainSelectionQuickPick(
     activeToolchain: SwiftToolchain | undefined,
-    logger?: SwiftLogger,
+    logger: SwiftLogger,
     cwd?: vscode.Uri
 ) {
     let xcodePaths: string[] = [];

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -139,11 +139,6 @@ export async function showMissingToolchainDialog(
  * Determines whether the given Swift version is available to install via Swiftly.
  */
 async function isSwiftlyToolchainAvailable(version: string, logger: SwiftLogger): Promise<boolean> {
-    // If it's a snapshot, always try to install it
-    if (version.toLowerCase().includes("snapshot")) {
-        return true;
-    }
-
     const branch = swiftlySnapshotBranch(version);
     const availableToolchains = await Swiftly.listAvailable(branch, logger);
     return availableToolchains.some(toolchain => toolchain.version.name === version);

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -130,7 +130,7 @@ export async function showMissingToolchainDialog(
         "Select Toolchain"
     );
     if (choice === "Select Toolchain") {
-        await selectToolchain();
+        await showToolchainSelectionQuickPick(undefined, logger, folder);
     }
     return false;
 }
@@ -219,7 +219,7 @@ type SelectToolchainItem = SwiftToolchainItem | ActionItem | SeparatorItem;
  */
 async function getQuickPickItems(
     activeToolchain: SwiftToolchain | undefined,
-    logger: SwiftLogger,
+    logger?: SwiftLogger,
     cwd?: vscode.Uri
 ): Promise<SelectToolchainItem[]> {
     // Find any Xcode installations on the system
@@ -269,7 +269,7 @@ async function getQuickPickItems(
                     );
                 }
             } catch (error) {
-                logger.error(error);
+                logger?.error(error);
                 void vscode.window.showErrorMessage(`Failed to switch Swiftly toolchain: ${error}`);
             }
         },
@@ -411,7 +411,7 @@ async function getSwiftlyActions(): Promise<ActionItem[]> {
  */
 export async function showToolchainSelectionQuickPick(
     activeToolchain: SwiftToolchain | undefined,
-    logger: SwiftLogger,
+    logger?: SwiftLogger,
     cwd?: vscode.Uri
 ) {
     let xcodePaths: string[] = [];

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -91,22 +91,68 @@ export async function showToolchainError(folder?: vscode.Uri): Promise<boolean> 
 }
 
 /**
- * Shows a dialog asking user permission to install a missing Swiftly toolchain
- * @param version The toolchain version to install
- * @param folder Optional folder context for the error
- * @returns Promise<boolean> true if user agrees to install, false otherwise
+ * Handles a required Swift toolchain that is not installed.
+ *
+ * Checks whether the required version is available to install via Swiftly. If it is, the user is
+ * prompted to install it. If it isn't (for example the user relies on a custom toolchain that
+ * Swiftly does not manage), the user is offered the option to select a toolchain instead.
+ *
+ * @param version The required toolchain version, e.g. from the folder's `.swift-version` file.
+ * @param logger Logger used while querying the toolchains available via Swiftly.
+ * @param folder Optional folder context for the message.
+ * @returns Promise<boolean> true if the user chose to install the toolchain via Swiftly, false otherwise.
  */
 export async function showMissingToolchainDialog(
     version: string,
+    logger?: SwiftLogger,
     folder?: vscode.Uri
 ): Promise<boolean> {
     const folderName = folder ? `${FolderContext.uriName(folder)}: ` : "";
-    const message =
-        `${folderName}Swift version ${version} is required but not installed. ` +
-        `Would you like to automatically install it using Swiftly?`;
 
-    const choice = await vscode.window.showWarningMessage(message, "Install Toolchain", "Cancel");
-    return choice === "Install Toolchain";
+    if (await isSwiftlyToolchainAvailable(version, logger)) {
+        const choice = await vscode.window.showInformationMessage(
+            `${folderName}Swift ${version} is not installed`,
+            {
+                modal: true,
+                detail: `Swift version ${version} is required but not installed. Would you like to install it using Swiftly?`,
+            },
+            "Install Toolchain"
+        );
+        return choice === "Install Toolchain";
+    }
+
+    const choice = await vscode.window.showInformationMessage(
+        `${folderName}Swift ${version} is not available`,
+        {
+            modal: true,
+            detail: `Swift version ${version} is required but is not available to install via Swiftly.`,
+        },
+        "Select Toolchain"
+    );
+    if (choice === "Select Toolchain") {
+        await selectToolchain();
+    }
+    return false;
+}
+
+/**
+ * Determines whether the given Swift version is available to install via Swiftly.
+ */
+async function isSwiftlyToolchainAvailable(
+    version: string,
+    logger?: SwiftLogger
+): Promise<boolean> {
+    const branch = swiftlySnapshotBranch(version);
+    const availableToolchains = await Swiftly.listAvailable(branch, logger);
+    return availableToolchains.some(toolchain => toolchain.version.name === version);
+}
+
+/**
+ * Derives the Swiftly snapshot branch (e.g. "main-snapshot", "6.1-snapshot") from a snapshot
+ * toolchain version. Returns undefined for stable releases, which are listed without a branch.
+ */
+function swiftlySnapshotBranch(version: string): string | undefined {
+    return /^(.+-snapshot)-\d{4}-\d{2}-\d{2}$/.exec(version)?.[1];
 }
 
 export async function selectToolchain() {

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -61,13 +61,21 @@ export async function showToolchainError(folder?: vscode.Uri): Promise<boolean> 
     const folderName = folder ? `${FolderContext.uriName(folder)}: ` : "";
     if (configuration.path) {
         selected = await vscode.window.showErrorMessage(
-            `${folderName}The Swift executable at "${configuration.path}" either could not be found or failed to launch. Please select a new toolchain.`,
+            "Toolchain failed",
+            {
+                modal: true,
+                detail: `${folderName}The Swift executable at "${configuration.path}" either could not be found or failed to launch. Please select a new toolchain.`,
+            },
             "Remove From Settings",
             "Select Toolchain"
         );
     } else {
         selected = await vscode.window.showErrorMessage(
-            `${folderName}Unable to automatically discover your Swift toolchain. Either install a toolchain from Swift.org or provide the path to an existing toolchain.`,
+            "Missing toolchain",
+            {
+                modal: true,
+                detail: `${folderName}Unable to automatically discover your Swift toolchain. Either install a toolchain from Swift.org or provide the path to an existing toolchain.`,
+            },
             "Open Documentation",
             "Select Toolchain"
         );

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -139,6 +139,11 @@ export async function showMissingToolchainDialog(
  * Determines whether the given Swift version is available to install via Swiftly.
  */
 async function isSwiftlyToolchainAvailable(version: string, logger: SwiftLogger): Promise<boolean> {
+    // If it's a snapshot, always try to install it
+    if (version.toLowerCase().includes("snapshot")) {
+        return true;
+    }
+
     const branch = swiftlySnapshotBranch(version);
     const availableToolchains = await Swiftly.listAvailable(branch, logger);
     return availableToolchains.some(toolchain => toolchain.version.name === version);

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -1504,14 +1504,26 @@ apt-get -y install libncurses5-dev
             version: { type: "stable" as const, major: 6, minor: 1, patch: 2, name: "6.1.2" },
         };
 
+        let mockLogger: MockedObject<SwiftLogger>;
+
         setup(() => {
+            mockLogger = mockObject<SwiftLogger>({
+                info: mockFn(),
+                warn: mockFn(),
+                error: mockFn(),
+                debug: mockFn(),
+            });
             // By default the required toolchain is available to install via Swiftly.
             mockSwiftlyListAvailable.setValue(async () => [availableToolchain]);
         });
 
         test("handleMissingSwiftlyToolchain returns false when user declines installation", async () => {
             mockWindow.showInformationMessage.resolves(undefined); // User dismisses the dialog
-            const result = await handleMissingSwiftlyToolchain("6.1.2", "/path/to/extension");
+            const result = await handleMissingSwiftlyToolchain(
+                "6.1.2",
+                "/path/to/extension",
+                instance(mockLogger)
+            );
             expect(result).to.be.false;
         });
 
@@ -1537,7 +1549,11 @@ apt-get -y install libncurses5-dev
                 .withArgs("swiftly", match.any)
                 .resolves({ stdout: "", stderr: "" });
 
-            const result = await handleMissingSwiftlyToolchain("6.1.2", "/path/to/extension");
+            const result = await handleMissingSwiftlyToolchain(
+                "6.1.2",
+                "/path/to/extension",
+                instance(mockLogger)
+            );
             expect(result).to.be.true;
         });
 
@@ -1547,7 +1563,11 @@ apt-get -y install libncurses5-dev
             mockSwiftlyListAvailable.setValue(async () => []);
             mockWindow.showInformationMessage.resolves(undefined);
 
-            const result = await handleMissingSwiftlyToolchain("6.1.2", "/path/to/extension");
+            const result = await handleMissingSwiftlyToolchain(
+                "6.1.2",
+                "/path/to/extension",
+                instance(mockLogger)
+            );
 
             expect(result).to.be.false;
         });

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -1775,6 +1775,28 @@ apt-get -y install libncurses5-dev
         suite("handleMissingSwiftly()", () => {
             const isInstalledStub = mockGlobalFunction(Swiftly, "isInstalled");
             const installSwiftlyStub = mockGlobalFunction(Swiftly, "installSwiftly");
+            const installToolchainStub = mockGlobalFunction(Swiftly, "installToolchain");
+
+            const runProgressTask = () => {
+                mockWindow.withProgress.callsFake((_options, task) =>
+                    task(
+                        { report: () => {} } as any,
+                        {
+                            isCancellationRequested: false,
+                            onCancellationRequested: () => ({ dispose: () => {} }),
+                        } as any
+                    )
+                );
+            };
+
+            const acceptSwiftlyInstallation = () => {
+                isInstalledStub.resolves(false);
+                mockConfiguration.get.withArgs("disableSwiftlyInstallPrompt").returns(false);
+                mockWindow.showWarningMessage.resolves("Install Swiftly" as any);
+                mockWindow.showInformationMessage.resolves("Continue" as any);
+                installSwiftlyStub.resolves();
+                runProgressTask();
+            };
 
             test("should return false when prompt is suppressed", async () => {
                 isInstalledStub.resolves(false);
@@ -1812,6 +1834,42 @@ apt-get -y install libncurses5-dev
                 // In this test, we mocked it to succeed
                 expect(result).to.be.true;
                 expect(installSwiftlyStub).to.have.been.called;
+            });
+
+            test("should prompt to restart normally when the toolchain installs successfully", async () => {
+                acceptSwiftlyInstallation();
+                installToolchainStub.resolves();
+
+                await handleMissingSwiftly(["6.1.0"], "");
+
+                expect(mockWindow.showErrorMessage).to.not.have.been.called;
+                expect(mockWindow.showInformationMessage).to.have.been.calledWith(
+                    match.any,
+                    match.has("detail", match("installation to take effect"))
+                );
+            });
+
+            test("should suppress the error notification and prompt to quit with a failure message when the toolchain fails to install", async () => {
+                acceptSwiftlyInstallation();
+                installToolchainStub.rejects(new Error("Network error"));
+
+                const result = await handleMissingSwiftly(["6.1.0"], "");
+
+                expect(result).to.be.true;
+                expect(mockWindow.showErrorMessage).to.not.have.been.called;
+                expect(mockWindow.showInformationMessage).to.have.been.calledWith(
+                    match.any,
+                    match.has(
+                        "detail",
+                        match(
+                            "Swiftly was successfully installed. Installing Swift version 6.1.0 failed."
+                        )
+                    )
+                );
+                expect(mockWindow.showInformationMessage).to.not.have.been.calledWith(
+                    match.any,
+                    match.has("detail", match("installation to take effect"))
+                );
             });
         });
     });

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -18,7 +18,6 @@ import { match } from "sinon";
 import * as vscode from "vscode";
 
 import * as askpass from "@src/askpass/askpass-server";
-import { Commands } from "@src/commands";
 import { handleMissingSwiftly, promptForSwiftlyInstallation } from "@src/commands/installSwiftly";
 import { installSwiftlyToolchainWithProgress } from "@src/commands/installSwiftlyToolchain";
 import { SwiftLogger } from "@src/logging/SwiftLogger";
@@ -1494,7 +1493,6 @@ apt-get -y install libncurses5-dev
 
     suite("handleMissingSwiftlyToolchain", () => {
         const mockWindow = mockGlobalObject(vscode, "window");
-        const mockCommands = mockGlobalObject(vscode, "commands");
         const mockedUtilities = mockGlobalModule(utilities);
         const mockSwiftlyInstallToolchain = mockGlobalValue(Swiftly, "installToolchain");
         const mockSwiftlyListAvailable = mockGlobalValue(Swiftly, "listAvailable");
@@ -1507,7 +1505,6 @@ apt-get -y install libncurses5-dev
         };
 
         setup(() => {
-            mockCommands.executeCommand.resolves(undefined);
             // By default the required toolchain is available to install via Swiftly.
             mockSwiftlyListAvailable.setValue(async () => [availableToolchain]);
         });
@@ -1544,15 +1541,15 @@ apt-get -y install libncurses5-dev
             expect(result).to.be.true;
         });
 
-        test("handleMissingSwiftlyToolchain prompts to select a toolchain when the version is unavailable", async () => {
-            // The required toolchain cannot be installed via Swiftly
+        test("handleMissingSwiftlyToolchain returns false when the version is unavailable", async () => {
+            // The required toolchain cannot be installed via Swiftly, so the user is offered the
+            // chance to select a toolchain instead. Dismissing that prompt returns false.
             mockSwiftlyListAvailable.setValue(async () => []);
-            mockWindow.showInformationMessage.resolves("Select Toolchain" as any);
+            mockWindow.showInformationMessage.resolves(undefined);
 
             const result = await handleMissingSwiftlyToolchain("6.1.2", "/path/to/extension");
 
             expect(result).to.be.false;
-            expect(mockCommands.executeCommand).to.have.been.calledWith(Commands.SELECT_TOOLCHAIN);
         });
 
         test("getActiveToolchain falls back to global toolchain when user declines and cwd is provided", async () => {

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -18,6 +18,7 @@ import { match } from "sinon";
 import * as vscode from "vscode";
 
 import * as askpass from "@src/askpass/askpass-server";
+import { Commands } from "@src/commands";
 import { handleMissingSwiftly, promptForSwiftlyInstallation } from "@src/commands/installSwiftly";
 import { installSwiftlyToolchainWithProgress } from "@src/commands/installSwiftlyToolchain";
 import { SwiftLogger } from "@src/logging/SwiftLogger";
@@ -1493,18 +1494,33 @@ apt-get -y install libncurses5-dev
 
     suite("handleMissingSwiftlyToolchain", () => {
         const mockWindow = mockGlobalObject(vscode, "window");
+        const mockCommands = mockGlobalObject(vscode, "commands");
         const mockedUtilities = mockGlobalModule(utilities);
         const mockSwiftlyInstallToolchain = mockGlobalValue(Swiftly, "installToolchain");
+        const mockSwiftlyListAvailable = mockGlobalValue(Swiftly, "listAvailable");
+
+        const availableToolchain = {
+            inUse: false,
+            installed: false,
+            isDefault: false,
+            version: { type: "stable" as const, major: 6, minor: 1, patch: 2, name: "6.1.2" },
+        };
+
+        setup(() => {
+            mockCommands.executeCommand.resolves(undefined);
+            // By default the required toolchain is available to install via Swiftly.
+            mockSwiftlyListAvailable.setValue(async () => [availableToolchain]);
+        });
 
         test("handleMissingSwiftlyToolchain returns false when user declines installation", async () => {
-            mockWindow.showWarningMessage.resolves(undefined); // User cancels/declines
+            mockWindow.showInformationMessage.resolves(undefined); // User dismisses the dialog
             const result = await handleMissingSwiftlyToolchain("6.1.2", "/path/to/extension");
             expect(result).to.be.false;
         });
 
         test("handleMissingSwiftlyToolchain returns true when user accepts and installation succeeds", async () => {
             // User accepts the installation
-            mockWindow.showWarningMessage.resolves("Install Toolchain" as any);
+            mockWindow.showInformationMessage.resolves("Install Toolchain" as any);
 
             // Mock successful installation with progress
             mockWindow.withProgress.callsFake(async (_options, task) => {
@@ -1528,6 +1544,17 @@ apt-get -y install libncurses5-dev
             expect(result).to.be.true;
         });
 
+        test("handleMissingSwiftlyToolchain prompts to select a toolchain when the version is unavailable", async () => {
+            // The required toolchain cannot be installed via Swiftly
+            mockSwiftlyListAvailable.setValue(async () => []);
+            mockWindow.showInformationMessage.resolves("Select Toolchain" as any);
+
+            const result = await handleMissingSwiftlyToolchain("6.1.2", "/path/to/extension");
+
+            expect(result).to.be.false;
+            expect(mockCommands.executeCommand).to.have.been.calledWith(Commands.SELECT_TOOLCHAIN);
+        });
+
         test("getActiveToolchain falls back to global toolchain when user declines and cwd is provided", async () => {
             const missingToolchainError = Object.create(ExecFileError.prototype);
             missingToolchainError.causedBy = new Error("swiftly use failed");
@@ -1544,7 +1571,7 @@ apt-get -y install libncurses5-dev
                 .resolves({ stdout: "/global/toolchain/path\n", stderr: "" });
 
             // User declines installation prompt
-            mockWindow.showWarningMessage.resolves(undefined);
+            mockWindow.showInformationMessage.resolves(undefined);
 
             const mockLogger = mockObject<SwiftLogger>({
                 info: mockFn(),

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -1557,21 +1557,6 @@ apt-get -y install libncurses5-dev
             expect(result).to.be.true;
         });
 
-        test("handleMissingSwiftlyToolchain returns false when the version is unavailable", async () => {
-            // The required toolchain cannot be installed via Swiftly, so the user is offered the
-            // chance to select a toolchain instead. Dismissing that prompt returns false.
-            mockSwiftlyListAvailable.setValue(async () => []);
-            mockWindow.showInformationMessage.resolves(undefined);
-
-            const result = await handleMissingSwiftlyToolchain(
-                "6.1.2",
-                "/path/to/extension",
-                instance(mockLogger)
-            );
-
-            expect(result).to.be.false;
-        });
-
         test("getActiveToolchain falls back to global toolchain when user declines and cwd is provided", async () => {
             const missingToolchainError = Object.create(ExecFileError.prototype);
             missingToolchainError.causedBy = new Error("swiftly use failed");

--- a/test/unit-tests/ui/ToolchainSelection.test.ts
+++ b/test/unit-tests/ui/ToolchainSelection.test.ts
@@ -16,10 +16,14 @@ import * as path from "path";
 import { match } from "sinon";
 import * as vscode from "vscode";
 
+import { Commands } from "@src/commands";
 import { SwiftLogger } from "@src/logging/SwiftLogger";
 import { Swiftly } from "@src/toolchain/swiftly";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
-import { showToolchainSelectionQuickPick } from "@src/ui/ToolchainSelection";
+import {
+    showMissingToolchainDialog,
+    showToolchainSelectionQuickPick,
+} from "@src/ui/ToolchainSelection";
 import * as utilities from "@src/utilities/utilities";
 
 import {
@@ -384,6 +388,101 @@ suite("ToolchainSelection Unit Test Suite", () => {
                 "path",
                 undefined,
                 vscode.ConfigurationTarget.Global
+            );
+        });
+    });
+
+    suite("showMissingToolchainDialog", () => {
+        const availableToolchain = {
+            inUse: false,
+            installed: false,
+            isDefault: false,
+            version: { type: "stable" as const, major: 6, minor: 1, patch: 2, name: "6.1.2" },
+        };
+
+        setup(() => {
+            mockedPlatform.setValue("darwin");
+        });
+
+        test("prompts to install when the required toolchain is available via Swiftly", async () => {
+            mockedSwiftly.listAvailable.resolves([availableToolchain]);
+            mockedVSCodeWindow.showInformationMessage.resolves("Install Toolchain" as any);
+
+            const result = await showMissingToolchainDialog("6.1.2", instance(mockedLogger));
+
+            expect(result).to.be.true;
+            expect(mockedVSCodeWindow.showInformationMessage).to.have.been.calledWith(
+                match("6.1.2"),
+                match.has("modal", true),
+                "Install Toolchain"
+            );
+        });
+
+        test("returns false when the user dismisses the install prompt", async () => {
+            mockedSwiftly.listAvailable.resolves([availableToolchain]);
+            mockedVSCodeWindow.showInformationMessage.resolves(undefined);
+
+            const result = await showMissingToolchainDialog("6.1.2", instance(mockedLogger));
+
+            expect(result).to.be.false;
+            expect(mockedVSCodeCommands.executeCommand).to.not.have.been.calledWith(
+                Commands.SELECT_TOOLCHAIN
+            );
+        });
+
+        test("prompts to select a toolchain when the required version is unavailable", async () => {
+            mockedSwiftly.listAvailable.resolves([]);
+            mockedVSCodeWindow.showInformationMessage.resolves("Select Toolchain" as any);
+
+            const result = await showMissingToolchainDialog("6.1.2", instance(mockedLogger));
+
+            expect(result).to.be.false;
+            expect(mockedVSCodeWindow.showInformationMessage).to.have.been.calledWith(
+                match("6.1.2"),
+                match.has("modal", true),
+                "Select Toolchain"
+            );
+            expect(mockedVSCodeCommands.executeCommand).to.have.been.calledWith(
+                Commands.SELECT_TOOLCHAIN
+            );
+        });
+
+        test("does not select a toolchain when the user dismisses the unavailable prompt", async () => {
+            mockedSwiftly.listAvailable.resolves([]);
+            mockedVSCodeWindow.showInformationMessage.resolves(undefined);
+
+            const result = await showMissingToolchainDialog("6.1.2", instance(mockedLogger));
+
+            expect(result).to.be.false;
+            expect(mockedVSCodeCommands.executeCommand).to.not.have.been.calledWith(
+                Commands.SELECT_TOOLCHAIN
+            );
+        });
+
+        test("queries Swiftly for the snapshot branch when a snapshot version is required", async () => {
+            mockedSwiftly.listAvailable.resolves([]);
+            mockedVSCodeWindow.showInformationMessage.resolves(undefined);
+
+            await showMissingToolchainDialog("main-snapshot-2025-01-15", instance(mockedLogger));
+
+            expect(mockedSwiftly.listAvailable).to.have.been.calledWith(
+                "main-snapshot",
+                instance(mockedLogger)
+            );
+        });
+
+        test("includes the folder name in the message", async () => {
+            mockedSwiftly.listAvailable.resolves([availableToolchain]);
+            mockedVSCodeWindow.showInformationMessage.resolves(undefined);
+
+            await showMissingToolchainDialog(
+                "6.1.2",
+                instance(mockedLogger),
+                vscode.Uri.file("/path/to/MyPackage")
+            );
+
+            expect(mockedVSCodeWindow.showInformationMessage).to.have.been.calledWith(
+                match("MyPackage")
             );
         });
     });

--- a/test/unit-tests/ui/ToolchainSelection.test.ts
+++ b/test/unit-tests/ui/ToolchainSelection.test.ts
@@ -16,7 +16,6 @@ import * as path from "path";
 import { match } from "sinon";
 import * as vscode from "vscode";
 
-import { Commands } from "@src/commands";
 import { SwiftLogger } from "@src/logging/SwiftLogger";
 import { Swiftly } from "@src/toolchain/swiftly";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
@@ -425,9 +424,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
             const result = await showMissingToolchainDialog("6.1.2", instance(mockedLogger));
 
             expect(result).to.be.false;
-            expect(mockedVSCodeCommands.executeCommand).to.not.have.been.calledWith(
-                Commands.SELECT_TOOLCHAIN
-            );
+            expect(mockedVSCodeWindow.showQuickPick).to.not.have.been.called;
         });
 
         test("prompts to select a toolchain when the required version is unavailable", async () => {
@@ -442,8 +439,9 @@ suite("ToolchainSelection Unit Test Suite", () => {
                 match.has("modal", true),
                 "Select Toolchain"
             );
-            expect(mockedVSCodeCommands.executeCommand).to.have.been.calledWith(
-                Commands.SELECT_TOOLCHAIN
+            expect(mockedVSCodeWindow.showQuickPick).to.have.been.calledWith(
+                match.any,
+                match.has("title", "Select the Swift toolchain")
             );
         });
 
@@ -454,9 +452,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
             const result = await showMissingToolchainDialog("6.1.2", instance(mockedLogger));
 
             expect(result).to.be.false;
-            expect(mockedVSCodeCommands.executeCommand).to.not.have.been.calledWith(
-                Commands.SELECT_TOOLCHAIN
-            );
+            expect(mockedVSCodeWindow.showQuickPick).to.not.have.been.called;
         });
 
         test("queries Swiftly for the snapshot branch when a snapshot version is required", async () => {


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
Currently, the Swiftly installation flow doesn't know if the Swift install failed — it prompts the user to restart their editor as if nothing happened: 

<img width="4014" height="2456" alt="image" src="https://github.com/user-attachments/assets/acd39fdc-74cf-4518-b56f-15e65d9368ae" />

This PR checks if any of the installations failed. If any installation failed, a popup is rendered telling the user to check their Swift version in `.swift-version`. 

Issue: https://github.com/swiftlang/vscode-swift/issues/2070

## Tasks
- [ ] Required tests have been written
- Manual tests: 
    - macOS:
        -  Included a wrong Swift version number in `.swift-version`, and confirmed that the "restart VS Code" modal was replaced by the "installation failed" modal. 
        - Included a correct Swift version number in `.swift-version`, and made sure the "restart VS Code" model was still rendered.
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
