### PR TITLE
Avoid duplicated toolchains in Select Toolchain picker

### DIFF
--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -221,8 +221,42 @@ async function getQuickPickItems(
                 swiftFolderPath: path.join(toolchainPath, "bin"),
             };
         });
-    // Find any public Swift toolchains on the system
+    // Find any Swift toolchains installed via Swiftly
+    const installedSwiftlyToolchains = await Swiftly.list(logger);
+    const swiftlyLocations = new Set(
+        installedSwiftlyToolchains
+            .map(t => t.location)
+            .filter((loc): loc is string => loc !== undefined)
+    );
+    const swiftlyToolchains = installedSwiftlyToolchains.map<SwiftlyToolchainItem>(toolchain => ({
+        type: "toolchain",
+        label: toolchain.name,
+        category: "swiftly",
+        version: toolchain.name,
+        onDidSelect: async target => {
+            try {
+                if (target === vscode.ConfigurationTarget.Global) {
+                    await Swiftly.use(toolchain.name);
+                } else {
+                    await Promise.all(
+                        vscode.workspace.workspaceFolders?.map(async folder => {
+                            await Swiftly.use(toolchain.name, folder.uri.fsPath);
+                        }) ?? []
+                    );
+                }
+                void showReloadExtensionNotification(
+                    "Changing the Swift path requires Visual Studio Code be reloaded."
+                );
+            } catch (error) {
+                logger.error(error);
+                void vscode.window.showErrorMessage(`Failed to switch Swiftly toolchain: ${error}`);
+            }
+        },
+    }));
+
+    // Find any public Swift toolchains on the system, excluding those managed by swiftly
     const publicToolchains = (await SwiftToolchain.getToolchainInstalls())
+        .filter(toolchainPath => !swiftlyLocations.has(toolchainPath))
         // Sort in descending order alphabetically
         .sort((a, b) => -a.localeCompare(b))
         .map<SwiftToolchainItem>(toolchainPath => {
@@ -244,38 +278,6 @@ async function getQuickPickItems(
             }
             return result;
         });
-
-    // Find any Swift toolchains installed via Swiftly
-    const swiftlyToolchains = (await Swiftly.list(logger)).map<SwiftlyToolchainItem>(
-        toolchainPath => ({
-            type: "toolchain",
-            label: path.basename(toolchainPath),
-            category: "swiftly",
-            version: path.basename(toolchainPath),
-            onDidSelect: async target => {
-                try {
-                    const version = path.basename(toolchainPath);
-                    if (target === vscode.ConfigurationTarget.Global) {
-                        await Swiftly.use(version);
-                    } else {
-                        await Promise.all(
-                            vscode.workspace.workspaceFolders?.map(async folder => {
-                                await Swiftly.use(version, folder.uri.fsPath);
-                            }) ?? []
-                        );
-                    }
-                    void showReloadExtensionNotification(
-                        "Changing the Swift path requires Visual Studio Code be reloaded."
-                    );
-                } catch (error) {
-                    logger.error(error);
-                    void vscode.window.showErrorMessage(
-                        `Failed to switch Swiftly toolchain: ${error}`
-                    );
-                }
-            },
-        })
-    );
 
     if (activeToolchain) {
         let currentSwiftlyVersion: string | undefined = undefined;

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -126,7 +126,7 @@ suite("Swiftly Unit Tests", () => {
     });
 
     suite("list()", () => {
-        test("should return toolchain names from list command for version 1.1.0", async () => {
+        test("should return toolchain names and locations from list command for version 1.1.0", async () => {
             // Mock version check to return 1.1.0
             mockUtilities.execFile.withArgs("swiftly", ["--version"]).resolves({
                 stdout: "1.1.0\n",
@@ -140,6 +140,7 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: true,
                             isDefault: true,
+                            location: "/home/.swiftly/toolchains/swift-5.9.0-RELEASE",
                             version: {
                                 major: 5,
                                 minor: 9,
@@ -151,6 +152,7 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: true,
                             isDefault: true,
+                            location: "/home/.swiftly/toolchains/swift-5.10.0-RELEASE",
                             version: {
                                 major: 5,
                                 minor: 10,
@@ -162,6 +164,7 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: true,
                             isDefault: true,
+                            location: "/home/.swiftly/toolchains/swift-5.10.1-RELEASE",
                             version: {
                                 major: 5,
                                 minor: 10,
@@ -181,6 +184,8 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: false,
                             isDefault: false,
+                            location:
+                                "/home/.swiftly/toolchains/swift-DEVELOPMENT-SNAPSHOT-2021-10-15-a",
                             version: {
                                 major: 5,
                                 minor: 10,
@@ -193,6 +198,8 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: false,
                             isDefault: false,
+                            location:
+                                "/home/.swiftly/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
                             version: {
                                 major: 5,
                                 minor: 10,
@@ -205,6 +212,7 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: false,
                             isDefault: false,
+                            location: "/home/.swiftly/toolchains/swift-5.8.0-RELEASE",
                             version: {
                                 major: 5,
                                 minor: 8,
@@ -223,13 +231,31 @@ suite("Swiftly Unit Tests", () => {
             // Toolchains should be sorted newest to oldest with system toolchains appearing first, followed by
             // stable toolchains, and finally snapshot toolchains.
             expect(result).to.deep.equal([
-                "xcode",
-                "swift-5.10.1-RELEASE",
-                "swift-5.10.0-RELEASE",
-                "swift-5.9.0-RELEASE",
-                "swift-5.8.0-RELEASE",
-                "swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
-                "swift-DEVELOPMENT-SNAPSHOT-2021-10-15-a",
+                { name: "xcode", location: undefined },
+                {
+                    name: "swift-5.10.1-RELEASE",
+                    location: "/home/.swiftly/toolchains/swift-5.10.1-RELEASE",
+                },
+                {
+                    name: "swift-5.10.0-RELEASE",
+                    location: "/home/.swiftly/toolchains/swift-5.10.0-RELEASE",
+                },
+                {
+                    name: "swift-5.9.0-RELEASE",
+                    location: "/home/.swiftly/toolchains/swift-5.9.0-RELEASE",
+                },
+                {
+                    name: "swift-5.8.0-RELEASE",
+                    location: "/home/.swiftly/toolchains/swift-5.8.0-RELEASE",
+                },
+                {
+                    name: "swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
+                    location: "/home/.swiftly/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
+                },
+                {
+                    name: "swift-DEVELOPMENT-SNAPSHOT-2021-10-15-a",
+                    location: "/home/.swiftly/toolchains/swift-DEVELOPMENT-SNAPSHOT-2021-10-15-a",
+                },
             ]);
 
             expect(mockUtilities.execFile).to.have.been.calledWith("swiftly", ["--version"]);
@@ -271,6 +297,7 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: true,
                             isDefault: true,
+                            location: "/home/.swiftly/toolchains/swift-5.9.0-RELEASE",
                             version: {
                                 major: 5,
                                 minor: 9,
@@ -284,6 +311,7 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: false,
                             isDefault: false,
+                            location: "/home/.swiftly/toolchains/swift-5.8.0-RELEASE",
                             version: {
                                 major: 5,
                                 minor: 8,
@@ -297,6 +325,8 @@ suite("Swiftly Unit Tests", () => {
                         {
                             inUse: false,
                             isDefault: false,
+                            location:
+                                "/home/.swiftly/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
                             version: {
                                 major: 5,
                                 minor: 10,
@@ -316,10 +346,19 @@ suite("Swiftly Unit Tests", () => {
             const result = await Swiftly.list();
 
             expect(result).to.deep.equal([
-                "xcode",
-                "swift-5.9.0-RELEASE",
-                "swift-5.8.0-RELEASE",
-                "swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
+                { name: "xcode", location: undefined },
+                {
+                    name: "swift-5.9.0-RELEASE",
+                    location: "/home/.swiftly/toolchains/swift-5.9.0-RELEASE",
+                },
+                {
+                    name: "swift-5.8.0-RELEASE",
+                    location: "/home/.swiftly/toolchains/swift-5.8.0-RELEASE",
+                },
+                {
+                    name: "swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
+                    location: "/home/.swiftly/toolchains/swift-DEVELOPMENT-SNAPSHOT-2023-10-15-a",
+                },
             ]);
 
             expect(mockUtilities.execFile).to.have.been.calledWith("swiftly", ["--version"]);
@@ -347,7 +386,7 @@ suite("Swiftly Unit Tests", () => {
             const result = await Swiftly.list();
 
             // Toolchains should be sorted by name in descending order
-            expect(result).to.deep.equal(["swift-6.0.0", "swift-5.9.0"]);
+            expect(result).to.deep.equal([{ name: "swift-6.0.0" }, { name: "swift-5.9.0" }]);
         });
 
         test("should return empty array when platform is not supported", async () => {

--- a/test/unit-tests/ui/ToolchainSelection.test.ts
+++ b/test/unit-tests/ui/ToolchainSelection.test.ts
@@ -211,7 +211,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
 
         test("shows toolchains installed via Swiftly", async () => {
-            mockedSwiftly.list.resolves(["6.2.0", "6.0.0", "5.9.3"]);
+            mockedSwiftly.list.resolves([{ name: "6.2.0" }, { name: "6.0.0" }, { name: "5.9.3" }]);
             // Extract the Swiftly toolchain labels and simulate user cancellation
             let swiftlyToolchains: string[] = [];
             mockedVSCodeWindow.showQuickPick
@@ -229,7 +229,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
 
         test("user is able to set a Swiftly toolchain for their workspace", async () => {
-            mockedSwiftly.list.resolves(["6.2.0"]);
+            mockedSwiftly.list.resolves([{ name: "6.2.0" }]);
             mockedSwiftToolchain.findXcodeInstalls.resolves(["/Applications/Xcode.app"]);
             // User selects the first toolchain that appears
             mockedVSCodeWindow.showQuickPick
@@ -261,7 +261,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
 
         test("user is able to set a global Swiftly toolchain", async () => {
-            mockedSwiftly.list.resolves(["6.2.0"]);
+            mockedSwiftly.list.resolves([{ name: "6.2.0" }]);
             mockedSwiftToolchain.findXcodeInstalls.resolves(["/Applications/Xcode.app"]);
             mockedVSCodeWorkspace.workspaceFolders = [
                 {
@@ -303,7 +303,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
 
         test("shows toolchains installed via Swiftly", async () => {
-            mockedSwiftly.list.resolves(["6.2.0", "6.0.0", "5.9.3"]);
+            mockedSwiftly.list.resolves([{ name: "6.2.0" }, { name: "6.0.0" }, { name: "5.9.3" }]);
             // Extract the Swiftly toolchain labels and simulate user cancellation
             let swiftlyToolchains: string[] = [];
             mockedVSCodeWindow.showQuickPick
@@ -321,7 +321,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
 
         test("user is able to set a Swiftly toolchain for their workspace", async () => {
-            mockedSwiftly.list.resolves(["6.2.0"]);
+            mockedSwiftly.list.resolves([{ name: "6.2.0" }]);
             // User selects the first toolchain that appears
             mockedVSCodeWindow.showQuickPick
                 .withArgs(match.any, match.has("title", "Select the Swift toolchain"))
@@ -352,7 +352,7 @@ suite("ToolchainSelection Unit Test Suite", () => {
         });
 
         test("user is able to set a global Swiftly toolchain", async () => {
-            mockedSwiftly.list.resolves(["6.2.0"]);
+            mockedSwiftly.list.resolves([{ name: "6.2.0" }]);
             mockedVSCodeWorkspace.workspaceFolders = [
                 {
                     index: 0,


### PR DESCRIPTION
## Description
When the user does `> Swift: Select Toolchain` the quick picker that opens starts with a list of swiftly managed toolchains, and also contains a list of toolchains found on disk. This list has some overlap, as swiftly managed toolchains show up in the list of toolchains on disk.

The JSON output now includes a "location" field for each toolchain containing its on-disk path, matching the output of swiftly use --print-location. This enables tools like vscode-swift to identify duplicate toolchains when combining swiftly with system toolchains.

Prefer showing the swiftly toolchain and omit the on disk entry when a duplicate is found.

Issue: #1850

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [ ] Added an entry to CHANGELOG.md if applicable
