### PR TITLE
Improve error logging when starting sourcekit-lsp fails

### DIFF
--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -291,7 +291,9 @@ export class LanguageClientManager implements vscode.Disposable {
             this.currentWorkspaceFolder = folder;
             this.restartedPromise = this.setupLanguageClient(folder).catch(reason => {
                 this.folderContext.workspaceContext.logger.error(
-                    Error("Error starting SourceKit-LSP in setLanguageClientFolder", {cause: reason})
+                    Error("Error starting SourceKit-LSP in setLanguageClientFolder", {
+                        cause: reason,
+                    })
                 );
             });
             return;


### PR DESCRIPTION
## Description

There were some code paths that did not log failure if sourcekit-lsp failed to start.

## Tasks
- [x] ~Required tests have been written~
- [x] ~Documentation has been updated~
- [x] ~Added an entry to CHANGELOG.md if applicable~
