### PR TITLE
Refactor TestRunProxy into its own file, clean up docs

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -21,7 +21,7 @@ import { FolderContext as ExternalFolderContext } from "./SwiftExtensionApi";
 import { SwiftPackage, Target, TargetType } from "./SwiftPackage";
 import { TestExplorer } from "./TestExplorer/TestExplorer";
 import { TestRunManager } from "./TestExplorer/TestRunManager";
-import { TestRunProxy } from "./TestExplorer/TestRunner";
+import { TestRunProxy } from "./TestExplorer/TestRunProxy";
 import { FolderOperation, WorkspaceContext } from "./WorkspaceContext";
 import configuration from "./configuration";
 import { SwiftLogger } from "./logging/SwiftLogger";

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -28,7 +28,8 @@ import { LSPTestDiscovery } from "./LSPTestDiscovery";
 import { parseTestsFromSwiftTestListOutput } from "./SPMTestDiscovery";
 import { TestCodeLensProvider } from "./TestCodeLensProvider";
 import * as TestDiscovery from "./TestDiscovery";
-import { TestRunProxy, TestRunner } from "./TestRunner";
+import { TestRunProxy } from "./TestRunProxy";
+import { TestRunner } from "./TestRunner";
 import { flattenTestItemCollection } from "./TestUtils";
 
 /** Build test explorer UI */

--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
-import { TestRunProxy } from "./TestRunner";
+import { TestRunProxy } from "./TestRunProxy";
 import { reduceTestItemChildren } from "./TestUtils";
 
 type ProcessResult = {

--- a/src/TestExplorer/TestRunManager.ts
+++ b/src/TestExplorer/TestRunManager.ts
@@ -14,7 +14,7 @@
 import * as vscode from "vscode";
 
 import { FolderContext } from "../FolderContext";
-import { TestRunProxy } from "./TestRunner";
+import { TestRunProxy } from "./TestRunProxy";
 
 /**
  * Manages active test runs and provides functionality to check if a test run is in progress

--- a/src/TestExplorer/TestRunProxy.ts
+++ b/src/TestExplorer/TestRunProxy.ts
@@ -1,0 +1,587 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2021-2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { FolderContext } from "../FolderContext";
+import { TestCoverage } from "../coverage/LcovResults";
+import { CompositeCancellationToken } from "../utilities/cancellation";
+import { compactMap } from "../utilities/utilities";
+import { TestClass, runnableTag, upsertTestItem } from "./TestDiscovery";
+import { SymbolRenderer, TestSymbol } from "./TestParsers/SwiftTestingOutputParser";
+import { TestRunArguments } from "./TestRunArguments";
+import { TestLibrary } from "./TestRunner";
+import { reduceTestItemChildren } from "./TestUtils";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import stripAnsi = require("strip-ansi");
+
+/**
+ * Test only structure that stores the state of test items.
+ */
+export class TestRunState {
+    public pending: vscode.TestItem[] = [];
+    public failed: {
+        test: vscode.TestItem;
+        message: vscode.TestMessage | readonly vscode.TestMessage[];
+    }[] = [];
+    public passed: vscode.TestItem[] = [];
+    public skipped: vscode.TestItem[] = [];
+    public enqueued = new Set<vscode.TestItem>();
+    public unknown: number = 0;
+    public output: string[] = [];
+}
+
+/**
+ * The TestRunProxy acts as the data store for test results during a test run, and is responsible
+ * for moving the underlying `vscode.TestItems` through from the `enqueued` state to one of passed,
+ * failed or skipped.
+ */
+export class TestRunProxy implements vscode.CancellationToken {
+    private testRun?: vscode.TestRun;
+    private token: CompositeCancellationToken;
+    private runStarted: boolean = false;
+    private queuedOutput: string[] = [];
+    private iteration: number | undefined;
+    private attachments: { [key: string]: string[] } = {};
+    private testItemFinder: TestItemFinder;
+    private testRunCompleteEmitter = new vscode.EventEmitter<void>();
+    private coverage: TestCoverage;
+    private _testItems: vscode.TestItem[];
+
+    /**
+     * The list of test items for this test run
+     **/
+    public get testItems(): vscode.TestItem[] {
+        return this._testItems;
+    }
+
+    /**
+     * Captures the state of the underlying `vscode.TestItem`s, which can
+     * then be verified in tests. Used in the extension's integration tests
+     * to validate that tests pass/fail/skip as expected.
+     */
+    public runState = new TestRunState();
+
+    /**
+     * Is `true` when the test run has been cancelled, `false` otherwise.
+     */
+    public get isCancellationRequested(): boolean {
+        return this.token.isCancellationRequested;
+    }
+
+    /**
+     * An {@link Event} which fires upon cancellation.
+     */
+    public onCancellationRequested: vscode.Event<unknown>;
+
+    /**
+     * An {@link Event} which fires when the test run has completed.
+     */
+    public onTestRunComplete: vscode.Event<void>;
+
+    /**
+     * Creates a new TestRunProxy that captures the state of individual test items during
+     * a test run, as well as any output and test coverage information.
+     * @param testRunRequest The `vscode.TestRunRequest` that initiated the test run
+     * @param controller The `vscode.TestController` that contains `vscode.TestItems`
+     * @param args Arguments for the test run, indicating the individual tests to run.
+     * @param folderContext The `FolderContext` for the folder that contains the tests.
+     * @param recordDuration Whether or not to record the duration
+     * @param testProfileCancellationToken A cancellation token for the test run
+     */
+    constructor(
+        private testRunRequest: vscode.TestRunRequest,
+        private controller: vscode.TestController,
+        private args: TestRunArguments,
+        private folderContext: FolderContext,
+        private recordDuration: boolean,
+        testProfileCancellationToken: vscode.CancellationToken
+    ) {
+        this._testItems = args.testItems;
+        this.coverage = new TestCoverage(folderContext);
+        this.token = new CompositeCancellationToken(testProfileCancellationToken);
+        this.onCancellationRequested = this.token.onCancellationRequested.bind(this.token);
+        this.testItemFinder =
+            process.platform === "darwin"
+                ? new DarwinTestItemFinder(args.testItems)
+                : new NonDarwinTestItemFinder(args.testItems, this.folderContext);
+        this.onTestRunComplete = this.testRunCompleteEmitter.event;
+    }
+
+    /**
+     * Begins the test run. Test items that have been added are moved to the `enqued` state.
+     */
+    public testRunStarted() {
+        if (this.runStarted) {
+            return;
+        }
+
+        this.runStarted = true;
+        this.resetTags(this.controller);
+
+        this.testRun = this.controller.createTestRun(this.testRunRequest);
+        this.token.add(this.testRun.token);
+
+        // Forward any output captured before the testRun was created.
+        for (const outputLine of this.queuedOutput) {
+            this.performAppendOutput(outputLine);
+        }
+        this.queuedOutput = [];
+
+        for (const test of this.testItems) {
+            this.enqueued(test);
+        }
+    }
+
+    /**
+     * Adds a parameterized test case (a swift-testing only concept). Parameterized test cases are
+     * discovered at run time, and are linked to a parent test class.
+     * @param testClasses A list of parameterized tests to add
+     * @param parentIndex The index of the parent `vscode.TestItem`
+     */
+    public addParameterizedTestCases(testClasses: TestClass[], parentIndex: number) {
+        const addedTestItems = testClasses
+            .map(testClass => {
+                const parent = this.args.testItems[parentIndex];
+                // clear out the children before we add the new ones.
+                parent.children.replace([]);
+                return {
+                    testClass,
+                    parent,
+                };
+            })
+            .map(({ testClass, parent }) => {
+                // strip the location off parameterized tests so only the parent TestItem
+                // has one. The parent collects all the issues so they're colated on the top
+                // level test item and users can cycle through them with the up/down arrows in the UI.
+                testClass.location = undefined;
+
+                // Results should inherit any tags from the parent.
+                // Until we can rerun a swift-testing test with an individual argument, mark
+                // the argument test items as not runnable. This should be revisited when
+                // https://github.com/swiftlang/swift-testing/issues/671 is resolved.
+                testClass.tags = compactMap(parent.tags, t =>
+                    t.id === runnableTag.id ? null : new vscode.TestTag(t.id)
+                ).concat(new vscode.TestTag(TestRunProxy.Tags.PARAMETERIZED_TEST_RESULT));
+
+                const added = upsertTestItem(this.controller, testClass, parent);
+
+                // If we just update leaf nodes the root test controller never realizes that
+                // items have updated. This may be a bug in VS Code. We can work around it by
+                // re-adding the existing items back up the chain to refresh all the nodes along the way.
+                let p = parent;
+                while (p?.parent) {
+                    p.parent.children.add(p);
+                    p = p.parent;
+                }
+
+                return added;
+            });
+        this._testItems = [...this.testItems, ...addedTestItems];
+
+        for (const test of addedTestItems) {
+            this.enqueued(test);
+        }
+
+        // Recreate a test item finder with the added test items
+        this.testItemFinder =
+            process.platform === "darwin"
+                ? new DarwinTestItemFinder(this.testItems)
+                : new NonDarwinTestItemFinder(this.testItems, this.folderContext);
+    }
+
+    /**
+     * Associates an attachment with a test item. Attachments are created during
+     * a test run by individual tests. Attachment are provided as paths to individual
+     * attachments stored on disk.
+     * @param testIndex The index of the vscode.TestItem that produced the attachment
+     * @param attachment The path to the attachment
+     */
+    public addAttachment(testIndex: number, attachment: string) {
+        const attachments = this.attachments[testIndex] ?? [];
+        attachments.push(attachment);
+        this.attachments[testIndex] = attachments;
+
+        const testItem = this.testItems[testIndex];
+        if (testItem) {
+            testItem.tags = [
+                ...testItem.tags,
+                new vscode.TestTag(TestRunProxy.Tags.HAS_ATTACHMENT),
+            ];
+        }
+    }
+
+    /**
+     * Returns the index for the given test.
+     * @param id The index for the given test
+     * @param filename An optional filename of the file that contains the test, used for disambiguation.
+     **/
+    public getTestIndex(id: string, filename?: string): number {
+        return this.testItemFinder.getIndex(id, filename);
+    }
+
+    /**
+     * Captures that an unknown test ran. This should not be called if functionality
+     * is working as expected, and the extension's tests assert that this function
+     * was not called during test runs.
+     */
+    public unknownTestRan() {
+        this.runState.unknown++;
+    }
+
+    /**
+     * Indicates the supplied test has started running.
+     * @param test The test that started
+     */
+    public started(test: vscode.TestItem) {
+        this.clearEnqueuedTest(test);
+        this.runState.pending.push(test);
+        this.testRun?.started(test);
+    }
+
+    /**
+     * Indicates the supplied test was skipped.
+     * @param test The test that was skipped
+     */
+    public skipped(test: vscode.TestItem) {
+        this.clearEnqueuedTest(test);
+        test.tags = [...test.tags, new vscode.TestTag(TestRunProxy.Tags.SKIPPED)];
+
+        this.runState.skipped.push(test);
+        this.clearPendingTest(test);
+        this.testRun?.skipped(test);
+    }
+
+    /**
+     * Indicates the supplied test passed.
+     * @param test The test that passed
+     * @param duration How long the test took to execute, in milliseconds.
+     */
+    public passed(test: vscode.TestItem, duration?: number) {
+        this.clearEnqueuedTest(test);
+        this.runState.passed.push(test);
+        this.clearPendingTest(test);
+        this.testRun?.passed(test, this.recordDuration ? duration : undefined);
+    }
+
+    /**
+     * Indicates the supplied test failed.
+     * @param test The test that failed
+     * @param message The cause, or causes of the test failure
+     * @param duration How long the test took to execute, in milliseconds.
+     */
+    public failed(
+        test: vscode.TestItem,
+        message: vscode.TestMessage | readonly vscode.TestMessage[],
+        duration?: number
+    ) {
+        this.clearEnqueuedTest(test);
+        this.runState.failed.push({ test, message });
+        this.clearPendingTest(test);
+        this.testRun?.failed(test, message, this.recordDuration ? duration : undefined);
+    }
+
+    /**
+     * Skip any pending tests.
+     * Call this method when a test run is cancelled to mark the pending tests as skipped.
+     * Otherwise, pending tests will be marked as failing as we assume they crashed.
+     */
+    public skipPendingTests() {
+        this.runState.pending.forEach(test => {
+            this.skipped(test);
+        });
+        this.runState.pending = [];
+    }
+
+    /**
+     * Completes the test run. Once the `end` method is called, test
+     * results will no longer be captured and any remaining pending tests
+     * will be marked as failed, and any enqueued tests will be marked as skipped.
+     */
+    public async end() {
+        // If the test run never started (typically due to a build error)
+        // start it to flush any queued output, and then immediately end it.
+        if (!this.runStarted) {
+            this.testRunStarted();
+        }
+
+        // Any tests still in the pending state are considered failed. This
+        // can happen if a test causes a crash and aborts the test run.
+        this.markPendingAsFailed();
+
+        // If there are tests that never started, mark them as skipped.
+        // This can happen if there is a build error preventing tests from running.
+        this.markEnqueuedAsSkipped();
+
+        // Capture and report attachments to the test output panel
+        this.reportAttachments();
+
+        // Finally, mark the underlying test run as ended.
+        this.testRun?.end();
+        this.testRunCompleteEmitter.fire();
+        this.token.dispose();
+    }
+
+    /**
+     * Set the iteration of the test run. Used when performing a test run multiple times.
+     * @param iteration The iteration number
+     */
+    public setIteration(iteration: number) {
+        this.runState = new TestRunState();
+        this.iteration = iteration;
+        if (this.testRun) {
+            this.performAppendOutput("\n\r");
+        }
+    }
+
+    /**
+     * Returns coverage information for the suppplied URI.
+     */
+    public loadDetailedCoverage(uri: vscode.Uri) {
+        return this.coverage.loadDetailedCoverage(uri);
+    }
+
+    /**
+     * Captures coverage information out of the build folder for
+     * the supplied test library. This should be called after the
+     * test run is complete and the `end` method has been called.
+     * @param testLibrary The test library to capture coverage for
+     */
+    public captureCoverage(testLibrary: TestLibrary) {
+        return this.coverage.captureCoverage(testLibrary);
+    }
+
+    /**
+     * Compute final coverage numbers if any coverage info has been captured during the run.
+     */
+    public async computeCoverage() {
+        if (!this.testRun) {
+            return;
+        }
+
+        await this.coverage.computeCoverage(this.testRun);
+    }
+
+    /**
+     * Append output to the test run. This output is shown in the Test Results panel.
+     */
+    public appendOutput(output: string) {
+        this.performAppendOutput(output);
+    }
+
+    /**
+     * Append output to the test run. This output is shown in the Test Results panel, and
+     * is associated with the supplied `vscode.TestItem`.
+     * @param output Output to append to the test results.
+     * @param test The test to associate with the output.
+     * @param location Optional location of the test that produced the output.
+     */
+    public appendOutputToTest(output: string, test: vscode.TestItem, location?: vscode.Location) {
+        this.performAppendOutput(output, test, location);
+    }
+
+    private enqueued(test: vscode.TestItem) {
+        this.testRun?.enqueued(test);
+        this.runState.enqueued.add(test);
+    }
+
+    private markPendingAsFailed() {
+        this.runState.pending.forEach(test => {
+            this.failed(test, new vscode.TestMessage("Test did not complete."));
+        });
+    }
+
+    private markEnqueuedAsSkipped() {
+        this.runState.enqueued.forEach(test => {
+            // Omit adding the root test item as a skipped test to keep just the suites/tests
+            // in the test run output, just like a regular pass/fail test run.
+            if (test.parent) {
+                for (const output of this.queuedOutput) {
+                    this.appendOutputToTest(output, test);
+                }
+                this.skipped(test);
+            }
+        });
+
+        this.queuedOutput = [];
+    }
+
+    private clearPendingTest(test: vscode.TestItem) {
+        this.runState.pending = this.runState.pending.filter(t => t !== test);
+    }
+
+    private clearEnqueuedTest(test: vscode.TestItem) {
+        this.runState.enqueued.delete(test);
+
+        if (!test.parent) {
+            return;
+        }
+
+        const parentHasEnqueuedChildren = Array.from(test.parent.children).some(([_, child]) =>
+            this.runState.enqueued.has(child)
+        );
+
+        if (!parentHasEnqueuedChildren) {
+            this.clearEnqueuedTest(test.parent);
+        }
+    }
+
+    private performAppendOutput(
+        output: string,
+        test?: vscode.TestItem,
+        location?: vscode.Location
+    ) {
+        const tranformedOutput = this.prependIterationToOutput(output);
+        if (this.testRun) {
+            this.testRun.appendOutput(output, location, test);
+            this.runState.output.push(stripAnsi(output));
+        } else {
+            this.queuedOutput.push(tranformedOutput);
+        }
+    }
+
+    private prependIterationToOutput(output: string): string {
+        if (this.iteration === undefined) {
+            return output;
+        }
+        const itr = this.iteration + 1;
+        const lines = output.match(/[^\r\n]*[\r\n]*/g);
+        return lines?.map(line => (line ? `\x1b[34mRun ${itr}\x1b[0m ${line}` : "")).join("") ?? "";
+    }
+
+    private reportAttachments() {
+        const attachmentKeys = Object.keys(this.attachments);
+        if (attachmentKeys.length > 0) {
+            let attachment = "";
+            const totalAttachments = attachmentKeys.reduce((acc, key) => {
+                const attachments = this.attachments[key];
+                attachment = attachments.length ? attachments[0] : attachment;
+                return acc + attachments.length;
+            }, 0);
+
+            if (attachment) {
+                attachment = path.dirname(attachment);
+                this.appendOutput(
+                    `${SymbolRenderer.eventMessageSymbol(TestSymbol.attachment)} ${SymbolRenderer.ansiEscapeCodePrefix}90mRecorded ${totalAttachments} attachment${totalAttachments === 1 ? "" : "s"} to ${attachment}${SymbolRenderer.resetANSIEscapeCode}`
+                );
+            }
+        }
+    }
+
+    /**
+     * Extra tags automatically applied by the extension to `vscode.TestItems`.
+     */
+    static Tags = {
+        SKIPPED: "skipped",
+        HAS_ATTACHMENT: "hasAttachment",
+        PARAMETERIZED_TEST_RESULT: "parameterizedTestResult",
+    };
+
+    // Remove any tags that were added due to test results
+    private resetTags(controller: vscode.TestController) {
+        function removeTestRunTags(_acc: void, test: vscode.TestItem) {
+            const tags = Object.values(TestRunProxy.Tags);
+            test.tags = test.tags.filter(tag => !tags.includes(tag.id));
+        }
+        reduceTestItemChildren(controller.items, removeTestRunTags, void 0);
+    }
+}
+
+/** Interface defining how to find test items given a test id from XCTest output */
+interface TestItemFinder {
+    getIndex(id: string, filename?: string): number;
+    testItems: vscode.TestItem[];
+}
+
+/** Defines how to find test items given a test id from XCTest output on Darwin platforms */
+class DarwinTestItemFinder implements TestItemFinder {
+    private readonly testItemMap: Map<string, number>;
+
+    constructor(public testItems: vscode.TestItem[]) {
+        this.testItemMap = new Map(testItems.map((item, index) => [item.id, index]));
+    }
+
+    getIndex(id: string): number {
+        return this.testItemMap.get(id) ?? -1;
+    }
+}
+
+/** Defines how to find test items given a test id from XCTest output on non-Darwin platforms */
+class NonDarwinTestItemFinder implements TestItemFinder {
+    constructor(
+        public testItems: vscode.TestItem[],
+        public folderContext: FolderContext
+    ) {}
+
+    /**
+     * Get test item index from id for non Darwin platforms. It is a little harder to
+     * be certain we have the correct test item on non Darwin platforms as the target
+     * name is not included in the id
+     */
+    getIndex(id: string, filename?: string): number {
+        let testIndex = -1;
+        if (filename) {
+            testIndex = this.testItems.findIndex(item =>
+                this.isTestWithFilenameInTarget(id, filename, item)
+            );
+        }
+
+        if (testIndex === -1) {
+            testIndex = this.testItems.findIndex(item => item.id.endsWith(id));
+        }
+
+        return testIndex;
+    }
+
+    /**
+     * Linux test output does not include the target name. So I have to work out which target
+     * the test is in via the test name and if it failed the filename from the error. In theory
+     * if a test fails the filename for where it failed should indicate which target it is in.
+     *
+     * @param testName Test name
+     * @param filename File name of where test failed
+     * @param item TestItem
+     * @returns Is it this TestItem
+     */
+    private isTestWithFilenameInTarget(
+        testName: string,
+        filename: string,
+        item: vscode.TestItem
+    ): boolean {
+        if (!item.id.endsWith(testName)) {
+            return false;
+        }
+
+        // get target test item
+        const targetTestItem = item.parent?.parent;
+        if (!targetTestItem) {
+            return false;
+        }
+
+        // get target from Package
+        const target = this.folderContext.swiftPackage.currentTargets.find(
+            item => targetTestItem.label === item.name
+        );
+
+        if (target) {
+            const fileErrorIsIn = filename;
+            const targetPath = path.join(this.folderContext.folder.fsPath, target.path);
+            const relativePath = path.relative(targetPath, fileErrorIsIn);
+            return target.sources.find(source => source === relativePath) !== undefined;
+        }
+
+        return false;
+    }
+}

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -20,7 +20,6 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { WorkspaceContext } from "../WorkspaceContext";
 import configuration from "../configuration";
-import { TestCoverage } from "../coverage/LcovResults";
 import {
     BuildConfigurationFactory,
     SwiftTestingBuildAguments,
@@ -36,19 +35,10 @@ import {
 } from "../utilities/cancellation";
 import { packageName, resolveScope } from "../utilities/tasks";
 import { TemporaryFolder } from "../utilities/tempFolder";
-import {
-    IS_RUNNING_UNDER_TEST,
-    compactMap,
-    execFile,
-    getErrorDescription,
-} from "../utilities/utilities";
-import { TestClass, runnableTag, upsertTestItem } from "./TestDiscovery";
+import { IS_RUNNING_UNDER_TEST, execFile, getErrorDescription } from "../utilities/utilities";
+import { runnableTag } from "./TestDiscovery";
 import { TestKind, isDebugging, isRelease } from "./TestKind";
-import {
-    SwiftTestingOutputParser,
-    SymbolRenderer,
-    TestSymbol,
-} from "./TestParsers/SwiftTestingOutputParser";
+import { SwiftTestingOutputParser } from "./TestParsers/SwiftTestingOutputParser";
 import { ITestRunState, TestIssueDiff } from "./TestParsers/TestRunState";
 import {
     IXCTestOutputParser,
@@ -56,377 +46,16 @@ import {
     XCTestOutputParser,
 } from "./TestParsers/XCTestOutputParser";
 import { TestRunArguments } from "./TestRunArguments";
+import { TestRunProxy, TestRunState } from "./TestRunProxy";
 import { reduceTestItemChildren } from "./TestUtils";
 import { TestXUnitParser } from "./TestXUnitParser";
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import stripAnsi = require("strip-ansi");
-
+/**
+ * The different types of test library supported by the test runner.
+ */
 export enum TestLibrary {
     xctest = "XCTest",
     swiftTesting = "swift-testing",
-}
-
-export interface TestRunState {
-    pending: vscode.TestItem[];
-    failed: {
-        test: vscode.TestItem;
-        message: vscode.TestMessage | readonly vscode.TestMessage[];
-    }[];
-    passed: vscode.TestItem[];
-    skipped: vscode.TestItem[];
-    errored: vscode.TestItem[];
-    enqueued: Set<vscode.TestItem>;
-    unknown: number;
-    output: string[];
-}
-
-export class TestRunProxy {
-    private testRun?: vscode.TestRun;
-    private runStarted: boolean = false;
-    private queuedOutput: string[] = [];
-    private _testItems: vscode.TestItem[];
-    private iteration: number | undefined;
-    private attachments: { [key: string]: string[] } = {};
-    private testItemFinder: TestItemFinder;
-    private testRunCompleteEmitter = new vscode.EventEmitter<void>();
-
-    public coverage: TestCoverage;
-    public token: CompositeCancellationToken;
-
-    public onTestRunComplete: vscode.Event<void>;
-    public runState = TestRunProxy.initialTestRunState();
-
-    public static initialTestRunState(): TestRunState {
-        return {
-            pending: [],
-            failed: [],
-            passed: [],
-            skipped: [],
-            errored: [],
-            enqueued: new Set<vscode.TestItem>(),
-            unknown: 0,
-            output: [],
-        };
-    }
-
-    /** The list of test items for this test run */
-    public get testItems(): vscode.TestItem[] {
-        return this._testItems;
-    }
-
-    public get isCancellationRequested(): boolean {
-        return this.token.isCancellationRequested;
-    }
-
-    constructor(
-        private testRunRequest: vscode.TestRunRequest,
-        private controller: vscode.TestController,
-        private args: TestRunArguments,
-        private folderContext: FolderContext,
-        private recordDuration: boolean,
-        testProfileCancellationToken: vscode.CancellationToken
-    ) {
-        this._testItems = args.testItems;
-        this.coverage = new TestCoverage(folderContext);
-        this.token = new CompositeCancellationToken(testProfileCancellationToken);
-        this.testItemFinder =
-            process.platform === "darwin"
-                ? new DarwinTestItemFinder(args.testItems)
-                : new NonDarwinTestItemFinder(args.testItems, this.folderContext);
-        this.onTestRunComplete = this.testRunCompleteEmitter.event;
-    }
-
-    public testRunStarted = () => {
-        if (this.runStarted) {
-            return;
-        }
-
-        this.runStarted = true;
-        this.resetTags(this.controller);
-
-        this.testRun = this.controller.createTestRun(this.testRunRequest);
-        this.token.add(this.testRun.token);
-
-        // Forward any output captured before the testRun was created.
-        for (const outputLine of this.queuedOutput) {
-            this.performAppendOutput(outputLine);
-        }
-        this.queuedOutput = [];
-
-        for (const test of this.testItems) {
-            this.enqueued(test);
-        }
-    };
-
-    public addParameterizedTestCases = (testClasses: TestClass[], parentIndex: number) => {
-        const addedTestItems = testClasses
-            .map(testClass => {
-                const parent = this.args.testItems[parentIndex];
-                // clear out the children before we add the new ones.
-                parent.children.replace([]);
-                return {
-                    testClass,
-                    parent,
-                };
-            })
-            .map(({ testClass, parent }) => {
-                // strip the location off parameterized tests so only the parent TestItem
-                // has one. The parent collects all the issues so they're colated on the top
-                // level test item and users can cycle through them with the up/down arrows in the UI.
-                testClass.location = undefined;
-
-                // Results should inherit any tags from the parent.
-                // Until we can rerun a swift-testing test with an individual argument, mark
-                // the argument test items as not runnable. This should be revisited when
-                // https://github.com/swiftlang/swift-testing/issues/671 is resolved.
-                testClass.tags = compactMap(parent.tags, t =>
-                    t.id === runnableTag.id ? null : new vscode.TestTag(t.id)
-                ).concat(new vscode.TestTag(TestRunProxy.Tags.PARAMETERIZED_TEST_RESULT));
-
-                const added = upsertTestItem(this.controller, testClass, parent);
-
-                // If we just update leaf nodes the root test controller never realizes that
-                // items have updated. This may be a bug in VS Code. We can work around it by
-                // re-adding the existing items back up the chain to refresh all the nodes along the way.
-                let p = parent;
-                while (p?.parent) {
-                    p.parent.children.add(p);
-                    p = p.parent;
-                }
-
-                return added;
-            });
-        this._testItems = [...this.testItems, ...addedTestItems];
-
-        for (const test of addedTestItems) {
-            this.enqueued(test);
-        }
-
-        // Recreate a test item finder with the added test items
-        this.testItemFinder =
-            process.platform === "darwin"
-                ? new DarwinTestItemFinder(this.testItems)
-                : new NonDarwinTestItemFinder(this.testItems, this.folderContext);
-    };
-
-    public addAttachment = (testIndex: number, attachment: string) => {
-        const attachments = this.attachments[testIndex] ?? [];
-        attachments.push(attachment);
-        this.attachments[testIndex] = attachments;
-
-        const testItem = this.testItems[testIndex];
-        if (testItem) {
-            testItem.tags = [
-                ...testItem.tags,
-                new vscode.TestTag(TestRunProxy.Tags.HAS_ATTACHMENT),
-            ];
-        }
-    };
-
-    public getTestIndex(id: string, filename?: string): number {
-        return this.testItemFinder.getIndex(id, filename);
-    }
-
-    private enqueued(test: vscode.TestItem) {
-        this.testRun?.enqueued(test);
-        this.runState.enqueued.add(test);
-    }
-
-    public unknownTestRan() {
-        this.runState.unknown++;
-    }
-
-    public started(test: vscode.TestItem) {
-        this.clearEnqueuedTest(test);
-        this.runState.pending.push(test);
-        this.testRun?.started(test);
-    }
-
-    private clearPendingTest(test: vscode.TestItem) {
-        this.runState.pending = this.runState.pending.filter(t => t !== test);
-    }
-
-    private clearEnqueuedTest(test: vscode.TestItem) {
-        this.runState.enqueued.delete(test);
-
-        if (!test.parent) {
-            return;
-        }
-
-        const parentHasEnqueuedChildren = Array.from(test.parent.children).some(([_, child]) =>
-            this.runState.enqueued.has(child)
-        );
-
-        if (!parentHasEnqueuedChildren) {
-            this.clearEnqueuedTest(test.parent);
-        }
-    }
-
-    public skipped(test: vscode.TestItem) {
-        this.clearEnqueuedTest(test);
-        test.tags = [...test.tags, new vscode.TestTag(TestRunProxy.Tags.SKIPPED)];
-
-        this.runState.skipped.push(test);
-        this.clearPendingTest(test);
-        this.testRun?.skipped(test);
-    }
-
-    public passed(test: vscode.TestItem, duration?: number) {
-        this.clearEnqueuedTest(test);
-        this.runState.passed.push(test);
-        this.clearPendingTest(test);
-        this.testRun?.passed(test, this.recordDuration ? duration : undefined);
-    }
-
-    public failed(
-        test: vscode.TestItem,
-        message: vscode.TestMessage | readonly vscode.TestMessage[],
-        duration?: number
-    ) {
-        this.clearEnqueuedTest(test);
-        this.runState.failed.push({ test, message });
-        this.clearPendingTest(test);
-        this.testRun?.failed(test, message, this.recordDuration ? duration : undefined);
-    }
-
-    public errored(
-        test: vscode.TestItem,
-        message: vscode.TestMessage | readonly vscode.TestMessage[],
-        duration?: number
-    ) {
-        this.clearEnqueuedTest(test);
-        this.runState.errored.push(test);
-        this.clearPendingTest(test);
-        this.testRun?.errored(test, message, this.recordDuration ? duration : undefined);
-    }
-
-    /**
-     * Skip any pending tests.
-     * Call this method when a test run is cancelled to mark the pending tests as skipped.
-     * Otherwise, pending tests will be marked as failing as we assume they crashed.
-     */
-    public skipPendingTests() {
-        this.runState.pending.forEach(test => {
-            this.skipped(test);
-        });
-        this.runState.pending = [];
-    }
-
-    public async end() {
-        // If the test run never started (typically due to a build error)
-        // start it to flush any queued output, and then immediately end it.
-        if (!this.runStarted) {
-            this.testRunStarted();
-        }
-
-        // Any tests still in the pending state are considered failed. This
-        // can happen if a test causes a crash and aborts the test run.
-        this.runState.pending.forEach(test => {
-            this.failed(test, new vscode.TestMessage("Test did not complete."));
-        });
-        // If there are tests that never started, mark them as skipped.
-        // This can happen if there is a build error preventing tests from running.
-        this.runState.enqueued.forEach(test => {
-            // Omit adding the root test item as a skipped test to keep just the suites/tests
-            // in the test run output, just like a regular pass/fail test run.
-            if (test.parent) {
-                for (const output of this.queuedOutput) {
-                    this.appendOutputToTest(output, test);
-                }
-                this.skipped(test);
-            }
-        });
-
-        this.queuedOutput = [];
-
-        this.reportAttachments();
-        this.testRun?.end();
-        this.testRunCompleteEmitter.fire();
-        this.token.dispose();
-    }
-
-    public setIteration(iteration: number) {
-        this.runState = TestRunProxy.initialTestRunState();
-        this.iteration = iteration;
-        if (this.testRun) {
-            this.performAppendOutput("\n\r");
-        }
-    }
-
-    public async computeCoverage() {
-        if (!this.testRun) {
-            return;
-        }
-
-        // Compute final coverage numbers if any coverage info has been captured during the run.
-        await this.coverage.computeCoverage(this.testRun);
-    }
-
-    public appendOutput(output: string) {
-        this.performAppendOutput(output);
-    }
-
-    public appendOutputToTest(output: string, test: vscode.TestItem, location?: vscode.Location) {
-        this.performAppendOutput(output, test, location);
-    }
-
-    private performAppendOutput(
-        output: string,
-        test?: vscode.TestItem,
-        location?: vscode.Location
-    ) {
-        const tranformedOutput = this.prependIterationToOutput(output);
-        if (this.testRun) {
-            this.testRun.appendOutput(output, location, test);
-            this.runState.output.push(stripAnsi(output));
-        } else {
-            this.queuedOutput.push(tranformedOutput);
-        }
-    }
-
-    private prependIterationToOutput(output: string): string {
-        if (this.iteration === undefined) {
-            return output;
-        }
-        const itr = this.iteration + 1;
-        const lines = output.match(/[^\r\n]*[\r\n]*/g);
-        return lines?.map(line => (line ? `\x1b[34mRun ${itr}\x1b[0m ${line}` : "")).join("") ?? "";
-    }
-
-    private reportAttachments() {
-        const attachmentKeys = Object.keys(this.attachments);
-        if (attachmentKeys.length > 0) {
-            let attachment = "";
-            const totalAttachments = attachmentKeys.reduce((acc, key) => {
-                const attachments = this.attachments[key];
-                attachment = attachments.length ? attachments[0] : attachment;
-                return acc + attachments.length;
-            }, 0);
-
-            if (attachment) {
-                attachment = path.dirname(attachment);
-                this.appendOutput(
-                    `${SymbolRenderer.eventMessageSymbol(TestSymbol.attachment)} ${SymbolRenderer.ansiEscapeCodePrefix}90mRecorded ${totalAttachments} attachment${totalAttachments === 1 ? "" : "s"} to ${attachment}${SymbolRenderer.resetANSIEscapeCode}`
-                );
-            }
-        }
-    }
-
-    static Tags = {
-        SKIPPED: "skipped",
-        HAS_ATTACHMENT: "hasAttachment",
-        PARAMETERIZED_TEST_RESULT: "parameterizedTestResult",
-    };
-
-    // Remove any tags that were added due to test results
-    private resetTags(controller: vscode.TestController) {
-        function removeTestRunTags(_acc: void, test: vscode.TestItem) {
-            const tags = Object.values(TestRunProxy.Tags);
-            test.tags = test.tags.filter(tag => !tags.includes(tag.id));
-        }
-        reduceTestItemChildren(controller.items, removeTestRunTags, void 0);
-    }
 }
 
 /** Class used to run tests */
@@ -504,7 +133,7 @@ export class TestRunner {
         return new vscode.TestRunRequest(items, request.exclude, request.profile);
     }
 
-    get workspaceContext(): WorkspaceContext {
+    private get workspaceContext(): WorkspaceContext {
         return this.folderContext.workspaceContext;
     }
 
@@ -586,9 +215,7 @@ export class TestRunner {
                                     _testRun,
                                     fileCoverage
                                 ) => {
-                                    return runner.testRun.coverage.loadDetailedCoverage(
-                                        fileCoverage.uri
-                                    );
+                                    return runner.testRun.loadDetailedCoverage(fileCoverage.uri);
                                 };
                             }
                             await vscode.commands.executeCommand("testing.openCoverage");
@@ -736,7 +363,7 @@ export class TestRunner {
      * @returns When complete
      */
     async runHandler() {
-        if (this.testRun.token.isCancellationRequested) {
+        if (this.testRun.isCancellationRequested) {
             return;
         }
 
@@ -745,7 +372,7 @@ export class TestRunner {
 
         const runState = new TestRunnerTestRunState(this.testRun);
 
-        const cancellationDisposable = this.testRun.token.onCancellationRequested(() => {
+        const cancellationDisposable = this.testRun.onCancellationRequested(() => {
             this.testRun.appendOutput("\r\nTest run cancelled.");
         });
 
@@ -957,7 +584,7 @@ export class TestRunner {
             });
 
             // If the test run is iterrupted by a cancellation request from VS Code, ensure the task is terminated.
-            const cancellationDisposable = this.testRun.token.onCancellationRequested(() => {
+            const cancellationDisposable = this.testRun.onCancellationRequested(() => {
                 task.execution.terminate("SIGINT");
                 reject(TestRunner.CANCELLATION_ERROR);
             });
@@ -973,10 +600,7 @@ export class TestRunner {
                 }
             });
 
-            void this.folderContext.taskQueue.queueOperation(
-                new TaskOperation(task),
-                this.testRun.token
-            );
+            void this.folderContext.taskQueue.queueOperation(new TaskOperation(task), this.testRun);
         });
     }
 
@@ -995,7 +619,7 @@ export class TestRunner {
             }
         }
 
-        await this.testRun.coverage.captureCoverage(testLibrary);
+        await this.testRun.captureCoverage(testLibrary);
     }
 
     /** Run tests in parallel outside of debugger */
@@ -1182,7 +806,7 @@ export class TestRunner {
                             );
 
                             // add cancellation
-                            const cancellation = this.testRun.token.onCancellationRequested(() => {
+                            const cancellation = this.testRun.onCancellationRequested(() => {
                                 this.workspaceContext.logger.debug(
                                     "Test Debugging Cancelled",
                                     this.folderContext.name
@@ -1315,87 +939,6 @@ export class TestRunner {
         if (testingSetting === "openOnTestFailure") {
             void vscode.commands.executeCommand("workbench.panel.testResults.view.focus");
         }
-    }
-}
-
-/** Interface defining how to find test items given a test id from XCTest output */
-interface TestItemFinder {
-    getIndex(id: string, filename?: string): number;
-    testItems: vscode.TestItem[];
-}
-
-/** Defines how to find test items given a test id from XCTest output on Darwin platforms */
-class DarwinTestItemFinder implements TestItemFinder {
-    private readonly testItemMap: Map<string, number>;
-
-    constructor(public testItems: vscode.TestItem[]) {
-        this.testItemMap = new Map(testItems.map((item, index) => [item.id, index]));
-    }
-
-    getIndex(id: string): number {
-        return this.testItemMap.get(id) ?? -1;
-    }
-}
-
-/** Defines how to find test items given a test id from XCTest output on non-Darwin platforms */
-class NonDarwinTestItemFinder implements TestItemFinder {
-    constructor(
-        public testItems: vscode.TestItem[],
-        public folderContext: FolderContext
-    ) {}
-
-    /**
-     * Get test item index from id for non Darwin platforms. It is a little harder to
-     * be certain we have the correct test item on non Darwin platforms as the target
-     * name is not included in the id
-     */
-    getIndex(id: string, filename?: string): number {
-        let testIndex = -1;
-        if (filename) {
-            testIndex = this.testItems.findIndex(item =>
-                this.isTestWithFilenameInTarget(id, filename, item)
-            );
-        }
-        if (testIndex === -1) {
-            testIndex = this.testItems.findIndex(item => item.id.endsWith(id));
-        }
-        return testIndex;
-    }
-
-    /**
-     * Linux test output does not include the target name. So I have to work out which target
-     * the test is in via the test name and if it failed the filename from the error. In theory
-     * if a test fails the filename for where it failed should indicate which target it is in.
-     *
-     * @param testName Test name
-     * @param filename File name of where test failed
-     * @param item TestItem
-     * @returns Is it this TestItem
-     */
-    private isTestWithFilenameInTarget(
-        testName: string,
-        filename: string,
-        item: vscode.TestItem
-    ): boolean {
-        if (!item.id.endsWith(testName)) {
-            return false;
-        }
-        // get target test item
-        const targetTestItem = item.parent?.parent;
-        if (!targetTestItem) {
-            return false;
-        }
-        // get target from Package
-        const target = this.folderContext.swiftPackage.currentTargets.find(
-            item => targetTestItem.label === item.name
-        );
-        if (target) {
-            const fileErrorIsIn = filename;
-            const targetPath = path.join(this.folderContext.folder.fsPath, target.path);
-            const relativePath = path.relative(targetPath, fileErrorIsIn);
-            return target.sources.find(source => source === relativePath) !== undefined;
-        }
-        return false;
     }
 }
 

--- a/src/commands/testMultipleTimes.ts
+++ b/src/commands/testMultipleTimes.ts
@@ -15,7 +15,8 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "../FolderContext";
 import { TestKind, isDebugging } from "../TestExplorer/TestKind";
-import { TestRunState, TestRunner, TestRunnerTestRunState } from "../TestExplorer/TestRunner";
+import { TestRunState } from "../TestExplorer/TestRunProxy";
+import { TestRunner, TestRunnerTestRunState } from "../TestExplorer/TestRunner";
 import { colorize } from "../utilities/utilities";
 
 /**
@@ -90,7 +91,7 @@ export async function runTestMultipleTimes(
 
         if (
             runner.testRun.isCancellationRequested ||
-            (untilFailure && (runState.failed.length > 0 || runState.errored.length > 0))
+            (untilFailure && runState.failed.length > 0)
         ) {
             break;
         }

--- a/test/integration-tests/commands/runTestMultipleTimes.test.ts
+++ b/test/integration-tests/commands/runTestMultipleTimes.test.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "@src/FolderContext";
 import { TestKind } from "@src/TestExplorer/TestKind";
-import { TestRunProxy } from "@src/TestExplorer/TestRunner";
+import { TestRunState } from "@src/TestExplorer/TestRunProxy";
 import { runTestMultipleTimes } from "@src/commands/testMultipleTimes";
 
 import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
@@ -55,19 +55,19 @@ suite("Test Multiple Times Command Test Suite", () => {
             false,
             TestKind.standard,
             3,
-            () => Promise.resolve(TestRunProxy.initialTestRunState())
+            () => Promise.resolve(new TestRunState())
         );
 
         expect(runState).to.deep.equal([
-            TestRunProxy.initialTestRunState(),
-            TestRunProxy.initialTestRunState(),
-            TestRunProxy.initialTestRunState(),
+            new TestRunState(),
+            new TestRunState(),
+            new TestRunState(),
         ]);
     });
 
     test("Stops after a failure on the 2nd iteration ", async () => {
         const failure = {
-            ...TestRunProxy.initialTestRunState(),
+            ...new TestRunState(),
             failed: [{ test: testItem, message: new vscode.TestMessage("oh no") }],
         };
         let ctr = 0;
@@ -82,10 +82,10 @@ suite("Test Multiple Times Command Test Suite", () => {
                 if (ctr === 2) {
                     return Promise.resolve(failure);
                 }
-                return Promise.resolve(TestRunProxy.initialTestRunState());
+                return Promise.resolve(new TestRunState());
             }
         );
 
-        expect(runState).to.deep.equal([TestRunProxy.initialTestRunState(), failure]);
+        expect(runState).to.deep.equal([new TestRunState(), failure]);
     });
 });

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -25,7 +25,7 @@ import {
     MessageRenderer,
     TestSymbol,
 } from "@src/TestExplorer/TestParsers/SwiftTestingOutputParser";
-import { TestRunProxy } from "@src/TestExplorer/TestRunner";
+import { TestRunProxy } from "@src/TestExplorer/TestRunProxy";
 import { flattenTestItemCollection, reduceTestItemChildren } from "@src/TestExplorer/TestUtils";
 import { WorkspaceContext } from "@src/WorkspaceContext";
 import { Commands } from "@src/commands";

--- a/test/integration-tests/testexplorer/utilities.ts
+++ b/test/integration-tests/testexplorer/utilities.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 
 import { TestExplorer } from "@src/TestExplorer/TestExplorer";
 import { TestKind } from "@src/TestExplorer/TestKind";
-import { TestRunProxy } from "@src/TestExplorer/TestRunner";
+import { TestRunProxy } from "@src/TestExplorer/TestRunProxy";
 import { reduceTestItemChildren } from "@src/TestExplorer/TestUtils";
 import { WorkspaceContext } from "@src/WorkspaceContext";
 import { SwiftLogger } from "@src/logging/SwiftLogger";
@@ -130,7 +130,6 @@ export function assertTestResults(
                 }))
                 .sort(),
             skipped: testRun.runState.skipped.map(({ id }) => id).sort(),
-            errored: testRun.runState.errored.map(({ id }) => id).sort(),
             enqueued: Array.from(testRun.runState.enqueued)
                 .map(({ id }) => id)
                 .sort(),


### PR DESCRIPTION
## Description
`TestRunProxy` was colocated in the same file as `TestRunner`. Move it to its own file and clean up its documentation.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
