### PR TITLE
Fixed Dockerfile build errors

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM swiftlang/swift:nightly-jammy
 
-COPY ../nvmrc /tmp/.nvmrc
+COPY .nvmrc /tmp/.nvmrc
 
 #  python3-lldb-13 is only needed for swiftly and a great dep to remove to test post-install script ;)
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
@@ -20,11 +20,11 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
 RUN mkdir -p /usr/local/nvm
 ENV NVM_DIR /usr/local/nvm
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-ARG NODE_VERSION
-RUN NODE_VERSION=$(cat /tmp/.nvmrc) && \
-    /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION"
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
-ENV PATH $NODE_PATH:$PATH
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && \
+    NODE_VERSION=\$(cat /tmp/.nvmrc) && \
+    nvm install \$NODE_VERSION && \
+    ln -sf \$NVM_DIR/versions/node/v\$NODE_VERSION \$NVM_DIR/current"
+ENV PATH $NVM_DIR/current/bin:$PATH
 RUN npm -v
 RUN node -v
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "Swift",
-    "dockerFile": "Dockerfile",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {
             "installZsh": "false",


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
The manual tests that I ran while QAing #2068 were flawed. When I would rebuild and open VS Code in a container, VS Code seems to have been caching some changes. I didn't realize that the `COPY ../nvmrc /tmp/.nvmrc` change that I wrote would cause the build to fail with `COPY failed: forbidden path outside the build context: ../nvmrc ()`. 

When I ran `Dev Containers: Rebuild Without Cache and Reopen in Container`, I found this issue, and rectified it in this PR.

Issue: Addresses a bug introduced in #2068 

To test this change, run `Dev Containers: Rebuild Without Cache and Reopen in Container`, and make sure the Docker container builds successfully. 

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
