### PR TITLE
Use knip to clean up unused dependencies

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -23,3 +23,6 @@ if [ $UNSTAGED_CHANGES -eq 1 ]; then
   echo "Please stage the modified files and try committing again."
   exit 1
 fi
+
+echo "Running knip to check for unused code..."
+npx knip

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://unpkg.com/knip@latest/schema.json",
+  "entry": [
+    "src/askpass/askpass-main.ts",
+    "src/coverage/**/*.ts",
+    "scripts/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "project": ["src/**/*.ts", "scripts/**/*.ts", "test/**/*.ts"],
+  "ignore": ["dist/**", "out/**", "assets/**", "**/*.d.ts"],
+  "ignoreDependencies": [
+    "node-pty",
+    "@vscode/codicons",
+    "@vscode/test-electron",
+    "@types/svg2ttf",
+    "@types/svgicons2svgfont",
+    "@types/ttf2woff"
+  ],
+  "ignoreBinaries": ["scripts/soundness.sh"],
+  "rules": {
+    "types": "warn",
+    "enumMembers": "warn"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "zod": "^4.1.5"
       },
       "devDependencies": {
-        "@actions/core": "^3.0.0",
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@twbs/fantasticon": "^3.1.0",
         "@types/archiver": "^7.0.0",
@@ -42,7 +41,6 @@
         "@types/source-map-support": "^0.5.10",
         "@types/svg2ttf": "^5.0.3",
         "@types/svgicons2svgfont": "^10.0.5",
-        "@types/tar": "^6.1.13",
         "@types/ttf2woff": "^2.0.4",
         "@types/vscode": "^1.88.0",
         "@types/xml2js": "^0.4.14",
@@ -63,6 +61,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-mocha": "^10.5.0",
         "husky": "^9.1.7",
+        "knip": "^5.83.1",
         "lint-staged": "^16.2.7",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1",
@@ -98,41 +97,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/@actions/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
-      "dev": true,
-      "dependencies": {
-        "@actions/exec": "^3.0.0",
-        "@actions/http-client": "^4.0.0"
-      }
-    },
-    "node_modules/@actions/exec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
-      "dev": true,
-      "dependencies": {
-        "@actions/io": "^3.0.2"
-      }
-    },
-    "node_modules/@actions/http-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
-      "dev": true,
-      "dependencies": {
-        "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
-      }
-    },
-    "node_modules/@actions/io": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
-      "dev": true
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",
@@ -519,6 +483,40 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1220,6 +1218,23 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1731,6 +1746,289 @@
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.17.0.tgz",
+      "integrity": "sha512-kVnY21v0GyZ/+LG6EIO48wK3mE79BUuakHUYLIqobO/Qqq4mJsjuYXMSn3JtLcKZpN1HDVit4UHpGJHef1lrlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.17.0.tgz",
+      "integrity": "sha512-Pf8e3XcsK9a8RHInoAtEcrwf2vp7V9bSturyUUYxw9syW6E7cGi7z9+6ADXxm+8KAevVfLA7pfBg8NXTvz/HOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.17.0.tgz",
+      "integrity": "sha512-lVSgKt3biecofXVr8e1hnfX0IYMd4A6VCxmvOmHsFt5Zbmt0lkO4S2ap2bvQwYDYh5ghUNamC7M2L8K6vishhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.17.0.tgz",
+      "integrity": "sha512-+/raxVJE1bo7R4fA9Yp0wm3slaCOofTEeUzM01YqEGcRDLHB92WRGjRhagMG2wGlvqFuSiTp81DwSbBVo/g6AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.17.0.tgz",
+      "integrity": "sha512-x9Ks56n+n8h0TLhzA6sJXa2tGh3uvMGpBppg6PWf8oF0s5S/3p/J6k1vJJ9lIUtTmenfCQEGKnFokpRP4fLTLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.17.0.tgz",
+      "integrity": "sha512-Wf3w07Ow9kXVJrS0zmsaFHKOGhXKXE8j1tNyy+qIYDsQWQ4UQZVx5SjlDTcqBnFerlp3Z3Is0RjmVzgoLG3qkA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.17.0.tgz",
+      "integrity": "sha512-N0OKA1al1gQ5Gm7Fui1RWlXaHRNZlwMoBLn3TVtSXX+WbnlZoVyDqqOqFL8+pVEHhhxEA2LR8kmM0JO6FAk6dg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.17.0.tgz",
+      "integrity": "sha512-wdcQ7Niad9JpjZIGEeqKJnTvczVunqlZ/C06QzR5zOQNeLVRScQ9S5IesKWUAPsJQDizV+teQX53nTK+Z5Iy+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.17.0.tgz",
+      "integrity": "sha512-65B2/t39HQN5AEhkLsC+9yBD1iRUkKOIhfmJEJ7g6wQ9kylra7JRmNmALFjbsj0VJsoSQkpM8K07kUZuNJ9Kxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.17.0.tgz",
+      "integrity": "sha512-kExgm3TLK21dNMmcH+xiYGbc6BUWvT03PUZ2aYn8mUzGPeeORklBhg3iYcaBI3ZQHB25412X1Z6LLYNjt4aIaA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.17.0.tgz",
+      "integrity": "sha512-1utUJC714/ydykZQE8c7QhpEyM4SaslMfRXxN9G61KYazr6ndt85LaubK3EZCSD50vVEfF4PVwFysCSO7LN9uA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.17.0.tgz",
+      "integrity": "sha512-mayiYOl3LMmtO2CLn4I5lhanfxEo0LAqlT/EQyFbu1ZN3RS+Xa7Q3JEM0wBpVIyfO/pqFrjvC5LXw/mHNDEL7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.17.0.tgz",
+      "integrity": "sha512-Ow/yI+CrUHxIIhn/Y1sP/xoRKbCC3x9O1giKr3G/pjMe+TCJ5ZmfqVWU61JWwh1naC8X5Xa7uyLnbzyYqPsHfg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.17.0.tgz",
+      "integrity": "sha512-Z4J7XlPMQOLPANyu6y3B3V417Md4LKH5bV6bhqgaG99qLHmU5LV2k9ErV14fSqoRc/GU/qOpqMdotxiJqN/YWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.17.0.tgz",
+      "integrity": "sha512-0effK+8lhzXsgsh0Ny2ngdnTPF30v6QQzVFApJ1Ctk315YgpGkghkelvrLYYgtgeFJFrzwmOJ2nDvCrUFKsS2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.17.0.tgz",
+      "integrity": "sha512-kFB48dRUW6RovAICZaxHKdtZe+e94fSTNA2OedXokzMctoU54NPZcv0vUX5PMqyikLIKJBIlW7laQidnAzNrDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.17.0.tgz",
+      "integrity": "sha512-a3elKSBLPT0OoRPxTkCIIc+4xnOELolEBkPyvdj01a6PSdSmyJ1NExWjWLaXnT6wBMblvKde5RmSwEi3j+jZpg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.17.0.tgz",
+      "integrity": "sha512-4eszUsSDb9YVx0RtYkPWkxxtSZIOgfeiX//nG5cwRRArg178w4RCqEF1kbKPud9HPrp1rXh7gE4x911OhvTnPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.17.0.tgz",
+      "integrity": "sha512-t946xTXMmR7yGH0KAe9rB055/X4EPIu93JUvjchl2cizR5QbuwkUV7vLS2BS6x6sfvDoQb6rWYnV1HCci6tBSg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.17.0.tgz",
+      "integrity": "sha512-pX6s2kMXLQg+hlqKk5UqOW09iLLxnTkvn8ohpYp2Mhsm2yzDPCx9dyOHiB/CQixLzTkLQgWWJykN4Z3UfRKW4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2326,6 +2624,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/archiver": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
@@ -2573,27 +2882,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "minipass": "^4.0.0"
-      }
-    },
-    "node_modules/@types/tar/node_modules/minipass": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@types/triple-beam": {
@@ -5796,6 +6084,16 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -5958,6 +6256,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^2.0.0"
+      },
+      "bin": {
+        "formatly": "bin/index.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0"
       }
     },
     "node_modules/fs-constants": {
@@ -6552,7 +6866,8 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -6883,6 +7198,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6890,10 +7215,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7004,6 +7330,7 @@
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
       "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -7042,6 +7369,74 @@
       "dependencies": {
         "node-addon-api": "^4.3.0",
         "prebuild-install": "^7.0.1"
+      }
+    },
+    "node_modules/knip": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-5.83.1.tgz",
+      "integrity": "sha512-av3ZG/Nui6S/BNL8Tmj12yGxYfTnwWnslouW97m40him7o8MwiMjZBY9TPvlEWUci45aVId0/HbgTwSKIDGpMw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/webpro"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/knip"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@nodelib/fs.walk": "^1.2.3",
+        "fast-glob": "^3.3.3",
+        "formatly": "^0.3.0",
+        "jiti": "^2.6.0",
+        "js-yaml": "^4.1.1",
+        "minimist": "^1.2.8",
+        "oxc-resolver": "^11.15.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.1",
+        "smol-toml": "^1.5.2",
+        "strip-json-comments": "5.0.3",
+        "zod": "^4.1.11"
+      },
+      "bin": {
+        "knip": "bin/knip.js",
+        "knip-bun": "bin/knip-bun.js"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18",
+        "typescript": ">=5.0.4 <7"
+      }
+    },
+    "node_modules/knip/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/knip/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/kuler": {
@@ -7096,6 +7491,7 @@
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -7673,10 +8069,14 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minipass": {
       "version": "7.1.2",
@@ -8418,9 +8818,9 @@
       }
     },
     "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8431,9 +8831,9 @@
       }
     },
     "node_modules/ora/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8444,9 +8844,9 @@
       }
     },
     "node_modules/ora/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -8512,9 +8912,9 @@
       }
     },
     "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8525,6 +8925,38 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.17.0.tgz",
+      "integrity": "sha512-R5P2Tw6th+nQJdNcZGfuppBS/sM0x1EukqYffmlfX2xXLgLGCCPwu4ruEr9Sx29mrpkHgITc130Qps2JR90NdQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.17.0",
+        "@oxc-resolver/binding-android-arm64": "11.17.0",
+        "@oxc-resolver/binding-darwin-arm64": "11.17.0",
+        "@oxc-resolver/binding-darwin-x64": "11.17.0",
+        "@oxc-resolver/binding-freebsd-x64": "11.17.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.17.0",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.17.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.17.0",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.17.0",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-x64-musl": "11.17.0",
+        "@oxc-resolver/binding-openharmony-arm64": "11.17.0",
+        "@oxc-resolver/binding-wasm32-wasi": "11.17.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.17.0",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.17.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.17.0"
       }
     },
     "node_modules/p-limit": {
@@ -9598,7 +10030,8 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -9841,6 +10274,19 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/socks": {
@@ -10866,15 +11312,6 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
-    "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true,
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -11220,6 +11657,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/which": {
@@ -11633,9 +12080,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
-      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -11646,41 +12094,6 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true
-    },
-    "@actions/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
-      "dev": true,
-      "requires": {
-        "@actions/exec": "^3.0.0",
-        "@actions/http-client": "^4.0.0"
-      }
-    },
-    "@actions/exec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
-      "dev": true,
-      "requires": {
-        "@actions/io": "^3.0.2"
-      }
-    },
-    "@actions/http-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
-      "dev": true,
-      "requires": {
-        "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
-      }
-    },
-    "@actions/io": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "dev": true
     },
     "@azu/format-text": {
@@ -11985,6 +12398,37 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@esbuild/aix-ppc64": {
@@ -12370,6 +12814,18 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
     },
+    "@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12748,6 +13204,149 @@
       "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
       "dev": true
+    },
+    "@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.17.0.tgz",
+      "integrity": "sha512-kVnY21v0GyZ/+LG6EIO48wK3mE79BUuakHUYLIqobO/Qqq4mJsjuYXMSn3JtLcKZpN1HDVit4UHpGJHef1lrlw==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-android-arm64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.17.0.tgz",
+      "integrity": "sha512-Pf8e3XcsK9a8RHInoAtEcrwf2vp7V9bSturyUUYxw9syW6E7cGi7z9+6ADXxm+8KAevVfLA7pfBg8NXTvz/HOw==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.17.0.tgz",
+      "integrity": "sha512-lVSgKt3biecofXVr8e1hnfX0IYMd4A6VCxmvOmHsFt5Zbmt0lkO4S2ap2bvQwYDYh5ghUNamC7M2L8K6vishhQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-darwin-x64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.17.0.tgz",
+      "integrity": "sha512-+/raxVJE1bo7R4fA9Yp0wm3slaCOofTEeUzM01YqEGcRDLHB92WRGjRhagMG2wGlvqFuSiTp81DwSbBVo/g6AQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.17.0.tgz",
+      "integrity": "sha512-x9Ks56n+n8h0TLhzA6sJXa2tGh3uvMGpBppg6PWf8oF0s5S/3p/J6k1vJJ9lIUtTmenfCQEGKnFokpRP4fLTLg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.17.0.tgz",
+      "integrity": "sha512-Wf3w07Ow9kXVJrS0zmsaFHKOGhXKXE8j1tNyy+qIYDsQWQ4UQZVx5SjlDTcqBnFerlp3Z3Is0RjmVzgoLG3qkA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.17.0.tgz",
+      "integrity": "sha512-N0OKA1al1gQ5Gm7Fui1RWlXaHRNZlwMoBLn3TVtSXX+WbnlZoVyDqqOqFL8+pVEHhhxEA2LR8kmM0JO6FAk6dg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.17.0.tgz",
+      "integrity": "sha512-wdcQ7Niad9JpjZIGEeqKJnTvczVunqlZ/C06QzR5zOQNeLVRScQ9S5IesKWUAPsJQDizV+teQX53nTK+Z5Iy+g==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.17.0.tgz",
+      "integrity": "sha512-65B2/t39HQN5AEhkLsC+9yBD1iRUkKOIhfmJEJ7g6wQ9kylra7JRmNmALFjbsj0VJsoSQkpM8K07kUZuNJ9Kxw==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.17.0.tgz",
+      "integrity": "sha512-kExgm3TLK21dNMmcH+xiYGbc6BUWvT03PUZ2aYn8mUzGPeeORklBhg3iYcaBI3ZQHB25412X1Z6LLYNjt4aIaA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.17.0.tgz",
+      "integrity": "sha512-1utUJC714/ydykZQE8c7QhpEyM4SaslMfRXxN9G61KYazr6ndt85LaubK3EZCSD50vVEfF4PVwFysCSO7LN9uA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.17.0.tgz",
+      "integrity": "sha512-mayiYOl3LMmtO2CLn4I5lhanfxEo0LAqlT/EQyFbu1ZN3RS+Xa7Q3JEM0wBpVIyfO/pqFrjvC5LXw/mHNDEL7A==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.17.0.tgz",
+      "integrity": "sha512-Ow/yI+CrUHxIIhn/Y1sP/xoRKbCC3x9O1giKr3G/pjMe+TCJ5ZmfqVWU61JWwh1naC8X5Xa7uyLnbzyYqPsHfg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.17.0.tgz",
+      "integrity": "sha512-Z4J7XlPMQOLPANyu6y3B3V417Md4LKH5bV6bhqgaG99qLHmU5LV2k9ErV14fSqoRc/GU/qOpqMdotxiJqN/YWg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.17.0.tgz",
+      "integrity": "sha512-0effK+8lhzXsgsh0Ny2ngdnTPF30v6QQzVFApJ1Ctk315YgpGkghkelvrLYYgtgeFJFrzwmOJ2nDvCrUFKsS2Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.17.0.tgz",
+      "integrity": "sha512-kFB48dRUW6RovAICZaxHKdtZe+e94fSTNA2OedXokzMctoU54NPZcv0vUX5PMqyikLIKJBIlW7laQidnAzNrDA==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.17.0.tgz",
+      "integrity": "sha512-a3elKSBLPT0OoRPxTkCIIc+4xnOELolEBkPyvdj01a6PSdSmyJ1NExWjWLaXnT6wBMblvKde5RmSwEi3j+jZpg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      }
+    },
+    "@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.17.0.tgz",
+      "integrity": "sha512-4eszUsSDb9YVx0RtYkPWkxxtSZIOgfeiX//nG5cwRRArg178w4RCqEF1kbKPud9HPrp1rXh7gE4x911OhvTnPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-win32-ia32-msvc": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.17.0.tgz",
+      "integrity": "sha512-t946xTXMmR7yGH0KAe9rB055/X4EPIu93JUvjchl2cizR5QbuwkUV7vLS2BS6x6sfvDoQb6rWYnV1HCci6tBSg==",
+      "dev": true,
+      "optional": true
+    },
+    "@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.17.0.tgz",
+      "integrity": "sha512-pX6s2kMXLQg+hlqKk5UqOW09iLLxnTkvn8ohpYp2Mhsm2yzDPCx9dyOHiB/CQixLzTkLQgWWJykN4Z3UfRKW4Q==",
+      "dev": true,
+      "optional": true
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -13204,6 +13803,16 @@
         }
       }
     },
+    "@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@types/archiver": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
@@ -13431,24 +14040,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/tar": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
-      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "minipass": "^4.0.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "4.2.8",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
-          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
-          "dev": true
-        }
       }
     },
     "@types/triple-beam": {
@@ -15719,6 +16310,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fd-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-2.0.0.tgz",
+      "integrity": "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==",
+      "dev": true,
+      "requires": {
+        "walk-up-path": "^4.0.0"
+      }
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -15838,6 +16438,15 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formatly": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
+      "integrity": "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==",
+      "dev": true,
+      "requires": {
+        "fd-package-json": "^2.0.0"
       }
     },
     "fs-constants": {
@@ -16469,6 +17078,12 @@
       "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
       "dev": true
     },
+    "jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16476,9 +17091,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -16607,6 +17222,40 @@
       "requires": {
         "node-addon-api": "^4.3.0",
         "prebuild-install": "^7.0.1"
+      }
+    },
+    "knip": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/knip/-/knip-5.83.1.tgz",
+      "integrity": "sha512-av3ZG/Nui6S/BNL8Tmj12yGxYfTnwWnslouW97m40him7o8MwiMjZBY9TPvlEWUci45aVId0/HbgTwSKIDGpMw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.walk": "^1.2.3",
+        "fast-glob": "^3.3.3",
+        "formatly": "^0.3.0",
+        "jiti": "^2.6.0",
+        "js-yaml": "^4.1.1",
+        "minimist": "^1.2.8",
+        "oxc-resolver": "^11.15.0",
+        "picocolors": "^1.1.1",
+        "picomatch": "^4.0.1",
+        "smol-toml": "^1.5.2",
+        "strip-json-comments": "5.0.3",
+        "zod": "^4.1.11"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+          "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+          "dev": true
+        }
       }
     },
     "kuler": {
@@ -17072,9 +17721,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minipass": {
@@ -17619,21 +18268,21 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
           "dev": true
         },
         "chalk": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-          "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+          "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
           "dev": true
         },
         "emoji-regex": {
-          "version": "10.4.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-          "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+          "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
           "dev": true
         },
         "is-unicode-supported": {
@@ -17672,14 +18321,42 @@
           }
         },
         "strip-ansi": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+          "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
           "dev": true,
           "requires": {
             "ansi-regex": "^6.0.1"
           }
         }
+      }
+    },
+    "oxc-resolver": {
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.17.0.tgz",
+      "integrity": "sha512-R5P2Tw6th+nQJdNcZGfuppBS/sM0x1EukqYffmlfX2xXLgLGCCPwu4ruEr9Sx29mrpkHgITc130Qps2JR90NdQ==",
+      "dev": true,
+      "requires": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.17.0",
+        "@oxc-resolver/binding-android-arm64": "11.17.0",
+        "@oxc-resolver/binding-darwin-arm64": "11.17.0",
+        "@oxc-resolver/binding-darwin-x64": "11.17.0",
+        "@oxc-resolver/binding-freebsd-x64": "11.17.0",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.17.0",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.17.0",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.17.0",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.17.0",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.17.0",
+        "@oxc-resolver/binding-linux-x64-musl": "11.17.0",
+        "@oxc-resolver/binding-openharmony-arm64": "11.17.0",
+        "@oxc-resolver/binding-wasm32-wasi": "11.17.0",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.17.0",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.17.0",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.17.0"
       }
     },
     "p-limit": {
@@ -18575,6 +19252,12 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true
     },
+    "smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "dev": true
+    },
     "socks": {
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
@@ -19315,12 +19998,6 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
-    "undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
-      "dev": true
-    },
     "undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -19583,6 +20260,12 @@
           }
         }
       }
+    },
+    "walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",
@@ -19880,9 +20563,9 @@
       }
     },
     "zod": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
-      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg=="
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2061,7 +2061,7 @@
     "watch": "npm run compile -- --watch",
     "compile-documentation-webview": "del-cli ./assets/documentation-webview && esbuild ./src/documentation/webview/webview.ts --bundle --outfile=assets/documentation-webview/index.js --define:process.env.NODE_ENV=\\\"production\\\" --define:process.env.CI=\\\"\\\" --format=cjs --sourcemap",
     "watch-documentation-webview": "npm run compile-documentation-webview -- --watch",
-    "lint": "eslint ./ --ext ts && tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",
+    "lint": "eslint ./ --ext ts && tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json && knip",
     "build-swift-docc-render": "tsx ./scripts/build_swift_docc_render.ts",
     "compile-icons": "tsx ./scripts/compile_icons.ts",
     "format": "prettier --check .",
@@ -2091,7 +2091,6 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "devDependencies": {
-    "@actions/core": "^3.0.0",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@twbs/fantasticon": "^3.1.0",
     "@types/archiver": "^7.0.0",
@@ -2113,7 +2112,6 @@
     "@types/source-map-support": "^0.5.10",
     "@types/svg2ttf": "^5.0.3",
     "@types/svgicons2svgfont": "^10.0.5",
-    "@types/tar": "^6.1.13",
     "@types/ttf2woff": "^2.0.4",
     "@types/vscode": "^1.88.0",
     "@types/xml2js": "^0.4.14",
@@ -2134,6 +2132,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-mocha": "^10.5.0",
     "husky": "^9.1.7",
+    "knip": "^5.83.1",
     "lint-staged": "^16.2.7",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -389,8 +389,3 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
         }
     }
 }
-
-export interface EditedPackage {
-    name: string;
-    folder: string;
-}

--- a/src/SwiftExtensionApi.ts
+++ b/src/SwiftExtensionApi.ts
@@ -14,7 +14,7 @@
 import * as vscode from "vscode";
 
 /** The identifier for the Swift extension as it appears in the VSCode Marketplace and OpenVSX. */
-export const SWIFT_EXTENSION_ID = "swiftlang.swift-vscode";
+const SWIFT_EXTENSION_ID = "swiftlang.swift-vscode";
 
 /**
  * Retrieves the API for the Swift extension.

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -38,15 +38,7 @@ import { lineBreakRegex } from "./utilities/tasks";
 import { execSwift, getErrorDescription, hashString, unwrapPromise } from "./utilities/utilities";
 
 // Re-export some types from the external API for convenience.
-export {
-    Dependency,
-    PackagePlugin,
-    PackageResolvedPin,
-    PackageResolvedPinState,
-    ResolvedDependency,
-    Target,
-    TargetType,
-};
+export { Dependency, PackagePlugin, ResolvedDependency, Target, TargetType };
 
 // Need to re-export the Product interface with internal types
 export interface Product extends ExternalProduct {
@@ -66,7 +58,7 @@ export function isAutomatic(product: Product): boolean {
 }
 
 /** Swift Package.resolved file */
-export class PackageResolved implements ExternalPackageResolved {
+class PackageResolved implements ExternalPackageResolved {
     readonly fileHash: number;
     readonly pins: PackageResolvedPin[];
     readonly version: number;
@@ -126,7 +118,7 @@ interface PackageResolvedPinFileV2 {
 }
 
 /** workspace-state.json file */
-export interface WorkspaceState {
+interface WorkspaceState {
     object: { dependencies: WorkspaceStateDependency[] };
     version: number;
 }
@@ -134,13 +126,13 @@ export interface WorkspaceState {
 /** revision + (branch || version)
  * ref: https://github.com/apple/swift-package-manager/blob/e25a590dc455baa430f2ec97eacc30257c172be2/Sources/Workspace/CheckoutState.swift#L19:L23
  */
-export interface CheckoutState {
+interface CheckoutState {
     revision: string;
     branch: string | null;
     version: string | null;
 }
 
-export interface WorkspaceStateDependency {
+interface WorkspaceStateDependency {
     packageRef: { identity: string; kind: string; location: string; name: string };
     state: { name: string; path?: string; checkoutState?: CheckoutState; version?: string };
     subpath: string;

--- a/src/SwiftSnippets.ts
+++ b/src/SwiftSnippets.ts
@@ -20,30 +20,6 @@ import { createSwiftTask } from "./tasks/SwiftTaskProvider";
 import { TaskOperation } from "./tasks/TaskQueue";
 
 /**
- * Set context key indicating whether current file is a Swift Snippet
- * @param ctx Workspace context
- */
-export function setSnippetContextKey(ctx: WorkspaceContext) {
-    if (
-        !ctx.currentFolder ||
-        !ctx.currentDocument ||
-        ctx.currentFolder.swiftVersion.isLessThan({ major: 5, minor: 7, patch: 0 })
-    ) {
-        ctx.contextKeys.fileIsSnippet = false;
-        return;
-    }
-
-    const filename = ctx.currentDocument.fsPath;
-    const snippetsFolder = path.join(ctx.currentFolder.folder.fsPath, "Snippets");
-    if (filename.startsWith(snippetsFolder)) {
-        ctx.contextKeys.fileIsSnippet = true;
-    } else {
-        ctx.contextKeys.fileIsSnippet = false;
-    }
-    return;
-}
-
-/**
  * If current file is a Swift Snippet run it
  * @param ctx Workspace Context
  */
@@ -65,7 +41,7 @@ export async function debugSnippet(
     return await debugSnippetWithOptions(ctx, {}, snippet);
 }
 
-export async function debugSnippetWithOptions(
+async function debugSnippetWithOptions(
     ctx: WorkspaceContext,
     options: vscode.DebugSessionOptions,
     snippet?: string

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -89,7 +89,7 @@ type ParameterizedTestRecord = TestRecord & {
     };
 };
 
-export interface TestCase {
+interface TestCase {
     id: string;
     displayName: string;
 }

--- a/src/TestExplorer/TestXUnitParser.ts
+++ b/src/TestExplorer/TestXUnitParser.ts
@@ -16,7 +16,7 @@ import * as xml2js from "xml2js";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { ITestRunState } from "./TestParsers/TestRunState";
 
-export interface TestResults {
+interface TestResults {
     tests: number;
     failures: number;
     errors: number;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,7 +50,6 @@ import { runTest } from "./commands/runTest";
 import { switchPlatform } from "./commands/switchPlatform";
 import { extractTestItemsAndCount, runTestMultipleTimes } from "./commands/testMultipleTimes";
 import { SwiftLogger } from "./logging/SwiftLogger";
-import { SwiftToolchain } from "./toolchain/toolchain";
 import { PackageNode, PlaygroundNode } from "./ui/ProjectPanelProvider";
 import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
 
@@ -62,8 +61,6 @@ import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
  * - Implementing commands:
  *   https://code.visualstudio.com/api/extension-guides/command
  */
-
-export type WorkspaceContextWithToolchain = WorkspaceContext & { toolchain: SwiftToolchain };
 
 export function registerToolchainCommands(
     ctx: WorkspaceContext | undefined,

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -50,7 +50,7 @@ export async function cleanBuild(ctx: WorkspaceContext) {
  * Run `swift package clean` inside a folder
  * @param folderContext folder to run update inside
  */
-export async function folderCleanBuild(folderContext: FolderContext) {
+async function folderCleanBuild(folderContext: FolderContext) {
     const task = createSwiftTask(
         ["package", "clean"],
         SwiftTaskProvider.cleanBuildName,
@@ -70,7 +70,7 @@ export async function folderCleanBuild(folderContext: FolderContext) {
 /**
  * Executes a {@link vscode.Task task} to debug swift target.
  */
-export async function debugBuildWithOptions(
+async function debugBuildWithOptions(
     ctx: WorkspaceContext,
     options: vscode.DebugSessionOptions,
     targetName: string | undefined

--- a/src/commands/dependencies/describe.ts
+++ b/src/commands/dependencies/describe.ts
@@ -22,7 +22,7 @@ import { executeTaskWithUI, updateAfterError } from "../utilities";
 /**
  * Configuration for executing a Swift package command
  */
-export interface SwiftPackageCommandConfig {
+interface SwiftPackageCommandConfig {
     /** The Swift command arguments (e.g., ["package", "show-dependencies", "--format", "json"]) */
     args: string[];
     /** The task name for the SwiftTaskProvider */

--- a/src/commands/dependencies/update.ts
+++ b/src/commands/dependencies/update.ts
@@ -35,7 +35,7 @@ export async function updateDependencies(ctx: WorkspaceContext) {
  * Run `swift package update` inside a folder
  * @param folderContext folder to run update inside
  */
-export async function updateFolderDependencies(folderContext: FolderContext) {
+async function updateFolderDependencies(folderContext: FolderContext) {
     const task = createSwiftTask(
         ["package", "update"],
         SwiftTaskProvider.updatePackageName,

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -20,8 +20,8 @@ import configuration from "../configuration";
 import { selectFolder } from "../ui/SelectFolderQuickPick";
 import restartLSPServer from "./restartLSPServer";
 
-export const sourcekitDotFolder: string = ".sourcekit-lsp";
-export const sourcekitConfigFileName: string = "config.json";
+const sourcekitDotFolder: string = ".sourcekit-lsp";
+const sourcekitConfigFileName: string = "config.json";
 
 export async function generateSourcekitConfiguration(ctx: WorkspaceContext): Promise<boolean> {
     if (ctx.folders.length === 0) {

--- a/src/commands/installSwiftly.ts
+++ b/src/commands/installSwiftly.ts
@@ -79,7 +79,7 @@ This process involves updating your shell profile in order to add swiftly to you
  * @param logger Optional logger
  * @returns Promise<boolean> true if installation succeeded
  */
-export async function installSwiftlyWithProgress(logger?: SwiftLogger): Promise<boolean> {
+async function installSwiftlyWithProgress(logger?: SwiftLogger): Promise<boolean> {
     try {
         await vscode.window.withProgress(
             {

--- a/src/commands/resetPackage.ts
+++ b/src/commands/resetPackage.ts
@@ -34,7 +34,7 @@ export async function resetPackage(ctx: WorkspaceContext, folder: FolderContext 
  * Run `swift package reset` inside a folder
  * @param folderContext folder to run update inside
  */
-export async function folderResetPackage(folderContext: FolderContext) {
+async function folderResetPackage(folderContext: FolderContext) {
     const task = createSwiftTask(
         folderContext.toolchain.buildFlags.withAdditionalFlags(["package", "reset"]),
         "Reset Package Dependencies",

--- a/src/commands/runPlayground.ts
+++ b/src/commands/runPlayground.ts
@@ -12,24 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
-import { Location, Range } from "vscode-languageclient";
 
 import { FolderContext } from "../FolderContext";
 import { createSwiftTask } from "../tasks/SwiftTaskProvider";
 import { TaskManager } from "../tasks/TaskManager";
 import { packageName } from "../utilities/tasks";
 
-export interface PlaygroundItem {
+interface PlaygroundItem {
     id: string;
     label?: string;
-}
-
-export interface DocumentPlaygroundItem extends PlaygroundItem {
-    range: Range;
-}
-
-export interface WorkspacePlaygroundItem extends PlaygroundItem {
-    location: Location;
 }
 
 /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -33,21 +33,17 @@ export class ConfigurationValidationError extends Error {
     }
 }
 
-export type DebugAdapters = "auto" | "lldb-dap" | "CodeLLDB";
-export type SetupCodeLLDBOptions =
-    | "prompt"
-    | "alwaysUpdateGlobal"
-    | "alwaysUpdateWorkspace"
-    | "never";
-export type CFamilySupportOptions = "enable" | "disable" | "cpptools-inactive";
-export type ActionAfterBuildError = "Focus Problems" | "Focus Terminal" | "Do Nothing";
-export type OpenAfterCreateNewProjectOptions =
+type DebugAdapters = "auto" | "lldb-dap" | "CodeLLDB";
+type SetupCodeLLDBOptions = "prompt" | "alwaysUpdateGlobal" | "alwaysUpdateWorkspace" | "never";
+type CFamilySupportOptions = "enable" | "disable" | "cpptools-inactive";
+type ActionAfterBuildError = "Focus Problems" | "Focus Terminal" | "Do Nothing";
+type OpenAfterCreateNewProjectOptions =
     | "always"
     | "alwaysNewWindow"
     | "whenNoFolderOpen"
     | "prompt";
 export type ShowBuildStatusOptions = "never" | "swiftStatus" | "progress" | "notification";
-export type DiagnosticCollectionOptions =
+type DiagnosticCollectionOptions =
     | "onlySwiftc"
     | "onlySourceKit"
     | "keepSwiftc"
@@ -57,7 +53,7 @@ export type DiagnosticStyle = "default" | "llvm" | "swift";
 export type ValidCodeLens = "run" | "debug" | "coverage";
 
 /** sourcekit-lsp configuration */
-export interface LSPConfiguration {
+interface LSPConfiguration {
     /** Path to sourcekit-lsp executable */
     readonly serverPath: string;
     /** Arguments to pass to sourcekit-lsp executable */
@@ -73,7 +69,7 @@ export interface LSPConfiguration {
 }
 
 /** debugger configuration */
-export interface DebuggerConfiguration {
+interface DebuggerConfiguration {
     /** Get the underlying debug adapter type requested by the user. */
     readonly debugAdapter: DebugAdapters;
     /** Return path to debug adapter */
@@ -125,7 +121,7 @@ export interface PluginPermissionConfiguration {
     allowNetworkConnections?: string;
 }
 
-export interface BackgroundCompilationConfiguration {
+interface BackgroundCompilationConfiguration {
     /** enable background compilation task on save */
     enabled: boolean;
     /** use the default `swift` build task when background compilation is enabled */

--- a/src/debugger/launch.ts
+++ b/src/debugger/launch.ts
@@ -23,7 +23,7 @@ import { getFolderAndNameSuffix } from "./buildConfig";
 import { SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 
 /** Options used to configure {@link makeDebugConfigurations}. */
-export interface WriteLaunchConfigurationsOptions {
+interface WriteLaunchConfigurationsOptions {
     /** Force the generation of launch configurations regardless of user settings. */
     force?: boolean;
 
@@ -144,7 +144,7 @@ export async function getTargetBinaryPath(
     }
 }
 
-export function getLegacyTargetBinaryPath(
+function getLegacyTargetBinaryPath(
     targetName: string,
     buildConfiguration: "debug" | "release",
     folderCtx: FolderContext

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -19,7 +19,7 @@ import { LaunchConfigType } from "./debugAdapter";
 /**
  * Factory class for building LoggingDebugAdapterTracker
  */
-export class LoggingDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
+class LoggingDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
     createDebugAdapterTracker(
         session: vscode.DebugSession
     ): vscode.ProviderResult<vscode.DebugAdapterTracker> {

--- a/src/documentation/webview/CommunicationBridge.ts
+++ b/src/documentation/webview/CommunicationBridge.ts
@@ -16,7 +16,7 @@ import { Disposable } from "./Disposable";
 /**
  * Sends and receives messages from swift-docc-render
  */
-export interface CommunicationBridge {
+interface CommunicationBridge {
     send(message: VueAppMessage): void;
     onDidReceiveMessage(handler: (message: VueAppMessage) => void): Disposable;
 }
@@ -83,13 +83,13 @@ export function createCommunicationBridge(): Promise<CommunicationBridge> {
 /**
  * Represents a message that can be sent between the webview and swift-docc-render
  */
-export type VueAppMessage = RenderedMessage | NavigationMessage | UpdateContentMessage;
+type VueAppMessage = RenderedMessage | NavigationMessage | UpdateContentMessage;
 
 /**
  * Sent from swift-docc-render to the webview when content as been rendered
  * to the screen.
  */
-export interface RenderedMessage {
+interface RenderedMessage {
     type: "rendered";
 }
 
@@ -100,7 +100,7 @@ export interface RenderedMessage {
  * need to send an {@link UpdateContentMessage} after the first render to
  * switch pages.
  */
-export interface NavigationMessage {
+interface NavigationMessage {
     type: "navigation";
     data: string;
 }
@@ -113,7 +113,7 @@ export interface NavigationMessage {
  * JavaScript object before sending. Raw strings will not be parsed
  * automatically.
  */
-export interface UpdateContentMessage {
+interface UpdateContentMessage {
     type: "contentUpdate";
     data: unknown;
 }

--- a/src/icons/config.ts
+++ b/src/icons/config.ts
@@ -26,7 +26,7 @@ export const config: IconConfiguration = {
  * Config used by scripts/compile_icons.ts to generate the SVG icons and
  * icon font file.
  */
-export interface IconConfiguration {
+interface IconConfiguration {
     icons: {
         [key: string]: {
             /**
@@ -49,4 +49,4 @@ export interface IconConfiguration {
     };
 }
 
-export type IconColor = string | { light: string; dark: string };
+type IconColor = string | { light: string; dark: string };

--- a/src/playgrounds/PlaygroundProvider.ts
+++ b/src/playgrounds/PlaygroundProvider.ts
@@ -20,7 +20,7 @@ import { LSPPlaygroundsDiscovery, Playground } from "./LSPPlaygroundsDiscovery";
 
 export { Playground };
 
-export interface PlaygroundChangeEvent {
+interface PlaygroundChangeEvent {
     uri: string;
     playgrounds: Playground[];
 }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -693,7 +693,7 @@ export class SourceKitLSPErrorHandler implements ErrorHandler {
 }
 
 /** Language client errors */
-export const enum LanguageClientError {
+const enum LanguageClientError {
     LanguageClientUnavailable = "Language Client Unavailable",
 }
 

--- a/src/sourcekit-lsp/extensions/DocCDocumentationRequest.ts
+++ b/src/sourcekit-lsp/extensions/DocCDocumentationRequest.ts
@@ -21,7 +21,7 @@ import {
 } from "vscode-languageclient";
 
 /** Parameters used to make a {@link DocCDocumentationRequest}. */
-export interface DocCDocumentationParams {
+interface DocCDocumentationParams {
     /**
      * The document to render documentation for.
      */

--- a/src/sourcekit-lsp/extensions/GetReferenceDocumentRequest.ts
+++ b/src/sourcekit-lsp/extensions/GetReferenceDocumentRequest.ts
@@ -22,7 +22,7 @@ export interface GetReferenceDocumentParams {
 }
 
 /** Response containing `content` of a {@link GetReferenceDocumentRequest}. */
-export interface GetReferenceDocumentResult {
+interface GetReferenceDocumentResult {
     content: string;
 }
 

--- a/src/sourcekit-lsp/extensions/GetTestsRequest.ts
+++ b/src/sourcekit-lsp/extensions/GetTestsRequest.ts
@@ -92,7 +92,7 @@ export namespace WorkspaceTestsRequest {
 }
 
 /** Parameters used to make a {@link TextDocumentTestsRequest}. */
-export interface TextDocumentTestsParams {
+interface TextDocumentTestsParams {
     textDocument: TextDocumentIdentifier;
 }
 

--- a/src/sourcekit-lsp/extensions/LegacyInlayHintRequest.ts
+++ b/src/sourcekit-lsp/extensions/LegacyInlayHintRequest.ts
@@ -22,7 +22,7 @@ import {
 } from "vscode-languageclient";
 
 /** Parameters used to make a {@link LegacyInlayHintRequest}. */
-export interface LegacyInlayHintsParams {
+interface LegacyInlayHintsParams {
     /**
      * The text document.
      */
@@ -43,7 +43,7 @@ export interface LegacyInlayHintsParams {
 }
 
 /** Inlay Hint (pre Swift 5.6) */
-export interface LegacyInlayHint {
+interface LegacyInlayHint {
     /**
      * The position within the code that this hint is
      * attached to.

--- a/src/sourcekit-lsp/extensions/PeekDocumentsRequest.ts
+++ b/src/sourcekit-lsp/extensions/PeekDocumentsRequest.ts
@@ -40,7 +40,7 @@ export interface PeekDocumentsParams {
 }
 
 /** Response to indicate the `success` of the {@link PeekDocumentsRequest}. */
-export interface PeekDocumentsResponse {
+interface PeekDocumentsResponse {
     success: boolean;
 }
 

--- a/src/sourcekit-lsp/extensions/SymbolInfoRequest.ts
+++ b/src/sourcekit-lsp/extensions/SymbolInfoRequest.ts
@@ -23,7 +23,7 @@ import {
 } from "vscode-languageclient";
 
 /** Parameters used to make a {@link SymbolInfoRequest}. */
-export interface SymbolInfoParams {
+interface SymbolInfoParams {
     /** The document in which to lookup the symbol location. */
     textDocument: TextDocumentIdentifier;
 
@@ -32,7 +32,7 @@ export interface SymbolInfoParams {
 }
 
 /** Information about which module a symbol is defined in. */
-export interface ModuleInfo {
+interface ModuleInfo {
     /** The name of the module in which the symbol is defined. */
     moduleName: string;
 
@@ -41,7 +41,7 @@ export interface ModuleInfo {
 }
 
 /** Detailed information about a symbol, such as the response to a {@link SymbolInfoRequest}. */
-export interface SymbolDetails {
+interface SymbolDetails {
     /** The name of the symbol, if any. */
     name?: string;
 

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -16,7 +16,7 @@ import * as vscode from "vscode";
 import { ReadOnlySwiftProcess, SwiftProcess, SwiftPtyProcess } from "./SwiftProcess";
 import { SwiftPseudoterminal } from "./SwiftPseudoterminal";
 
-export interface SwiftExecutionOptions extends vscode.ProcessExecutionOptions {
+interface SwiftExecutionOptions extends vscode.ProcessExecutionOptions {
     presentation?: vscode.TaskPresentationOptions;
     readOnlyTerminal?: boolean;
 }

--- a/src/tasks/SwiftTaskProvider.ts
+++ b/src/tasks/SwiftTaskProvider.ts
@@ -73,7 +73,7 @@ export function platformDebugBuildOptions(toolchain: SwiftToolchain): string[] {
 }
 
 /** arguments for setting diagnostics style */
-export function diagnosticsStyleOptions(): string[] {
+function diagnosticsStyleOptions(): string[] {
     if (configuration.diagnosticsStyle !== "default") {
         return ["-Xswiftc", `-diagnostic-style=${configuration.diagnosticsStyle}`];
     }

--- a/src/tasks/TaskManager.ts
+++ b/src/tasks/TaskManager.ts
@@ -163,5 +163,5 @@ export class TaskManager implements vscode.Disposable {
 }
 
 /** Workspace Folder observer function */
-export type TaskStartObserver = (event: vscode.TaskStartEvent) => unknown;
-export type TaskEndObserver = (execution: vscode.TaskProcessEndEvent) => unknown;
+type TaskStartObserver = (event: vscode.TaskStartEvent) => unknown;
+type TaskEndObserver = (execution: vscode.TaskProcessEndEvent) => unknown;

--- a/src/tasks/TaskQueue.ts
+++ b/src/tasks/TaskQueue.ts
@@ -17,7 +17,7 @@ import { FolderContext } from "../FolderContext";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { execSwift, poll } from "../utilities/utilities";
 
-export interface SwiftOperationOptions {
+interface SwiftOperationOptions {
     // Should I show a status item
     showStatusItem: boolean;
     // Should I check if an instance of this task is already running
@@ -26,7 +26,7 @@ export interface SwiftOperationOptions {
     log?: string;
 }
 /** Swift operation to add to TaskQueue */
-export interface SwiftOperation {
+interface SwiftOperation {
     // options
     options: SwiftOperationOptions;
     // identifier for statusitem

--- a/src/toolchain/BuildFlags.ts
+++ b/src/toolchain/BuildFlags.ts
@@ -19,7 +19,7 @@ import { execSwift } from "../utilities/utilities";
 import { DarwinCompatibleTarget, SwiftToolchain, getDarwinTargetTriple } from "./toolchain";
 
 /** Target info */
-export interface DarwinTargetInfo {
+interface DarwinTargetInfo {
     name: string;
     target: DarwinCompatibleTarget;
     version: string;

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -36,7 +36,7 @@ const SystemVersion = z.object({
     type: z.literal("system"),
     name: z.string(),
 });
-export type SystemVersion = z.infer<typeof SystemVersion>;
+type SystemVersion = z.infer<typeof SystemVersion>;
 
 const StableVersion = z.object({
     type: z.literal("stable"),
@@ -46,7 +46,7 @@ const StableVersion = z.object({
     minor: z.number(),
     patch: z.number(),
 });
-export type StableVersion = z.infer<typeof StableVersion>;
+type StableVersion = z.infer<typeof StableVersion>;
 
 const SnapshotVersion = z.object({
     type: z.literal("snapshot"),
@@ -57,18 +57,18 @@ const SnapshotVersion = z.object({
     branch: z.string(),
     date: z.string(),
 });
-export type SnapshotVersion = z.infer<typeof SnapshotVersion>;
+type SnapshotVersion = z.infer<typeof SnapshotVersion>;
 
-export type ToolchainVersion = SystemVersion | StableVersion | SnapshotVersion;
+type ToolchainVersion = SystemVersion | StableVersion | SnapshotVersion;
 
-export interface AvailableToolchain {
+interface AvailableToolchain {
     inUse: boolean;
     installed: boolean;
     isDefault: boolean;
     version: ToolchainVersion;
 }
 
-export interface InstalledToolchain {
+interface InstalledToolchain {
     name: string;
     location?: string;
 }
@@ -128,13 +128,13 @@ const SwiftlyProgressData = z.object({
 
 export type SwiftlyProgressData = z.infer<typeof SwiftlyProgressData>;
 
-export interface PostInstallValidationResult {
+interface PostInstallValidationResult {
     isValid: boolean;
     summary: string;
     invalidCommands?: string[];
 }
 
-export interface MissingToolchainError {
+interface MissingToolchainError {
     version: string;
     originalError: string;
 }

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -76,7 +76,7 @@ export enum DarwinCompatibleTarget {
     visionOS = "xrOS",
 }
 
-export function getDarwinSDKName(target: DarwinCompatibleTarget): string {
+function getDarwinSDKName(target: DarwinCompatibleTarget): string {
     switch (target) {
         case DarwinCompatibleTarget.iOS:
             return "iphoneos";

--- a/src/ui/win32.ts
+++ b/src/ui/win32.ts
@@ -53,7 +53,7 @@ export function checkAndWarnAboutWindowsSymlinks(logger: SwiftLogger) {
  *
  * @returns whether or not a symlink can be created
  */
-export async function isSymlinkAllowed(logger?: SwiftLogger): Promise<boolean> {
+async function isSymlinkAllowed(logger?: SwiftLogger): Promise<boolean> {
     const temporaryFolder = await TemporaryFolder.create();
     return await temporaryFolder.withTemporaryFile("", async testFilePath => {
         const testSymlinkPath = temporaryFolder.filename("symlink-");

--- a/src/utilities/commands.ts
+++ b/src/utilities/commands.ts
@@ -16,6 +16,5 @@ export enum Workbench {
     ACTION_DEBUG_CONTINUE = "workbench.action.debug.continue",
     ACTION_CLOSEALLEDITORS = "workbench.action.closeAllEditors",
     ACTION_RELOADWINDOW = "workbench.action.reloadWindow",
-    ACTION_PREVIOUSEDITORINGROUP = "workbench.action.previousEditorInGroup",
     ACTION_QUIT = "workbench.action.quit",
 }

--- a/src/utilities/workspace.ts
+++ b/src/utilities/workspace.ts
@@ -55,10 +55,7 @@ export async function searchForPackages(
     return folders;
 }
 
-export async function hasBSPConfigurationFile(
-    folder: string,
-    swiftVersion: Version
-): Promise<boolean> {
+async function hasBSPConfigurationFile(folder: string, swiftVersion: Version): Promise<boolean> {
     // buildServer.json
     const buildServerPath = path.join(folder, "buildServer.json");
     const buildServerStat = await fs.stat(buildServerPath).catch(() => undefined);

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -10,6 +10,7 @@
     "module": "commonjs",
 
     "strict": true,
+    "skipLibCheck": true,
 
     "sourceMap": true,
 


### PR DESCRIPTION
## Description
Add `knip` to the linting steps to ensure there are no unused dependencies or exports.

Go through and cull the warnings reported so we lint clean with the new check.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
