### PR TITLE
Unset DEVELOPER_DIR in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,9 @@
         "--security-opt",
         "seccomp=unconfined"
     ],
+    "remoteEnv": {
+        "DEVELOPER_DIR": null
+    },
     // Configure tool-specific properties.
     "customizations": {
         // Configure properties specific to VS Code.


### PR DESCRIPTION
## Description
When launching the Linux devcontainer on macOS its possible to have a DEVELOPER_DIR env var set, which doesn't apply to the Linux devcontainer. However it will confuse the extension, so simply unset it.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
