### PR TITLE
Fix check for running tests under the debugger

### DIFF
--- a/.vscode-test.js
+++ b/.vscode-test.js
@@ -23,8 +23,9 @@ const dataDir = process.env["VSCODE_DATA_DIR"];
 
 // Check if we're debugging by looking at the process executable. Unfortunately, the VS Code debugger
 // doesn't seem to allow setting environment variables on a launched extension host.
-const processPath = process.env["_"] ?? "";
-const isDebugRun = !isCIBuild && !processPath.endsWith("node_modules/.bin/vscode-test");
+//
+// When debugging, the process will be launched under VS Code instead of NodeJS.
+const isDebugRun = !isCIBuild && process.argv0.toLocaleLowerCase().includes("code");
 
 function log(/** @type {string} */ message) {
     if (!isDebugRun) {

--- a/src/logging/SwiftLogger.ts
+++ b/src/logging/SwiftLogger.ts
@@ -16,7 +16,7 @@ import * as winston from "winston";
 import type * as Transport from "winston-transport";
 
 import configuration from "../configuration";
-import { IS_RUNNING_IN_DEVELOPMENT_MODE, IS_RUNNING_UNDER_TEST } from "../utilities/utilities";
+import { IS_RUNNING_UNDER_DEBUGGER, IS_RUNNING_UNDER_TEST } from "../utilities/utilities";
 import { FileTransport } from "./FileTransport";
 import { OutputChannelTransport } from "./OutputChannelTransport";
 import { RollingLog } from "./RollingLog";
@@ -59,7 +59,7 @@ export class SwiftLogger implements vscode.Disposable {
             transports.push(rollingLogTransport);
         }
         // Log everything to the console when we're debugging
-        if (IS_RUNNING_IN_DEVELOPMENT_MODE) {
+        if (IS_RUNNING_UNDER_DEBUGGER) {
             transports.push(new winston.transports.Console({ level: "debug" }));
         }
 

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -52,9 +52,9 @@ export const IS_RUNNING_UNDER_TEST = process.env.RUNNING_UNDER_VSCODE_TEST_CLI =
 
 /**
  * Determined by the presence of the `VSCODE_DEBUG` environment variable, set by the
- * launch.json when starting the extension in development.
+ * launch.json when debugging the extension.
  */
-export const IS_RUNNING_IN_DEVELOPMENT_MODE = process.env["VSCODE_DEBUG"] === "1";
+export const IS_RUNNING_UNDER_DEBUGGER = process.env["VSCODE_DEBUG"] === "1";
 
 /** Determines whether the provided object has any properties set to non-null values. */
 export function isEmptyObject(obj: { [key: string]: unknown }): boolean {


### PR DESCRIPTION
## Description
The way we check for the presence of a debugger in `.vscode-test.js` only worked on macOS. While trying this out locally on macOS, Windows, and Linux I noticed that the process under which this script gets run is `node` when running from `npm test` and `code` when running from the debugger. Update the check to use this tell instead.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
