### PR TITLE
Show actionable LLDB-DAP error when python310.dll is missing on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fix legacy boolean setting values for `swift.sourcekit-lsp.backgroundIndexing` not being recognized ([#2092](https://github.com/swiftlang/vscode-swift/pull/2092))
 - Launch configurations defined in multi-root workspaces were unable to find the appropriate folder to run in ([#2105](https://github.com/swiftlang/vscode-swift/pull/2105))
 - Show a helpful error on Windows when LLDB-DAP cannot launch because `python310.dll` is missing ([#2054](https://github.com/swiftlang/vscode-swift/issues/2054))
-- Ignoring the dialog to use the toolchain defined in `.swift-version` would prevent extension acitvation ([2107](https://github.com/swiftlang/vscode-swift/pull/2107))
+- Ignoring the dialog to use the toolchain defined in `.swift-version` would prevent extension activation ([#2107](https://github.com/swiftlang/vscode-swift/pull/2107))
 
 ## 2.16.1 - 2026-02-02
 

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -19,7 +19,12 @@ import configuration from "../configuration";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { SwiftToolchain } from "../toolchain/toolchain";
 import { fileExists } from "../utilities/filesystem";
-import { execFile, getErrorDescription, swiftRuntimeEnv } from "../utilities/utilities";
+import {
+    ExecFileError,
+    execFile,
+    getErrorDescription,
+    swiftRuntimeEnv,
+} from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { DebugAdapter, LaunchConfigType, SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 import { getTargetBinaryPath, swiftPrelaunchBuildTaskArguments } from "./launch";
@@ -218,7 +223,9 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
                 );
                 return undefined;
             }
-            if (!(await this.checkWindowsPython310Requirement(lldbDapPath, toolchain.swiftVersion))) {
+            if (
+                !(await this.checkWindowsPython310Requirement(lldbDapPath, toolchain.swiftVersion))
+            ) {
                 return undefined;
             }
             launchConfig.debugAdapterExecutable = lldbDapPath;
@@ -278,7 +285,12 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
                 false
             );
             return stdout.trim().length > 0;
-        } catch {
+        } catch (error: unknown) {
+            if (!(error instanceof ExecFileError)) {
+                this.logger.error(
+                    `Failed while searching for ${pythonRuntimeDLL} with the 'where' command: ${getErrorDescription(error)}`
+                );
+            }
             return false;
         }
     }


### PR DESCRIPTION
## Description
Improve LLDB-DAP launch diagnostics on Windows when Python 3.10 is missing for Swift toolchains `6.2.3` and newer.

This change checks for `python310.dll` before launching `lldb-dap` and shows an actionable modal error instead of a generic lost-socket failure. It includes guidance to install Python 3.10, verify `python310.dll` on `PATH`, and logs the failure with the LLDB-DAP path.

It also adds unit tests for both missing and available runtime cases and updates `CHANGELOG.md`.

Issue: https://github.com/swiftlang/vscode-swift/issues/2054

## Tasks
- [x] Required tests have been written
- [x] Documentation has been updated (N/A for this bug fix)
- [x] Added an entry to CHANGELOG.md if applicable