### PR TITLE
Make logger required during toolchain creation

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -102,6 +102,7 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
         try {
             toolchain = await SwiftToolchain.create(
                 workspaceContext.extensionContext.extensionPath,
+                workspaceContext.logger,
                 configuration.folder(workspaceFolder).ignoreSwiftVersionFile ? undefined : folder
             );
         } catch (error) {
@@ -119,6 +120,7 @@ export class FolderContext implements ExternalFolderContext, vscode.Disposable {
                 try {
                     toolchain = await SwiftToolchain.create(
                         workspaceContext.extensionContext.extensionPath,
+                        workspaceContext.logger,
                         configuration.folder(workspaceFolder).ignoreSwiftVersionFile
                             ? undefined
                             : folder

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -432,7 +432,7 @@ async function createActiveToolchain(
     logger: SwiftLogger
 ): Promise<SwiftToolchain | undefined> {
     try {
-        const toolchain = await SwiftToolchain.create(extensionPath, undefined, logger);
+        const toolchain = await SwiftToolchain.create(extensionPath, logger, undefined);
         toolchain.logDiagnostics(logger);
         contextKeys.updateKeysBasedOnActiveVersion(toolchain.swiftVersion);
         return toolchain;

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -610,8 +610,8 @@ export class Swiftly {
 
     public static async getActiveToolchain(
         extensionRoot: string,
-        cwd?: vscode.Uri,
-        logger?: SwiftLogger
+        logger: SwiftLogger,
+        cwd?: vscode.Uri
     ): Promise<string> {
         try {
             return await Swiftly.inUseLocation("swiftly", cwd);
@@ -629,11 +629,11 @@ export class Swiftly {
                     );
                     if (installed) {
                         // Retry toolchain location after successful installation
-                        return await this.getActiveToolchain(extensionRoot, cwd, logger);
+                        return await this.getActiveToolchain(extensionRoot, logger, cwd);
                     } else if (cwd) {
                         // If the user dismisses the installation prompt then fall back
                         // to using the global toolchain
-                        return await Swiftly.getActiveToolchain(extensionRoot, undefined, logger);
+                        return await Swiftly.getActiveToolchain(extensionRoot, logger, undefined);
                     }
                 }
             }

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -127,15 +127,15 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
 
     static async create(
         extensionRoot: string,
-        folder?: vscode.Uri,
-        logger?: SwiftLogger
+        logger: SwiftLogger,
+        folder?: vscode.Uri
     ): Promise<SwiftToolchain> {
         const swiftBinaryPath = await this.findSwiftBinaryInPath();
         const { toolchainPath, toolchainManager } = await this.getToolchainPath(
             swiftBinaryPath,
             extensionRoot,
-            folder,
-            logger
+            logger,
+            folder
         );
         const targetInfo = await this.getSwiftTargetInfo(
             this._getToolchainExecutable(toolchainPath, "swift"),
@@ -550,8 +550,8 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
     private static async getToolchainPath(
         swiftBinaryPath: string,
         extensionRoot: string,
-        cwd?: vscode.Uri,
-        logger?: SwiftLogger
+        logger: SwiftLogger,
+        cwd?: vscode.Uri
     ): Promise<{
         toolchainPath: string;
         toolchainManager: ToolchainManager;
@@ -574,7 +574,11 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
             }
             // Check if the swift binary is managed by swiftly
             if (await Swiftly.isManagedBySwiftly(swiftBinaryPath)) {
-                const swiftlyToolchainPath = await Swiftly.getActiveToolchain(extensionRoot, cwd);
+                const swiftlyToolchainPath = await Swiftly.getActiveToolchain(
+                    extensionRoot,
+                    logger,
+                    cwd
+                );
                 return {
                     toolchainPath: path.resolve(swiftlyToolchainPath, "usr"),
                     toolchainManager: "swiftly",

--- a/test/integration-tests/FolderContext.test.ts
+++ b/test/integration-tests/FolderContext.test.ts
@@ -74,6 +74,7 @@ suite("FolderContext Error Handling Test Suite", () => {
         assert.ok(
             swiftToolchainCreateStub.calledWith(
                 workspaceContext.extensionContext.extensionPath,
+                folderContext.logger,
                 testFolder
             ),
             "Should attempt to create toolchain for specific folder"

--- a/test/integration-tests/tasks/SwiftExecution.test.ts
+++ b/test/integration-tests/tasks/SwiftExecution.test.ts
@@ -34,7 +34,8 @@ suite("SwiftExecution Tests Suite", () => {
         async setup(ctx) {
             workspaceContext = ctx;
             toolchain = await SwiftToolchain.create(
-                workspaceContext.extensionContext.extensionPath
+                workspaceContext.extensionContext.extensionPath,
+                ctx.logger
             );
             assert.notEqual(workspaceContext.folders.length, 0);
             workspaceFolder = workspaceContext.folders[0].workspaceFolder;

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -21,6 +21,7 @@ import * as vscode from "vscode";
 import * as askpass from "@src/askpass/askpass-server";
 import { handleMissingSwiftly, promptForSwiftlyInstallation } from "@src/commands/installSwiftly";
 import { installSwiftlyToolchainWithProgress } from "@src/commands/installSwiftlyToolchain";
+import { SwiftLogger } from "@src/logging/SwiftLogger";
 import * as SwiftOutputChannelModule from "@src/logging/SwiftOutputChannel";
 import {
     Swiftly,
@@ -1452,8 +1453,16 @@ apt-get -y install libncurses5-dev
             // User declines installation prompt
             mockWindow.showWarningMessage.resolves(undefined);
 
+            const mockLogger = mockObject<SwiftLogger>({
+                info: mockFn(),
+            });
+
             const cwd = vscode.Uri.file("/project/path");
-            const result = await Swiftly.getActiveToolchain("/extension/root", cwd);
+            const result = await Swiftly.getActiveToolchain(
+                "/extension/root",
+                instance(mockLogger),
+                cwd
+            );
 
             expect(result).to.equal("/global/toolchain/path");
             expect(mockedUtilities.execFile).to.have.been.calledTwice;


### PR DESCRIPTION
## Description
I noticed that the `logger` wasn't getting forwarded to `Swiftly.getActiveToolchain` in `src/toolchain/toolchain.ts`. We can stand to be more strict about requiring a logger to be propagated during toolchain creation.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
