### PR TITLE
Omit sourcekit-lsp logs from debug console when debugging

### DIFF
--- a/src/logging/SwiftLogger.ts
+++ b/src/logging/SwiftLogger.ts
@@ -27,6 +27,7 @@ import { RollingLogTransport } from "./RollingLogTransport";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type LoggerMeta = any;
 type LogMessageOptions = { append: boolean };
+type SwiftLoggerOptions = { logConsole?: boolean };
 
 export class SwiftLogger implements vscode.Disposable {
     private subscriptions: vscode.Disposable[] = [];
@@ -40,8 +41,10 @@ export class SwiftLogger implements vscode.Disposable {
     constructor(
         public readonly name: string,
         public readonly logFilePath: string,
-        logStoreLinesSize: number = 250_000 // default to capturing 250k log lines
+        logStoreLinesSize: number = 250_000, // default to capturing 250k log lines
+        options: SwiftLoggerOptions = {}
     ) {
+        const { logConsole = true } = options;
         this.rollingLog = new RollingLog(logStoreLinesSize);
         this.outputChannel = vscode.window.createOutputChannel(name);
         const ouptutChannelTransport = new OutputChannelTransport(this.outputChannel);
@@ -59,7 +62,7 @@ export class SwiftLogger implements vscode.Disposable {
             transports.push(rollingLogTransport);
         }
         // Log everything to the console when we're debugging
-        if (IS_RUNNING_UNDER_DEBUGGER) {
+        if (logConsole && IS_RUNNING_UNDER_DEBUGGER) {
             transports.push(new winston.transports.Console({ level: "debug" }));
         }
 

--- a/src/logging/SwiftLoggerFactory.ts
+++ b/src/logging/SwiftLoggerFactory.ts
@@ -22,15 +22,22 @@ export class SwiftLoggerFactory {
     constructor(public readonly logFolderUri: vscode.Uri) {}
 
     create(name: string, logFilename: string): SwiftLogger;
-    create(name: string, logFilename: string, options: { outputChannel: true }): SwiftOutputChannel;
     create(
         name: string,
         logFilename: string,
-        options: { outputChannel: boolean } = { outputChannel: false }
+        options: { outputChannel: true; logConsole?: boolean }
+    ): SwiftOutputChannel;
+    create(
+        name: string,
+        logFilename: string,
+        options: { outputChannel: boolean; logConsole?: boolean } = { outputChannel: false }
     ): SwiftLogger {
+        const logPath = this.logFilePath(logFilename);
+        const logOptions = { logConsole: options.logConsole };
+
         return options?.outputChannel
-            ? new SwiftOutputChannel(name, this.logFilePath(logFilename))
-            : new SwiftLogger(name, this.logFilePath(logFilename));
+            ? new SwiftOutputChannel(name, logPath, undefined, logOptions)
+            : new SwiftLogger(name, logPath, undefined, logOptions);
     }
 
     /**

--- a/src/logging/SwiftOutputChannel.ts
+++ b/src/logging/SwiftOutputChannel.ts
@@ -16,14 +16,6 @@ import * as vscode from "vscode";
 import { SwiftLogger } from "./SwiftLogger";
 
 export class SwiftOutputChannel extends SwiftLogger implements vscode.OutputChannel {
-    /**
-     * Creates a vscode.OutputChannel that allows for later retrieval of logs.
-     * @param name
-     */
-    constructor(name: string, logFilePath: string, logStoreLinesSize?: number) {
-        super(name, logFilePath, logStoreLinesSize);
-    }
-
     append(value: string): void {
         this.info(value, undefined, { append: true });
     }

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -225,7 +225,7 @@ export function lspClientOptions(
         outputChannel: workspaceContext.loggerFactory.create(
             `SourceKit Language Server (${swiftVersion.toString()})`,
             `sourcekit-lsp-${swiftVersion.toString()}.log`,
-            { outputChannel: true }
+            { outputChannel: true, logConsole: false }
         ),
         middleware: {
             didOpen: activeDocumentManager.didOpen.bind(activeDocumentManager),


### PR DESCRIPTION
## Description
When debugging the extension avoid overwhelming the Debug Output view with all the sourcekit-lsp log output. If you need to see it use the Output channel in the launched extension being debugged.

This is purely a quality of life improvement for extension development and doesn't impact user facing logs.

## Tasks
- [X] ~Required tests have been written~
- [X] ~Documentation has been updated~
- [X] ~Added an entry to CHANGELOG.md if applicable~
