### PR TITLE
Don't run a nightly insiders job on nightly-6.3 toolchain

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,7 +88,7 @@ jobs:
     with:
       needs_token: true
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-6.2"}, {"swift_version": "nightly-main"}]'
+      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-6.2"}, {"swift_version": "nightly-6.3"}, {"swift_version": "nightly-main"}]'
       linux_env_vars: |
         NODE_VERSION=${{ needs.package.outputs.node-version }}
         NODE_PATH=${{ needs.package.outputs.node-path }}


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
This was already done for windows but I missed for Linux

Issue: N/A

## Tasks
- [X] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
