### PR TITLE
Enable installing Swiftly via Select Toolchain command

### DIFF
--- a/src/commands/installSwiftly.ts
+++ b/src/commands/installSwiftly.ts
@@ -79,7 +79,7 @@ This process involves updating your shell profile in order to add swiftly to you
  * @param logger Optional logger
  * @returns Promise<boolean> true if installation succeeded
  */
-async function installSwiftlyWithProgress(logger?: SwiftLogger): Promise<boolean> {
+export async function installSwiftlyWithProgress(logger?: SwiftLogger): Promise<boolean> {
     try {
         await vscode.window.withProgress(
             {
@@ -100,7 +100,7 @@ async function installSwiftlyWithProgress(logger?: SwiftLogger): Promise<boolean
     }
 }
 
-async function promptToRestartVSCode(): Promise<void> {
+export async function promptToRestartVSCode(): Promise<void> {
     const editorName = vscode.env.appName;
     const selection = await vscode.window.showInformationMessage(
         `Restart ${editorName}`,


### PR DESCRIPTION
Fixes #2065

-> Problem
Previously, when users ran the "Swift: Select Toolchain" command and Swiftly was not installed, they were only directed to the Swift.org website with a link. This required leaving VS Code, manually installing Swiftly via terminal commands, and then restarting VS Code.

-> Solution
This PR adds a new "Install Swiftly for toolchain management..." action that appears in the Select Toolchain quick pick when:

Swiftly is not installed
The platform is macOS or Linux (where Swiftly is supported)
When the user selects this action:

A confirmation dialog appears explaining what will happen
User can choose:
Continue - Proceeds with installation
Open Swiftly Documentation - Opens the Swiftly docs for manual installation
Cancel - Dismisses the dialog
If user continues, Swiftly installs with a progress notification
After successful installation, user is prompted to restart VS Code

Added comprehensive test suite "Install Swiftly action" with 5 test cases:
 Shows action when Swiftly not installed
 Hides action when Swiftly is installed
 Installs Swiftly when user confirms
 Does not install when user cancels
 Opens documentation when user selects doc link

-> Testing
All existing tests pass, plus 5 new unit tests covering: