### PR TITLE
Simplify swift-testing args in debug mode to prevent EPIPE

### DIFF
--- a/src/TestExplorer/TestRunArguments.ts
+++ b/src/TestExplorer/TestRunArguments.ts
@@ -187,13 +187,15 @@ export class TestRunArguments {
         const isTestTarget = !!testItem.tags.find(tag => tag.id === "test-target");
 
         if (isTestTarget) {
-            // We cannot simplify away test suites leaving only the target if we are debugging,
-            // since the exact names of test suites to run need to be passed to the xctest binary.
-            // It will not debug all tests with only the target name.
             if (isDebug) {
+                // XCTests require exact suite names to be passed to the xctest binary
+                // when debugging, so we cannot simplify them to the target level.
+                // Swift-testing uses regex filters and supports target-level wildcards,
+                // allowing us to reduce the number of --filter arguments. Without this,
+                // large projects produce so many args that the debug adapter can crash.
                 return {
                     xcTestResult: xcTestArgs,
-                    swiftTestResult: swiftTestArgs,
+                    swiftTestResult: swiftTestArgs.length > 0 ? [testItem] : [],
                 };
             }
             return {

--- a/test/integration-tests/testexplorer/TestRunArguments.test.ts
+++ b/test/integration-tests/testexplorer/TestRunArguments.test.ts
@@ -206,6 +206,19 @@ suite("TestRunArguments Suite", () => {
                 testItems: [testTargetId, xcSuiteId, xcTestId, swiftTestSuiteId, swiftTestId],
             });
         });
+
+        test("Entire test target (debug mode)", () => {
+            const testArgs = new TestRunArguments(runRequestByIds([testTargetId], []), true);
+            assertRunArguments(testArgs, {
+                // XCTests must remain expanded in debug mode since the xctest
+                // binary requires exact suite names.
+                xcTestArgs: [xcSuiteId],
+                // Swift-testing supports target-level wildcards during debug,
+                // keeping the argument list short and avoiding debug adapter crashes.
+                swiftTestArgs: [`${testTargetId}.*`],
+                testItems: [testTargetId, xcSuiteId, xcTestId, swiftTestSuiteId, swiftTestId],
+            });
+        });
     });
 
     test("Test empty test target", () => {
@@ -349,6 +362,32 @@ suite("TestRunArguments Suite", () => {
                 testTargetId,
                 xcTestId2,
                 xcTestId,
+            ],
+        });
+    });
+
+    test("Full swift-testing Target (debug mode)", () => {
+        const swiftTestSuiteId2 = "Swift Test Suite 2";
+        const swiftTestId1 = "Swift Test Item 1";
+        const swiftTestId2 = "Swift Test Item 2";
+        const dsl = `
+        tt:${testTargetId}
+            st:${swiftTestSuiteId}
+                st:${swiftTestId1}
+            st:${swiftTestSuiteId2}
+                st:${swiftTestId2}
+        `;
+        createTestItemTree(controller, dsl);
+        const testArgs = new TestRunArguments(runRequestByIds([testTargetId]), true);
+        assertRunArguments(testArgs, {
+            xcTestArgs: [],
+            swiftTestArgs: [`${testTargetId}.*`],
+            testItems: [
+                swiftTestSuiteId,
+                swiftTestSuiteId2,
+                swiftTestId1,
+                swiftTestId2,
+                testTargetId,
             ],
         });
     });


### PR DESCRIPTION
## Description

When clicking "Debug Tests" on a large project (e.g. swift-package-manager with 4700+ tests), the debug adapter crashes with EPIPE because `TestRunArguments` expands every swift-testing test into individual `--filter` arguments, exceeding OS argument length limits.

In `simplifyTestArgs()`, swift-testing arguments are now simplified to target-level wildcards (`TestTarget.*`) in debug mode, instead of listing every test individually. XCTest arguments remain expanded since the `xctest` binary requires exact suite names.

Issue: #2117

## Testing

- Added 2 integration tests covering debug mode argument simplification (mixed target + pure swift-testing target)
- All 451 unit tests pass
- Manually verified in Extension Development Host with swift-package-manager: debugger starts successfully (previously crashed immediately with "Debugger not started")

## Tasks
- [x] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable