### PR TITLE
Remove extra cancel button from Swiftly dialog

### DIFF
--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -1004,8 +1004,7 @@ export class Swiftly {
         const choice = await vscode.window.showWarningMessage(
             message,
             { modal: true },
-            "Execute Script",
-            "Cancel"
+            "Execute Script"
         );
 
         return choice === "Execute Script";


### PR DESCRIPTION
## Description
Removes the unnecessary `"Cancel"` button that was added to the Swiftly post-install script dialog. VS Code automatically adds a cancel button to all modals.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
