### PR TITLE
Add "Review Script" option to post-install dialog (#2139)

### DIFF
--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -892,9 +892,14 @@ export class Swiftly {
             return;
         }
 
-        const shouldExecute = await this.showPostInstallConfirmation(version, validation, logger);
+        let choice = await this.showPostInstallConfirmation(version, validation, logger);
 
-        if (shouldExecute) {
+        while (choice === "Review Script") {
+            await this.showPostInstallScript(postInstallFilePath);
+            choice = await this.showPostInstallConfirmation(version, validation, logger);
+        }
+
+        if (choice === "Execute Script") {
             await this.executePostInstallScript(
                 postInstallFilePath,
                 version,
@@ -982,13 +987,13 @@ export class Swiftly {
      * @param version The toolchain version being installed
      * @param validation The validation result
      * @param logger
-     * @returns Promise resolving to user's decision
+     * @returns Promise resolving to the user's choice
      */
     private static async showPostInstallConfirmation(
         version: string,
         validation: PostInstallValidationResult,
         logger?: SwiftLogger
-    ): Promise<boolean> {
+    ): Promise<string | undefined> {
         const summaryLines = validation.summary.split("\n");
         const firstTwoLines = summaryLines.slice(0, 2).join("\n");
 
@@ -1004,10 +1009,25 @@ export class Swiftly {
         const choice = await vscode.window.showWarningMessage(
             message,
             { modal: true },
-            "Execute Script"
+            "Execute Script",
+            "Review Script"
         );
 
-        return choice === "Execute Script";
+        return choice;
+    }
+
+    /**
+     * Opens the post-install script in a read-only editor for the user to review.
+     *
+     * @param postInstallFilePath Path to the post-install script
+     */
+    private static async showPostInstallScript(postInstallFilePath: string): Promise<void> {
+        const scriptContent = await fs.readFile(postInstallFilePath, "utf-8");
+        const document = await vscode.workspace.openTextDocument({
+            content: scriptContent,
+            language: "shellscript",
+        });
+        await vscode.window.showTextDocument(document, { preview: true });
     }
 
     /**

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -994,6 +994,7 @@ suite("Swiftly Unit Tests", () => {
 
     suite("Post-Install File Handling", () => {
         const mockVscodeWindow = mockGlobalObject(vscode, "window");
+        const mockVscodeWorkspace = mockGlobalObject(vscode, "workspace");
 
         setup(() => {
             mockedPlatform.setValue("linux");
@@ -1001,6 +1002,12 @@ suite("Swiftly Unit Tests", () => {
             mockVscodeWindow.showInformationMessage.reset();
             mockVscodeWindow.showErrorMessage.reset();
             mockVscodeWindow.createOutputChannel.reset();
+            mockVscodeWorkspace.openTextDocument.reset();
+            mockVscodeWindow.showTextDocument.reset();
+
+            // Mock openTextDocument for review script tests
+            mockVscodeWorkspace.openTextDocument.resolves({} as vscode.TextDocument);
+            mockVscodeWindow.showTextDocument.resolves(undefined as any);
 
             // Mock createOutputChannel to return a basic output channel mock
             mockVscodeWindow.createOutputChannel.returns({
@@ -1088,8 +1095,7 @@ apt-get -y install build-essential`;
                     await fs.writeFile(postInstallPath, validScript);
                 });
 
-            // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Cancel");
+            mockVscodeWindow.showWarningMessage.resolves(undefined);
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
@@ -1337,6 +1343,129 @@ apt-get -y install libncurses5-dev
                     "Swift 6.0.0 installation requires additional system packages to be installed"
                 )
             );
+            expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
+                "sudo",
+                match.array,
+                match.any,
+                match.any,
+                null,
+                match.object
+            );
+        });
+
+        test("should open script for review and execute after user confirms", async () => {
+            const validScript = `#!/bin/bash
+apt-get -y install build-essential`;
+
+            mockUtilities.execFileStreamOutput
+                .withArgs("swiftly", [
+                    "install",
+                    "6.0.0",
+                    "--assume-yes",
+                    "--post-install-file",
+                    match.string,
+                ])
+                .callsFake(async (_command, args) => {
+                    const postInstallPath = args[4];
+                    await fs.writeFile(postInstallPath, validScript);
+                });
+            mockUtilities.execFile
+                .withArgs("chmod", match.array)
+                .resolves({ stdout: "", stderr: "" });
+
+            // Mock execFileStreamOutput for sudo
+            mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
+
+            // First dialog: user clicks "Review Script", second dialog: user clicks "Execute Script"
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.onFirstCall().resolves("Review Script");
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.onSecondCall().resolves("Execute Script");
+
+            await Swiftly.installToolchain("6.0.0", "/path/to/extension");
+
+            expect(mockVscodeWorkspace.openTextDocument).to.have.been.calledOnce;
+            expect(mockVscodeWindow.showTextDocument).to.have.been.calledOnce;
+            expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
+                "sudo",
+                match.array,
+                match.any,
+                match.any,
+                null,
+                match.object
+            );
+        });
+
+        test("should open script for review and cancel after user declines", async () => {
+            const validScript = `#!/bin/bash
+apt-get -y install build-essential`;
+
+            mockUtilities.execFileStreamOutput
+                .withArgs("swiftly", [
+                    "install",
+                    "6.0.0",
+                    "--assume-yes",
+                    "--post-install-file",
+                    match.string,
+                ])
+                .callsFake(async (_command, args) => {
+                    const postInstallPath = args[4];
+                    await fs.writeFile(postInstallPath, validScript);
+                });
+
+            // First dialog: user clicks "Review Script", second dialog: user dismisses
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.onFirstCall().resolves("Review Script");
+            mockVscodeWindow.showWarningMessage.onSecondCall().resolves(undefined);
+
+            await Swiftly.installToolchain("6.0.0", "/path/to/extension");
+
+            expect(mockVscodeWorkspace.openTextDocument).to.have.been.calledOnce;
+            expect(mockVscodeWindow.showTextDocument).to.have.been.calledOnce;
+            expect(mockUtilities.execFileStreamOutput).to.not.have.been.calledWith(
+                "sudo",
+                match.array
+            );
+            expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
+                match("Swift 6.0.0 installation is incomplete")
+            );
+        });
+
+        test("should allow multiple reviews before executing", async () => {
+            const validScript = `#!/bin/bash
+apt-get -y install build-essential`;
+
+            mockUtilities.execFileStreamOutput
+                .withArgs("swiftly", [
+                    "install",
+                    "6.0.0",
+                    "--assume-yes",
+                    "--post-install-file",
+                    match.string,
+                ])
+                .callsFake(async (_command, args) => {
+                    const postInstallPath = args[4];
+                    await fs.writeFile(postInstallPath, validScript);
+                });
+            mockUtilities.execFile
+                .withArgs("chmod", match.array)
+                .resolves({ stdout: "", stderr: "" });
+
+            // Mock execFileStreamOutput for sudo
+            mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
+
+            // Review twice, then execute
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.onFirstCall().resolves("Review Script");
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.onSecondCall().resolves("Review Script");
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.onThirdCall().resolves("Execute Script");
+
+            await Swiftly.installToolchain("6.0.0", "/path/to/extension");
+
+            expect(mockVscodeWorkspace.openTextDocument).to.have.been.calledTwice;
+            expect(mockVscodeWindow.showTextDocument).to.have.been.calledTwice;
             expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
                 "sudo",
                 match.array,


### PR DESCRIPTION
## Description

Adds a "Review Script" button to the Swiftly post-install confirmation dialog on Linux, so users can inspect the script before executing it.

When a post-install script is detected after toolchain installation:
1. The dialog now shows two new options: "Execute Script" and "Review Script" (Cancel is VS Code's built-in modal dismiss)
2. Clicking "Review Script" opens the script in a preview tab as a shellscript document
3. The confirmation dialog re-appears, letting the user execute or cancel

Changes in `src/toolchain/swiftly.ts`:
- `showPostInstallConfirmation()` returns the raw button choice (`string | undefined`) instead of a boolean
- `handlePostInstallFile()` handles the new review flow
- New `showPostInstallScript()` method opens the script as an untitled document

Issue: https://github.com/swiftlang/vscode-swift/issues/2139

## Tasks
- [x] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable

### Testing

Added 2 unit tests in `test/unit-tests/toolchain/swiftly.test.ts`:
- Review then Execute: user clicks "Review Script", sees the script, then clicks "Execute Script"
- Review then Cancel: user clicks "Review Script", sees the script, then dismisses the dialog
- Multiple reviews: user clicks "Review Script" twice before executing (tests the while loop)

All existing post-install tests pass without changes.

Results:
- macOS: 459 passing, 0 failing
- Linux ARM64 (Dev Container, xvfb-run): 448 passing, 0 failing, 11 pending (macOS-only Xcode Watcher tests)
- `npm run lint` clean

<img width="3002" height="1702" alt="image" src="https://github.com/user-attachments/assets/b86a2687-3e7c-4ff3-9173-502946fe727d" />

<img width="2986" height="1686" alt="image" src="https://github.com/user-attachments/assets/de17c20d-4fc9-4a06-8c30-063e85e268a1" />

