### PR TITLE
Fix diagnostics not being shown for Swift packages in workspace subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 - Refresh tests in the test explorer when background indexing completes ([#2164](https://github.com/swiftlang/vscode-swift/pull/2164))
 - Fix infinite loop on startup when swift-package-manager has a lock on the package being opened ([#2174](https://github.com/swiftlang/vscode-swift/pull/2174))
+- Fix diagnostics not always being shown for Swift packages in workspace subfolders ([#2173](https://github.com/swiftlang/vscode-swift/pull/2173))
 
 ## 2.16.2 - 2026-03-17
 

--- a/src/TestExplorer/LSPTestDiscovery.ts
+++ b/src/TestExplorer/LSPTestDiscovery.ts
@@ -69,7 +69,12 @@ export class LSPTestDiscovery {
             // workspace/tests method, and is at least version 2.
             if (checkExperimentalCapability(client, WorkspaceTestsRequest.method, 2)) {
                 const tests = await client.sendRequest(WorkspaceTestsRequest.type, token);
-                return await this.transformToTestClass(client, swiftPackage, tests);
+                const transformedTests = await this.transformToTestClass(
+                    client,
+                    swiftPackage,
+                    tests
+                );
+                return transformedTests;
             } else {
                 throw new Error(`${WorkspaceTestsRequest.method} requests not supported`);
             }
@@ -85,8 +90,12 @@ export class LSPTestDiscovery {
         swiftPackage: SwiftPackage,
         input: LSPTestItem[]
     ): Promise<TestDiscovery.TestClass[]> {
+        // Due to a bug in sourcekit-lsp (fixed in https://github.com/swiftlang/sourcekit-lsp/pull/2575)
+        // when we get tests from the LSP via semantic discovery instead of syntatic discovery
+        // we can get duplicate test items with the same ID.
+        const deduplicated = this.deduplicateTestItems(input);
         return Promise.all(
-            input.map(async item => {
+            deduplicated.map(async item => {
                 const location = client.protocol2CodeConverter.asLocation(item.location);
                 return {
                     ...item,
@@ -96,6 +105,25 @@ export class LSPTestDiscovery {
                 };
             })
         );
+    }
+
+    private deduplicateTestItems(items: readonly LSPTestItem[]): LSPTestItem[] {
+        const idCounts = new Map<string, number>();
+        for (const item of items) {
+            idCounts.set(item.id, (idCounts.get(item.id) ?? 0) + 1);
+        }
+
+        const seen = new Set<string>();
+        return items.reduce<LSPTestItem[]>((acc, item) => {
+            if (seen.has(item.id)) {
+                return acc;
+            }
+            seen.add(item.id);
+
+            const isDuplicate = (idCounts.get(item.id) ?? 0) > 1;
+            const id = isDuplicate ? item.id.replace(/\/[^/]+\.\w+:\d+:\d+$/, "") : item.id;
+            return [...acc, { ...item, id }];
+        }, []);
     }
 
     /**

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -78,7 +78,7 @@ export class WorkspaceContext implements ExternalWorkspaceContext, Disposable {
     public testRunManager: TestRunManager;
     public projectPanel: ProjectPanelProvider;
     private lastFocusUri: vscode.Uri | undefined;
-    private initialisationFinished = false;
+    private initializationFinished = false;
 
     private readonly testStartEmitter = new vscode.EventEmitter<TestEvent>();
     private readonly testFinishEmitter = new vscode.EventEmitter<TestEvent>();
@@ -326,7 +326,7 @@ export class WorkspaceContext implements ExternalWorkspaceContext, Disposable {
             }
         }
 
-        await this.initialisationComplete();
+        await this.initializationComplete();
     }
 
     /**
@@ -549,7 +549,7 @@ export class WorkspaceContext implements ExternalWorkspaceContext, Disposable {
             // clear last focus uri as we have set focus for a folder that has already loaded
             this.lastFocusUri = undefined;
         } else if (packageFolder instanceof vscode.Uri) {
-            if (this.initialisationFinished === false) {
+            if (this.initializationFinished === false) {
                 // If a package takes a long time to load during initialisation, a focus event
                 // can occur prior to the package being fully loaded. At this point because the
                 // folder for that package isn't setup it will attempt to add the package again.
@@ -571,8 +571,8 @@ export class WorkspaceContext implements ExternalWorkspaceContext, Disposable {
         }
     }
 
-    private async initialisationComplete() {
-        this.initialisationFinished = true;
+    private async initializationComplete() {
+        this.initializationFinished = true;
         if (this.lastFocusUri) {
             await this.focusUri(this.lastFocusUri);
             this.lastFocusUri = undefined;

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -360,7 +360,7 @@ function diagnosticLogs(): string {
 
 function sourceKitLogFile(folder: FolderContext) {
     const languageClient = folder.workspaceContext.languageClientManager.get(folder);
-    return languageClient.languageClientOutputChannel?.logFilePath;
+    return languageClient.languageClientOutputChannelLogFilePath;
 }
 
 async function sourcekitDiagnose(ctx: FolderContext, dir: string) {

--- a/src/logging/OutputChannelTransport.ts
+++ b/src/logging/OutputChannelTransport.ts
@@ -24,6 +24,10 @@ export class OutputChannelTransport extends TransportStream {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public log(info: any, next: () => void): void {
+        if (!this.ouptutChannel) {
+            next();
+            return;
+        }
         const logMessage = this.appending ? info.message : info[Symbol.for("message")];
         if (info.append) {
             this.ouptutChannel.append(logMessage);

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -26,6 +26,7 @@ import { promptForDiagnostics } from "../commands/captureDiagnostics";
 import configuration from "../configuration";
 import { Version } from "../utilities/version";
 import { SourceKitLSPErrorHandler } from "./LanguageClientManager";
+import { WorkspaceFolderGate } from "./WorkspaceFolderGate";
 import { LSPActiveDocumentManager } from "./didChangeActiveDocument";
 import { uriConverters } from "./uriConverters";
 
@@ -212,6 +213,7 @@ export function lspClientOptions(
     workspaceFolder: vscode.WorkspaceFolder | undefined,
     activeDocumentManager: LSPActiveDocumentManager,
     errorHandler: SourceKitLSPErrorHandler,
+    folderGate: WorkspaceFolderGate,
     documentSymbolWatcher?: (
         document: vscode.TextDocument,
         symbols: vscode.DocumentSymbol[]
@@ -228,9 +230,16 @@ export function lspClientOptions(
             { outputChannel: true, logConsole: false }
         ),
         middleware: {
-            didOpen: activeDocumentManager.didOpen.bind(activeDocumentManager),
-            didClose: activeDocumentManager.didClose.bind(activeDocumentManager),
+            didOpen: async (document, next) => {
+                await folderGate.waitForFolder(document.uri);
+                await activeDocumentManager.didOpen(document, next);
+            },
+            didClose: async (document, next) => {
+                await folderGate.waitForFolder(document.uri);
+                await activeDocumentManager.didClose(document, next);
+            },
             provideCompletionItem: async (document, position, context, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
                 const result = await next(document, position, context, token);
 
                 if (!result) {
@@ -247,6 +256,7 @@ export function lspClientOptions(
                 };
             },
             provideCodeLenses: async (document, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
                 const result = await next(document, token);
                 if (documentCodeLensWatcher && result) {
                     documentCodeLensWatcher(document, result);
@@ -267,6 +277,7 @@ export function lspClientOptions(
                 });
             },
             provideDocumentSymbols: async (document, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
                 const result = await next(document, token);
                 const documentSymbols = result as vscode.DocumentSymbol[];
                 if (documentSymbolWatcher && documentSymbols) {
@@ -275,6 +286,7 @@ export function lspClientOptions(
                 return result;
             },
             provideDefinition: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
                 const result = await next(document, position, token);
                 const definitions = result as vscode.Location[];
                 if (
@@ -290,6 +302,7 @@ export function lspClientOptions(
             // temporarily remove text edit from Inlay hints while SourceKit-LSP
             // returns invalid replacement text
             provideInlayHints: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
                 const result = await next(document, position, token);
                 // remove textEdits for swift version earlier than 5.10 as it sometimes
                 // generated invalid textEdits
@@ -298,14 +311,71 @@ export function lspClientOptions(
                 }
                 return result;
             },
+            provideCodeActions: async (document, range, context, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, range, context, token);
+            },
+            provideDocumentColors: async (document, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, token);
+            },
+            provideDocumentSemanticTokens: async (document, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, token);
+            },
+            provideDocumentRangeSemanticTokens: async (document, range, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, range, token);
+            },
+            provideFoldingRanges: async (document, context, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, context, token);
+            },
+            provideHover: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, token);
+            },
+            provideReferences: async (document, position, options, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, options, token);
+            },
+            provideDocumentHighlights: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, token);
+            },
+            provideSignatureHelp: async (document, position, context, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, context, token);
+            },
+            provideTypeDefinition: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, token);
+            },
+            provideImplementation: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, token);
+            },
+            provideDeclaration: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, token);
+            },
+            provideRenameEdits: async (document, position, newName, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, newName, token);
+            },
+            prepareRename: async (document, position, token, next) => {
+                await folderGate.waitForFolder(document.uri, undefined, token);
+                return next(document, position, token);
+            },
             provideDiagnostics: async (uri, previousResultId, token, next) => {
+                const documentUri = (uri as vscode.TextDocument).uri ?? uri;
+                await folderGate.waitForFolder(documentUri, undefined, token);
                 const result = await next(uri, previousResultId, token);
                 if (result?.kind === vsdiag.DocumentDiagnosticReportKind.unChanged) {
                     return undefined;
                 }
-                const document = uri as vscode.TextDocument;
                 workspaceContext.diagnostics.handleDiagnostics(
-                    document.uri ?? uri,
+                    documentUri,
                     DiagnosticsManager.isSourcekit,
                     result?.items ?? []
                 );

--- a/src/sourcekit-lsp/LanguageClientFactory.ts
+++ b/src/sourcekit-lsp/LanguageClientFactory.ts
@@ -11,7 +11,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import { LanguageClient, LanguageClientOptions, ServerOptions } from "vscode-languageclient/node";
+import {
+    InitializeParams,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+} from "vscode-languageclient/node";
 
 /**
  * Used to create a {@link LanguageClient} for use in VS Code.
@@ -35,6 +40,12 @@ export class LanguageClientFactory {
         serverOptions: ServerOptions,
         clientOptions: LanguageClientOptions
     ): LanguageClient {
-        return new LanguageClient(id, name, serverOptions, clientOptions);
+        return new SourcekitLSPLanguageClient(id, name, serverOptions, clientOptions);
+    }
+}
+
+class SourcekitLSPLanguageClient extends LanguageClient {
+    protected fillInitializeParams(params: InitializeParams): void {
+        super.fillInitializeParams(params);
     }
 }

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -490,18 +490,18 @@ export class LanguageClientManager implements Disposable {
         errorHandler: SourceKitLSPErrorHandler
     ): Promise<void> {
         const runningPromise = new Promise<void>((res, rej) => {
-            const disposable = client.onDidChangeState(e => {
+            const disposable = client.onDidChangeState(async e => {
                 // if state is now running add in any sub-folder workspaces that
                 // we have cached. If this is the first time we are starting then
                 // we won't have any sub folder workspaces, but if the server crashed
                 // or we forced a restart then we need to do this
                 if (e.oldState === State.Starting && e.newState === State.Running) {
+                    await this.addSubFolderWorkspaces(client);
+                    disposable.dispose();
                     res();
-                    disposable.dispose();
-                    void this.addSubFolderWorkspaces(client);
                 } else if (e.oldState === State.Starting && e.newState === State.Stopped) {
-                    rej("SourceKit-LSP failed to start");
                     disposable.dispose();
+                    rej("SourceKit-LSP failed to start");
                 }
             });
         });

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -28,14 +28,17 @@ import { Executable, LanguageClient, ServerOptions } from "vscode-languageclient
 
 import { FolderContext } from "../FolderContext";
 import configuration from "../configuration";
+import { SwiftLogger } from "../logging/SwiftLogger";
 import { SwiftOutputChannel } from "../logging/SwiftOutputChannel";
 import { ArgumentFilter, BuildFlags } from "../toolchain/BuildFlags";
+import { SwiftToolchain } from "../toolchain/toolchain";
 import { Disposable } from "../utilities/Disposable";
 import { swiftRuntimeEnv } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { LSPLogger, LSPOutputChannel } from "./LSPOutputChannel";
 import { lspClientOptions } from "./LanguageClientConfiguration";
 import { LanguageClientFactory } from "./LanguageClientFactory";
+import { WorkspaceFolderGate } from "./WorkspaceFolderGate";
 import { LSPActiveDocumentManager } from "./didChangeActiveDocument";
 import { SourceKitLogMessageNotification, SourceKitLogMessageParams } from "./extensions";
 import { DidChangeActiveDocumentNotification } from "./extensions/DidChangeActiveDocumentRequest";
@@ -87,26 +90,19 @@ export class LanguageClientManager implements Disposable {
      * null means in the process of restarting
      */
     private languageClient: LanguageClient | null | undefined;
-    private cancellationToken?: vscode.CancellationTokenSource;
+    private cancellationToken: vscode.CancellationTokenSource;
     private legacyInlayHints?: Disposable;
     private peekDocuments?: Disposable;
     private getReferenceDocument?: Disposable;
     private didChangeActiveDocument?: Disposable;
-    private restartedPromise?: Promise<void>;
-    private waitingOnRestartCount: number;
-    private clientReadyPromise?: Promise<void>;
-    public documentSymbolWatcher?: (
-        document: vscode.TextDocument,
-        symbols: vscode.DocumentSymbol[] | null | undefined
-    ) => void;
-    private subscriptions: Disposable[];
-    // used by single server support to keep a record of the project folders
-    // that are not at the root of their workspace
-    public subFolderWorkspaces: FolderContext[] = [];
-    private addedFolders: FolderContext[] = [];
+    private subscriptions: Disposable[] = [];
     private namedOutputChannels: Map<string, LSPOutputChannel> = new Map();
     private swiftVersion: Version;
     private activeDocumentManager = new LSPActiveDocumentManager();
+    private logger: SwiftLogger;
+    public addedFolders: FolderContext[] = [];
+
+    public readonly folderGate: WorkspaceFolderGate;
 
     /** Get the current state of the underlying LanguageClient */
     public get state(): State {
@@ -116,7 +112,24 @@ export class LanguageClientManager implements Disposable {
         return this.languageClient.state;
     }
 
-    constructor(
+    /**
+     * Creates a new LSP client.
+     * @param folderContext
+     * @param options
+     * @param languageClientFactory
+     * @returns LanguageClientManager with the LSP client already started and ready to use
+     */
+    public static async create(
+        folderContext: FolderContext,
+        options: LanguageClientManageOptions = {},
+        languageClientFactory: LanguageClientFactory = new LanguageClientFactory()
+    ) {
+        const manager = new LanguageClientManager(folderContext, options, languageClientFactory);
+        await manager.setupLanguageClient(folderContext, folderContext.toolchain);
+        return manager;
+    }
+
+    private constructor(
         public folderContext: FolderContext,
         private options: LanguageClientManageOptions = {},
         private languageClientFactory: LanguageClientFactory = new LanguageClientFactory()
@@ -125,8 +138,10 @@ export class LanguageClientManager implements Disposable {
             LanguageClientManager.indexingLogName,
             new LSPOutputChannel(LanguageClientManager.indexingLogName, false, true)
         );
+        this.logger = folderContext.logger;
         this.swiftVersion = folderContext.swiftVersion;
-        this.subscriptions = [];
+        this.cancellationToken = new vscode.CancellationTokenSource();
+        this.folderGate = new WorkspaceFolderGate(folderContext.folder);
 
         // on change config restart server
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
@@ -167,31 +182,24 @@ export class LanguageClientManager implements Disposable {
         });
 
         this.subscriptions.push(onChangeConfig);
-
-        this.waitingOnRestartCount = 0;
-        this.documentSymbolWatcher = undefined;
-        this.cancellationToken = new vscode.CancellationTokenSource();
     }
 
-    // The language client stops asnyhronously, so we need to wait for it to stop
-    // instead of doing it in dispose, which must be synchronous.
-    async stop(dispose: boolean = true) {
-        if (this.languageClient && this.languageClient.state === State.Running) {
-            await this.languageClient.stop(15000);
-            if (dispose) {
-                await this.languageClient.dispose();
-            }
+    /**
+     * Stops the LSP client if it is running.
+     * If dispose is true then also dispose the client after stopping, otherwise leave it in a stopped state.
+     * This is useful for when we want to restart the client, as we need to stop it first but we don't want to
+     * dispose it until the extension is deactivated.
+     * @param dispose Whether to dispose the client after stopping. Defaults to true.
+     */
+    public async stop(dispose: boolean = true) {
+        if (!this.languageClient || this.languageClient.state !== State.Running) {
+            return;
         }
-    }
 
-    dispose() {
-        this.cancellationToken?.cancel();
-        this.cancellationToken?.dispose();
-        this.legacyInlayHints?.dispose();
-        this.peekDocuments?.dispose();
-        this.getReferenceDocument?.dispose();
-        this.subscriptions.forEach(item => item.dispose());
-        this.namedOutputChannels.forEach(channel => channel.dispose());
+        await this.languageClient.stop(15000);
+        if (dispose) {
+            await this.languageClient.dispose();
+        }
     }
 
     /**
@@ -201,104 +209,83 @@ export class LanguageClientManager implements Disposable {
      * @param process process using language client
      * @returns result of process
      */
-    async useLanguageClient<Return>(process: {
+    public async useLanguageClient<Return>(process: {
         (client: LanguageClient, cancellationToken: vscode.CancellationToken): Promise<Return>;
     }): Promise<Return> {
-        if (!this.languageClient || !this.clientReadyPromise) {
+        if (!this.languageClient) {
             throw new Error(LanguageClientError.LanguageClientUnavailable);
         }
-        return this.clientReadyPromise.then(
-            () => {
-                if (!this.languageClient || !this.cancellationToken) {
-                    throw new Error(LanguageClientError.LanguageClientUnavailable);
-                }
-                return process(this.languageClient, this.cancellationToken.token);
-            },
-            reason => reason
-        );
+        return process(this.languageClient, this.cancellationToken.token);
     }
 
-    /** Restart language client */
-    async restart() {
-        // force restart of language client
-        await this.setLanguageClientFolder(this.folderContext);
+    /**
+     * Restart the language client.
+     */
+    public async restart() {
+        await this.restartLanguageClient(this.folderContext, this.folderContext.toolchain);
     }
 
-    get languageClientOutputChannel(): SwiftOutputChannel | undefined {
-        return this.languageClient?.outputChannel as SwiftOutputChannel | undefined;
+    /**
+     * Returns the path to the log file for the output channel of the language client, if it exists.
+     */
+    public get languageClientOutputChannelLogFilePath(): string | undefined {
+        return this.languageClientOutputChannel?.logFilePath;
     }
 
-    async addFolder(folderContext: FolderContext) {
+    /**
+     * Add a sub-folder to the language client.
+     * For multi-root workspaces the root folder may contain several swift packages.
+     * Each of these swift package folders should be added via addFolder to ensure they are
+     * indexed by the language server.
+     * @param folderContext The folder to add
+     */
+    public async addFolder(folderContext: FolderContext) {
         if (!folderContext.isRootFolder) {
             await this.useLanguageClient(async client => {
-                this.subFolderWorkspaces.push(folderContext);
-
                 const uri = folderContext.folder;
                 const workspaceFolder = {
                     uri: client.code2ProtocolConverter.asUri(uri),
                     name: FolderContext.uriName(uri),
                 };
+                this.logger.info(`Adding folder ${uri.fsPath} to SourceKit-LSP workspace`);
                 await client.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
                     event: { added: [workspaceFolder], removed: [] },
                 });
+                this.folderGate.folderAdded(folderContext.folder);
             });
         }
         this.addedFolders.push(folderContext);
     }
 
-    async removeFolder(folderContext: FolderContext) {
+    /**
+     * Remove a sub-folder from the language client.
+     * For multi-root workspaces the root folder may contain several swift packages.
+     * Each of these swift package folders should be removed via removeFolder to ensure they are
+     * no longer indexed by the language server.
+     * @param folderContext The folder to remove
+     */
+    public async removeFolder(folderContext: FolderContext) {
         if (!folderContext.isRootFolder) {
             await this.useLanguageClient(async client => {
                 const uri = folderContext.folder;
-                this.subFolderWorkspaces = this.subFolderWorkspaces.filter(
-                    item => item.folder !== uri
-                );
-
                 const workspaceFolder = {
                     uri: client.code2ProtocolConverter.asUri(uri),
                     name: FolderContext.uriName(uri),
                 };
+
+                this.logger.info(`Removing folder ${uri.fsPath} from SourceKit-LSP workspace`);
+
                 await client.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
                     event: { added: [], removed: [workspaceFolder] },
                 });
+                this.folderGate.folderRemoved(folderContext.folder);
             });
         }
         this.addedFolders = this.addedFolders.filter(item => item.folder !== folderContext.folder);
     }
 
-    private async addSubFolderWorkspaces(client: LanguageClient) {
-        for (const folderContext of this.subFolderWorkspaces) {
-            const workspaceFolder = {
-                uri: client.code2ProtocolConverter.asUri(folderContext.folder),
-                name: FolderContext.uriName(folderContext.folder),
-            };
-            await client.sendNotification(DidChangeWorkspaceFoldersNotification.type, {
-                event: { added: [workspaceFolder], removed: [] },
-            });
-        }
-    }
-
     /**
-     * Set folder for LSP server.
-     * If server is already running then check if the workspace folder is the same if
-     * it isn't then restart the server using the new workspace folder.
-     */
-    async setLanguageClientFolder(folder: FolderContext) {
-        if (this.languageClient === undefined) {
-            this.restartedPromise = this.setupLanguageClient(folder).catch(reason => {
-                this.folderContext.workspaceContext.logger.error(
-                    Error("Error starting SourceKit-LSP in setLanguageClientFolder", {
-                        cause: reason,
-                    })
-                );
-            });
-        } else {
-            await this.restartLanguageClient(folder);
-        }
-    }
-
-    /**
-     * Wait for the LSP to indicate it is done indexing
+     * Wait for the LSP to indicate it is done indexing.
      */
     async waitForIndex(): Promise<void> {
         const requestType = this.swiftVersion.isGreaterThanOrEqual(new Version(6, 2, 0))
@@ -316,29 +303,30 @@ export class LanguageClientManager implements Disposable {
         );
     }
 
-    /**
-     * Restart language client using supplied workspace folder
-     * @param workspaceFolder workspace folder to send to server
-     * @returns when done
-     */
-    private async restartLanguageClient(workspaceFolder: FolderContext) {
-        // count number of setLanguageClientFolder calls waiting on startedPromise
-        this.waitingOnRestartCount += 1;
-        // if in the middle of a restart then we have to wait until that
-        // restart has finished
-        if (this.restartedPromise) {
-            try {
-                await this.restartedPromise;
-            } catch (error) {
-                //ignore error
-            }
-        }
-        this.waitingOnRestartCount -= 1;
-        // only continue if no more calls are waiting on startedPromise
-        if (this.waitingOnRestartCount !== 0) {
-            return;
+    public dispose() {
+        if (this.languageClient && this.languageClient.state === State.Running) {
+            throw new Error(
+                "LanguageClient is still running. Please call stop() and wait for it to finish before disposing."
+            );
         }
 
+        this.cancellationToken?.cancel();
+        this.cancellationToken?.dispose();
+        this.folderGate.dispose();
+        this.legacyInlayHints?.dispose();
+        this.peekDocuments?.dispose();
+        this.getReferenceDocument?.dispose();
+        this.subscriptions.forEach(item => item.dispose());
+        this.namedOutputChannels.forEach(channel => channel.dispose());
+    }
+
+    /**
+     * Restart language client using supplied workspace folder
+     * @param workspaceFolder workspace folder to use for the new language client
+     * @param toolchain toolchain to get new language client for
+     * @returns when done
+     */
+    private async restartLanguageClient(folderContext: FolderContext, toolchain: SwiftToolchain) {
         const client = this.languageClient;
         // language client is set to null while it is in the process of restarting
         this.languageClient = null;
@@ -351,53 +339,70 @@ export class LanguageClientManager implements Disposable {
         if (client) {
             this.cancellationToken?.cancel();
             this.cancellationToken?.dispose();
-            this.restartedPromise = client
-                .stop()
-                .then(async () => {
-                    // Dispose the old client's output channel before creating the
-                    // new client. The server process may still write to stderr after
-                    // stop() resolves. Disposing here sets isDisposed on the logger,
-                    // preventing late writes from entering the winston pipeline and
-                    // reaching a destroyed transport.
-                    client.outputChannel.dispose();
 
-                    await this.setupLanguageClient(workspaceFolder);
-                })
-                .catch(async reason => {
-                    client.outputChannel.dispose();
-                    this.folderContext.workspaceContext.logger.error(
-                        `Error starting SourceKit-LSP in restartLanguageClient: ${reason}`
-                    );
-                    // error message matches code here https://github.com/microsoft/vscode-languageserver-node/blob/2041784436fed53f4e77267a49396bca22a7aacf/client/src/common/client.ts#L1409C1-L1409C54
-                    if (reason.message === "Stopping the server timed out") {
-                        try {
-                            await this.setupLanguageClient(workspaceFolder);
-                        } catch (reason) {
-                            this.folderContext.workspaceContext.logger.error(
-                                `Error starting SourceKit-LSP after server timeout in restartLanguageClient: ${reason}`
-                            );
-                        }
+            try {
+                await client.stop();
+
+                // Dispose the old client's output channel before creating the
+                // new client. The server process may still write to stderr after
+                // stop() resolves. Disposing here sets isDisposed on the logger,
+                // preventing late writes from entering the winston pipeline and
+                // reaching a destroyed transport.
+                client.outputChannel.dispose();
+
+                await this.setupLanguageClient(folderContext, toolchain);
+            } catch (reason: Error | unknown) {
+                client.outputChannel.dispose();
+                this.logger.error(
+                    `Error starting SourceKit-LSP in restartLanguageClient: ${reason}`
+                );
+                // error message matches code here https://github.com/microsoft/vscode-languageserver-node/blob/2041784436fed53f4e77267a49396bca22a7aacf/client/src/common/client.ts#L1409C1-L1409C54
+                if ((reason as Error).message === "Stopping the server timed out") {
+                    try {
+                        await this.setupLanguageClient(folderContext, toolchain);
+                    } catch (reason) {
+                        this.logger.error(
+                            `Error starting SourceKit-LSP after server timeout in restartLanguageClient: ${reason}`
+                        );
                     }
-                    this.folderContext.logger.error(reason);
-                });
-            await this.restartedPromise;
+                }
+                this.logger.error(reason);
+            }
         }
     }
 
-    private async setupLanguageClient(folder: FolderContext) {
+    private async setupLanguageClient(folderContext: FolderContext, toolchain: SwiftToolchain) {
         if (configuration.lsp.disable) {
             this.languageClient = undefined;
             return;
         }
-        const { client, errorHandler } = this.createLSPClient(folder);
-        return this.startClient(client, errorHandler);
+
+        try {
+            const { client, errorHandler } = this.createLSPClient(
+                {
+                    uri: folderContext.folder,
+                    name: FolderContext.uriName(folderContext.folder),
+                    index: 0,
+                },
+                toolchain
+            );
+            return await this.startClient(client, errorHandler);
+        } catch (error) {
+            this.logger.error(
+                Error("Error starting SourceKit-LSP in initializeLanguageClient", {
+                    cause: error,
+                })
+            );
+        }
     }
 
-    private createLSPClient(folder: FolderContext): {
+    private createLSPClient(
+        workspaceFolder: vscode.WorkspaceFolder | undefined,
+        toolchain: SwiftToolchain
+    ): {
         client: LanguageClient;
         errorHandler: SourceKitLSPErrorHandler;
     } {
-        const toolchain = folder.toolchain;
         const toolchainSourceKitLSP = toolchain.getToolchainExecutable("sourcekit-lsp");
         const lspConfig = configuration.lsp;
         const serverPathConfig = lspConfig.serverPath;
@@ -445,9 +450,10 @@ export class LanguageClientManager implements Disposable {
         const clientOptions: LanguageClientOptions = lspClientOptions(
             this.swiftVersion,
             this.folderContext.workspaceContext,
-            undefined,
+            workspaceFolder,
             this.activeDocumentManager,
             errorHandler,
+            this.folderGate,
             (document, symbols) => {
                 const documentFolderContext = [this.folderContext, ...this.addedFolders].find(
                     folderContext => document.uri.fsPath.startsWith(folderContext.folder.fsPath)
@@ -485,18 +491,23 @@ export class LanguageClientManager implements Disposable {
         };
     }
 
-    private startClient(
+    private async startClient(
         client: LanguageClient,
         errorHandler: SourceKitLSPErrorHandler
     ): Promise<void> {
+        // Monitors the client's state and waits for it to enter the Running state.
+        // If the client fails to start and enters the Stopped state, the promise is rejected.
         const runningPromise = new Promise<void>((res, rej) => {
+            if (client.state === State.Running) {
+                res();
+                return;
+            }
             const disposable = client.onDidChangeState(async e => {
                 // if state is now running add in any sub-folder workspaces that
                 // we have cached. If this is the first time we are starting then
                 // we won't have any sub folder workspaces, but if the server crashed
                 // or we forced a restart then we need to do this
                 if (e.oldState === State.Starting && e.newState === State.Running) {
-                    await this.addSubFolderWorkspaces(client);
                     disposable.dispose();
                     res();
                 } else if (e.oldState === State.Starting && e.newState === State.Stopped) {
@@ -505,65 +516,62 @@ export class LanguageClientManager implements Disposable {
                 }
             });
         });
-        if (client.clientOptions.workspaceFolder) {
-            this.folderContext.logger.info(
-                `SourceKit-LSP setup for ${FolderContext.uriName(
-                    client.clientOptions.workspaceFolder.uri
-                )}`
-            );
-        } else {
-            this.folderContext.logger.info(`SourceKit-LSP setup`);
-        }
+
+        this.logger.info(
+            client.clientOptions.workspaceFolder
+                ? `SourceKit-LSP setup for ${FolderContext.uriName(
+                      client.clientOptions.workspaceFolder.uri
+                  )}`
+                : `SourceKit-LSP setup`
+        );
 
         client.onNotification(SourceKitLogMessageNotification.type, params => {
             this.logMessage(client, params as SourceKitLogMessageParams);
         });
 
-        // Create and save the client ready promise
-        this.clientReadyPromise = (async () => {
+        await client.start();
+        await runningPromise;
+
+        try {
+            // start client
+
+            // Now that we've started up correctly, start the error handler to auto-restart
+            // if sourcekit-lsp crashes during normal operation.
+            errorHandler.enable();
+
+            this.peekDocuments = activatePeekDocuments(client);
+            this.getReferenceDocument = activateGetReferenceDocument(client);
+            this.subscriptions.push(this.getReferenceDocument);
             try {
-                // start client
-                await client.start();
-                await runningPromise;
-
-                // Now that we've started up correctly, start the error handler to auto-restart
-                // if sourcekit-lsp crashes during normal operation.
-                errorHandler.enable();
-
-                this.peekDocuments = activatePeekDocuments(client);
-                this.getReferenceDocument = activateGetReferenceDocument(client);
-                this.subscriptions.push(this.getReferenceDocument);
-                try {
-                    if (
-                        checkExperimentalCapability(
-                            client,
-                            DidChangeActiveDocumentNotification.method,
-                            1
-                        )
-                    ) {
-                        this.didChangeActiveDocument =
-                            this.activeDocumentManager.activateDidChangeActiveDocument(client);
-                        this.subscriptions.push(this.didChangeActiveDocument);
-                    }
-                } catch {
-                    // do nothing, the experimental capability is not supported
+                if (
+                    checkExperimentalCapability(
+                        client,
+                        DidChangeActiveDocumentNotification.method,
+                        1
+                    )
+                ) {
+                    this.didChangeActiveDocument =
+                        this.activeDocumentManager.activateDidChangeActiveDocument(client);
+                    this.subscriptions.push(this.didChangeActiveDocument);
                 }
-            } catch (reason) {
-                this.folderContext.logger.error(
-                    `Error starting SourceKit-LSP in startClient: ${reason}`
-                );
-                if (this.languageClient?.state === State.Running) {
-                    await this.languageClient?.stop();
-                }
-                this.languageClient = undefined;
-                throw reason;
+            } catch {
+                // do nothing, the experimental capability is not supported
             }
-        })();
+        } catch (reason) {
+            this.logger.error(`Error starting SourceKit-LSP in startClient: ${reason}`);
+            if (this.languageClient?.state === State.Running) {
+                await this.languageClient?.stop();
+            }
+            this.languageClient = undefined;
+            throw reason;
+        }
 
         this.languageClient = client;
         this.cancellationToken = new vscode.CancellationTokenSource();
+    }
 
-        return this.clientReadyPromise;
+    private get languageClientOutputChannel(): SwiftOutputChannel | undefined {
+        return this.languageClient?.outputChannel as SwiftOutputChannel | undefined;
     }
 
     private logMessage(client: LanguageClient, params: SourceKitLogMessageParams) {

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -354,12 +354,17 @@ export class LanguageClientManager implements Disposable {
             this.restartedPromise = client
                 .stop()
                 .then(async () => {
-                    await this.setupLanguageClient(workspaceFolder);
-
-                    // Now that the client has been replaced, dispose the old client's output channel.
+                    // Dispose the old client's output channel before creating the
+                    // new client. The server process may still write to stderr after
+                    // stop() resolves. Disposing here sets isDisposed on the logger,
+                    // preventing late writes from entering the winston pipeline and
+                    // reaching a destroyed transport.
                     client.outputChannel.dispose();
+
+                    await this.setupLanguageClient(workspaceFolder);
                 })
                 .catch(async reason => {
+                    client.outputChannel.dispose();
                     this.folderContext.workspaceContext.logger.error(
                         `Error starting SourceKit-LSP in restartLanguageClient: ${reason}`
                     );

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -93,7 +93,6 @@ export class LanguageClientManager implements Disposable {
     private getReferenceDocument?: Disposable;
     private didChangeActiveDocument?: Disposable;
     private restartedPromise?: Promise<void>;
-    private currentWorkspaceFolder?: FolderContext;
     private waitingOnRestartCount: number;
     private clientReadyPromise?: Promise<void>;
     public documentSymbolWatcher?: (
@@ -101,7 +100,6 @@ export class LanguageClientManager implements Disposable {
         symbols: vscode.DocumentSymbol[] | null | undefined
     ) => void;
     private subscriptions: Disposable[];
-    private singleServerSupport: boolean;
     // used by single server support to keep a record of the project folders
     // that are not at the root of their workspace
     public subFolderWorkspaces: FolderContext[] = [];
@@ -128,7 +126,6 @@ export class LanguageClientManager implements Disposable {
             new LSPOutputChannel(LanguageClientManager.indexingLogName, false, true)
         );
         this.swiftVersion = folderContext.swiftVersion;
-        this.singleServerSupport = this.swiftVersion.isGreaterThanOrEqual(new Version(5, 7, 0));
         this.subscriptions = [];
 
         // on change config restart server
@@ -224,7 +221,7 @@ export class LanguageClientManager implements Disposable {
     /** Restart language client */
     async restart() {
         // force restart of language client
-        await this.setLanguageClientFolder(this.folderContext, true);
+        await this.setLanguageClientFolder(this.folderContext);
     }
 
     get languageClientOutputChannel(): SwiftOutputChannel | undefined {
@@ -286,10 +283,8 @@ export class LanguageClientManager implements Disposable {
      * If server is already running then check if the workspace folder is the same if
      * it isn't then restart the server using the new workspace folder.
      */
-    async setLanguageClientFolder(folder: FolderContext, forceRestart = false) {
-        const uri = folder.folder;
+    async setLanguageClientFolder(folder: FolderContext) {
         if (this.languageClient === undefined) {
-            this.currentWorkspaceFolder = folder;
             this.restartedPromise = this.setupLanguageClient(folder).catch(reason => {
                 this.folderContext.workspaceContext.logger.error(
                     Error("Error starting SourceKit-LSP in setLanguageClientFolder", {
@@ -298,14 +293,6 @@ export class LanguageClientManager implements Disposable {
                 );
             });
         } else {
-            // don't check for undefined uri's or if the current workspace is the same if we are
-            // running a single server. The only way we can get here while using a single server
-            // is when restart is called.
-            if (!this.singleServerSupport) {
-                if (this.currentWorkspaceFolder?.folder === uri && !forceRestart) {
-                    return;
-                }
-            }
             await this.restartLanguageClient(folder);
         }
     }
@@ -355,7 +342,6 @@ export class LanguageClientManager implements Disposable {
         const client = this.languageClient;
         // language client is set to null while it is in the process of restarting
         this.languageClient = null;
-        this.currentWorkspaceFolder = workspaceFolder;
         this.legacyInlayHints?.dispose();
         this.legacyInlayHints = undefined;
         this.peekDocuments?.dispose();
@@ -449,20 +435,12 @@ export class LanguageClientManager implements Disposable {
         }
 
         const serverOptions: ServerOptions = sourcekit;
-        let workspaceFolder = undefined;
-        if (folder && !this.singleServerSupport) {
-            workspaceFolder = {
-                uri: folder.folder,
-                name: FolderContext.uriName(folder.folder),
-                index: 0,
-            };
-        }
 
         const errorHandler = new SourceKitLSPErrorHandler(5);
         const clientOptions: LanguageClientOptions = lspClientOptions(
             this.swiftVersion,
             this.folderContext.workspaceContext,
-            workspaceFolder,
+            undefined,
             this.activeDocumentManager,
             errorHandler,
             (document, symbols) => {

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -141,7 +141,7 @@ export class LanguageClientManager implements Disposable {
         this.logger = folderContext.logger;
         this.swiftVersion = folderContext.swiftVersion;
         this.cancellationToken = new vscode.CancellationTokenSource();
-        this.folderGate = new WorkspaceFolderGate(folderContext.folder);
+        this.folderGate = new WorkspaceFolderGate(folderContext.folder, this.logger);
 
         // on change config restart server
         const onChangeConfig = vscode.workspace.onDidChangeConfiguration(event => {
@@ -193,11 +193,17 @@ export class LanguageClientManager implements Disposable {
      */
     public async stop(dispose: boolean = true) {
         if (!this.languageClient || this.languageClient.state !== State.Running) {
+            this.logger.info(
+                `SourceKit-LSP stop requested but client is ${this.languageClient ? "not running" : "unavailable"}`
+            );
             return;
         }
 
+        this.logger.info("Stopping SourceKit-LSP language client");
         await this.languageClient.stop(15000);
+        this.logger.info("SourceKit-LSP language client stopped");
         if (dispose) {
+            this.logger.info("Disposing SourceKit-LSP language client");
             await this.languageClient.dispose();
         }
     }
@@ -310,6 +316,7 @@ export class LanguageClientManager implements Disposable {
             );
         }
 
+        this.logger.info("Disposing SourceKit-LSP manager resources");
         this.cancellationToken?.cancel();
         this.cancellationToken?.dispose();
         this.folderGate.dispose();
@@ -327,6 +334,7 @@ export class LanguageClientManager implements Disposable {
      * @returns when done
      */
     private async restartLanguageClient(folderContext: FolderContext, toolchain: SwiftToolchain) {
+        this.logger.info("Restarting SourceKit-LSP language client");
         const client = this.languageClient;
         // language client is set to null while it is in the process of restarting
         this.languageClient = null;
@@ -341,6 +349,7 @@ export class LanguageClientManager implements Disposable {
             this.cancellationToken?.dispose();
 
             try {
+                this.logger.info("Stopping previous SourceKit-LSP client before restart");
                 await client.stop();
 
                 // Dispose the old client's output channel before creating the
@@ -373,9 +382,14 @@ export class LanguageClientManager implements Disposable {
 
     private async setupLanguageClient(folderContext: FolderContext, toolchain: SwiftToolchain) {
         if (configuration.lsp.disable) {
+            this.logger.info("SourceKit-LSP is disabled via configuration");
             this.languageClient = undefined;
             return;
         }
+
+        this.logger.info(
+            `Setting up SourceKit-LSP for ${FolderContext.uriName(folderContext.folder)} using toolchain ${toolchain.swiftVersion}`
+        );
 
         try {
             const { client, errorHandler } = this.createLSPClient(
@@ -446,6 +460,11 @@ export class LanguageClientManager implements Disposable {
 
         const serverOptions: ServerOptions = sourcekit;
 
+        this.logger.info(`SourceKit-LSP server path: ${serverPath}`);
+        if (sourcekit.args && sourcekit.args.length > 0) {
+            this.logger.info(`SourceKit-LSP server arguments: ${sourcekit.args.join(" ")}`);
+        }
+
         const errorHandler = new SourceKitLSPErrorHandler(5);
         const clientOptions: LanguageClientOptions = lspClientOptions(
             this.swiftVersion,
@@ -503,6 +522,9 @@ export class LanguageClientManager implements Disposable {
                 return;
             }
             const disposable = client.onDidChangeState(async e => {
+                this.logger.info(
+                    `SourceKit-LSP state changed: ${stateToString(e.oldState)} -> ${stateToString(e.newState)}`
+                );
                 // if state is now running add in any sub-folder workspaces that
                 // we have cached. If this is the first time we are starting then
                 // we won't have any sub folder workspaces, but if the server crashed
@@ -530,7 +552,9 @@ export class LanguageClientManager implements Disposable {
         });
 
         await client.start();
+        this.logger.info("SourceKit-LSP client.start() completed, waiting for running state");
         await runningPromise;
+        this.logger.info("SourceKit-LSP is now running");
 
         try {
             // start client
@@ -685,6 +709,19 @@ export class SourceKitLSPErrorHandler implements ErrorHandler {
 /** Language client errors */
 const enum LanguageClientError {
     LanguageClientUnavailable = "Language Client Unavailable",
+}
+
+function stateToString(state: State): string {
+    switch (state) {
+        case State.Stopped:
+            return "Stopped";
+        case State.Starting:
+            return "Starting";
+        case State.Running:
+            return "Running";
+        default:
+            return `Unknown(${state})`;
+    }
 }
 
 /**

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -127,14 +127,12 @@ export class LanguageClientToolchainCoordinator implements Disposable {
         folder: FolderContext,
         languageClientFactory: LanguageClientFactory
     ): Promise<LanguageClientManager> {
-        // A client is created for each unique toolchain version, as each toolchain has its own sourcekit-lsp
         const client = this.getClientForFolderSwiftVersion(folder, languageClientFactory);
 
-        if (!folder.isRootFolder && client.subFolderWorkspaces.indexOf(folder) === -1) {
+        if (!folder.isRootFolder && !client.subFolderWorkspaces.includes(folder)) {
             client.subFolderWorkspaces.push(folder);
         }
 
-        // Tell the LSP to switch to the target folder
         await client.setLanguageClientFolder(folder);
 
         return client;
@@ -145,8 +143,11 @@ export class LanguageClientToolchainCoordinator implements Disposable {
         factory: LanguageClientFactory
     ): LanguageClientManager {
         const version = folder.swiftVersion.toString();
-        const client =
-            this.clients.get(version) ?? new LanguageClientManager(folder, this.options, factory);
+        const existing = this.clients.get(version);
+        if (existing) {
+            return existing;
+        }
+        const client = new LanguageClientManager(folder, this.options, factory);
         this.clients.set(version, client);
         return client;
     }

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -30,6 +30,8 @@ import { LanguageClientManager } from "./LanguageClientManager";
 export class LanguageClientToolchainCoordinator implements Disposable {
     private subscriptions: Disposable[] = [];
     private clients: Map<string, LanguageClientManager> = new Map();
+    private clientCreationPromises: Map<string, Promise<LanguageClientManager>> = new Map();
+    public readonly initialized: Promise<void>;
 
     public constructor(
         workspaceContext: WorkspaceContext,
@@ -57,9 +59,10 @@ export class LanguageClientToolchainCoordinator implements Disposable {
         // Add any folders already in the workspace context at the time of construction.
         // This is mainly for testing purposes, as this class should be created immediately
         // when the extension is activated and the workspace context is first created.
-        for (const folder of workspaceContext.folders) {
-            void this.handleEvent(folder, FolderOperation.add, languageClientFactory);
-        }
+        const initPromises = workspaceContext.folders.map(folder =>
+            this.handleEvent(folder, FolderOperation.add, languageClientFactory)
+        );
+        this.initialized = Promise.all(initPromises).then(() => {});
     }
 
     private async handleEvent(
@@ -76,12 +79,18 @@ export class LanguageClientToolchainCoordinator implements Disposable {
 
         switch (operation) {
             case FolderOperation.add: {
-                const client = await this.create(folder, languageClientFactory);
+                const client = await this.getClientForFolderSwiftVersion(
+                    folder,
+                    languageClientFactory
+                );
                 await client.addFolder(folder);
                 break;
             }
             case FolderOperation.remove: {
-                const client = await this.create(folder, languageClientFactory);
+                const client = await this.getClientForFolderSwiftVersion(
+                    folder,
+                    languageClientFactory
+                );
                 await client.removeFolder(folder);
                 break;
             }
@@ -121,35 +130,38 @@ export class LanguageClientToolchainCoordinator implements Disposable {
             await client.stop();
         }
         this.clients.clear();
+        this.clientCreationPromises.clear();
     }
 
-    private async create(
-        folder: FolderContext,
-        languageClientFactory: LanguageClientFactory
-    ): Promise<LanguageClientManager> {
-        const client = this.getClientForFolderSwiftVersion(folder, languageClientFactory);
-
-        if (!folder.isRootFolder && !client.subFolderWorkspaces.includes(folder)) {
-            client.subFolderWorkspaces.push(folder);
-        }
-
-        await client.setLanguageClientFolder(folder);
-
-        return client;
-    }
-
-    private getClientForFolderSwiftVersion(
+    private async getClientForFolderSwiftVersion(
         folder: FolderContext,
         factory: LanguageClientFactory
-    ): LanguageClientManager {
+    ): Promise<LanguageClientManager> {
         const version = folder.swiftVersion.toString();
+
+        // Check if client already exists
         const existing = this.clients.get(version);
         if (existing) {
             return existing;
         }
-        const client = new LanguageClientManager(folder, this.options, factory);
-        this.clients.set(version, client);
-        return client;
+
+        // Check if client creation is already in progress
+        const existingPromise = this.clientCreationPromises.get(version);
+        if (existingPromise) {
+            return existingPromise;
+        }
+
+        // Create new client and track the promise to prevent race conditions
+        const clientPromise = LanguageClientManager.create(folder, this.options, factory);
+        this.clientCreationPromises.set(version, clientPromise);
+
+        try {
+            const client = await clientPromise;
+            this.clients.set(version, client);
+            return client;
+        } finally {
+            this.clientCreationPromises.delete(version);
+        }
     }
 
     dispose() {

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -17,7 +17,6 @@ import { FolderContext } from "../FolderContext";
 import { FolderOperation, WorkspaceContext } from "../WorkspaceContext";
 import { Disposable } from "../utilities/Disposable";
 import { isExcluded } from "../utilities/filesystem";
-import { Version } from "../utilities/version";
 import { LanguageClientFactory } from "./LanguageClientFactory";
 import { LanguageClientManager } from "./LanguageClientManager";
 
@@ -74,25 +73,16 @@ export class LanguageClientToolchainCoordinator implements Disposable {
         if (isExcluded(folder.workspaceFolder.uri)) {
             return;
         }
-        const singleServer = folder.swiftVersion.isGreaterThanOrEqual(new Version(5, 7, 0));
+
         switch (operation) {
             case FolderOperation.add: {
-                const client = await this.create(folder, singleServer, languageClientFactory);
-                await (singleServer
-                    ? client.addFolder(folder)
-                    : client.setLanguageClientFolder(folder));
+                const client = await this.create(folder, languageClientFactory);
+                await client.addFolder(folder);
                 break;
             }
             case FolderOperation.remove: {
-                const client = await this.create(folder, singleServer, languageClientFactory);
+                const client = await this.create(folder, languageClientFactory);
                 await client.removeFolder(folder);
-                break;
-            }
-            case FolderOperation.focus: {
-                if (!singleServer) {
-                    const client = await this.create(folder, singleServer, languageClientFactory);
-                    await client.setLanguageClientFolder(folder);
-                }
                 break;
             }
         }
@@ -135,19 +125,29 @@ export class LanguageClientToolchainCoordinator implements Disposable {
 
     private async create(
         folder: FolderContext,
-        singleServerSupport: boolean,
         languageClientFactory: LanguageClientFactory
     ): Promise<LanguageClientManager> {
-        const versionString = folder.swiftVersion.toString();
-        let client = this.clients.get(versionString);
-        if (!client) {
-            client = new LanguageClientManager(folder, this.options, languageClientFactory);
-            this.clients.set(versionString, client);
-            // Callers that must restart when switching folders will call setLanguageClientFolder themselves.
-            if (singleServerSupport) {
-                await client.setLanguageClientFolder(folder);
-            }
+        // A client is created for each unique toolchain version, as each toolchain has its own sourcekit-lsp
+        const client = this.getClientForFolderSwiftVersion(folder, languageClientFactory);
+
+        if (!folder.isRootFolder && client.subFolderWorkspaces.indexOf(folder) === -1) {
+            client.subFolderWorkspaces.push(folder);
         }
+
+        // Tell the LSP to switch to the target folder
+        await client.setLanguageClientFolder(folder);
+
+        return client;
+    }
+
+    private getClientForFolderSwiftVersion(
+        folder: FolderContext,
+        factory: LanguageClientFactory
+    ): LanguageClientManager {
+        const version = folder.swiftVersion.toString();
+        const client =
+            this.clients.get(version) ?? new LanguageClientManager(folder, this.options, factory);
+        this.clients.set(version, client);
         return client;
     }
 

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -15,6 +15,7 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "../FolderContext";
 import { FolderOperation, WorkspaceContext } from "../WorkspaceContext";
+import { SwiftLogger } from "../logging/SwiftLogger";
 import { Disposable } from "../utilities/Disposable";
 import { isExcluded } from "../utilities/filesystem";
 import { LanguageClientFactory } from "./LanguageClientFactory";
@@ -32,6 +33,7 @@ export class LanguageClientToolchainCoordinator implements Disposable {
     private clients: Map<string, LanguageClientManager> = new Map();
     private clientCreationPromises: Map<string, Promise<LanguageClientManager>> = new Map();
     public readonly initialized: Promise<void>;
+    private readonly logger: SwiftLogger;
 
     public constructor(
         workspaceContext: WorkspaceContext,
@@ -49,6 +51,7 @@ export class LanguageClientToolchainCoordinator implements Disposable {
         } = {},
         languageClientFactory: LanguageClientFactory = new LanguageClientFactory() // used for testing only
     ) {
+        this.logger = workspaceContext.logger;
         this.subscriptions.push(
             // stop and start server for each folder based on which file I am looking at
             workspaceContext.onDidChangeFolders(async ({ folder, operation }) => {
@@ -79,6 +82,9 @@ export class LanguageClientToolchainCoordinator implements Disposable {
 
         switch (operation) {
             case FolderOperation.add: {
+                this.logger.info(
+                    `Coordinator: Adding folder ${FolderContext.uriName(folder.folder)} (Swift ${folder.swiftVersion})`
+                );
                 const client = await this.getClientForFolderSwiftVersion(
                     folder,
                     languageClientFactory
@@ -87,6 +93,9 @@ export class LanguageClientToolchainCoordinator implements Disposable {
                 break;
             }
             case FolderOperation.remove: {
+                this.logger.info(
+                    `Coordinator: Removing folder ${FolderContext.uriName(folder.folder)} (Swift ${folder.swiftVersion})`
+                );
                 const client = await this.getClientForFolderSwiftVersion(
                     folder,
                     languageClientFactory
@@ -126,6 +135,7 @@ export class LanguageClientToolchainCoordinator implements Disposable {
      * This should be called when the extension is deactivated.
      */
     public async stop() {
+        this.logger.info(`Coordinator: Stopping ${this.clients.size} SourceKit-LSP client(s)`);
         for (const client of this.clients.values()) {
             await client.stop();
         }
@@ -142,16 +152,23 @@ export class LanguageClientToolchainCoordinator implements Disposable {
         // Check if client already exists
         const existing = this.clients.get(version);
         if (existing) {
+            this.logger.info(
+                `Coordinator: Reusing existing SourceKit-LSP client for Swift ${version}`
+            );
             return existing;
         }
 
         // Check if client creation is already in progress
         const existingPromise = this.clientCreationPromises.get(version);
         if (existingPromise) {
+            this.logger.info(
+                `Coordinator: Waiting for in-progress SourceKit-LSP client creation for Swift ${version}`
+            );
             return existingPromise;
         }
 
         // Create new client and track the promise to prevent race conditions
+        this.logger.info(`Coordinator: Creating new SourceKit-LSP client for Swift ${version}`);
         const clientPromise = LanguageClientManager.create(folder, this.options, factory);
         this.clientCreationPromises.set(version, clientPromise);
 

--- a/src/sourcekit-lsp/WorkspaceFolderGate.ts
+++ b/src/sourcekit-lsp/WorkspaceFolderGate.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { SwiftLogger } from "../logging/SwiftLogger";
 import { isPathInsidePath } from "../utilities/filesystem";
 
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -27,7 +28,10 @@ export class WorkspaceFolderGate implements vscode.Disposable {
     private knownFolders: Set<string>;
     private pendingRequests: Set<PendingRequest>;
 
-    constructor(rootUri: vscode.Uri) {
+    constructor(
+        rootUri: vscode.Uri,
+        private logger?: SwiftLogger
+    ) {
         this.knownFolders = new Set([rootUri.fsPath]);
         this.pendingRequests = new Set();
     }
@@ -41,8 +45,15 @@ export class WorkspaceFolderGate implements vscode.Disposable {
             return Promise.resolve();
         }
 
+        this.logger?.info(
+            `WorkspaceFolderGate: Deferring request for ${documentUri.fsPath} until its workspace folder is registered`
+        );
+
         return new Promise<void>(resolve => {
             const timeoutHandle = setTimeout(() => {
+                this.logger?.info(
+                    `WorkspaceFolderGate: Timed out waiting for folder containing ${documentUri.fsPath}`
+                );
                 this.removePendingRequest(request);
                 resolve();
             }, timeoutMs);
@@ -66,17 +77,24 @@ export class WorkspaceFolderGate implements vscode.Disposable {
     }
 
     folderAdded(folderUri: vscode.Uri): void {
+        this.logger?.info(`WorkspaceFolderGate: Registering folder ${folderUri.fsPath}`);
         this.knownFolders = new Set([...this.knownFolders, folderUri.fsPath]);
         this.resolveMatchingRequests(folderUri);
     }
 
     folderRemoved(folderUri: vscode.Uri): void {
+        this.logger?.info(`WorkspaceFolderGate: Unregistering folder ${folderUri.fsPath}`);
         const updated = new Set(this.knownFolders);
         updated.delete(folderUri.fsPath);
         this.knownFolders = updated;
     }
 
     dispose(): void {
+        if (this.pendingRequests.size > 0) {
+            this.logger?.info(
+                `WorkspaceFolderGate: Disposing with ${this.pendingRequests.size} pending request(s)`
+            );
+        }
         for (const request of this.pendingRequests) {
             request.cleanup();
             request.resolve();

--- a/src/sourcekit-lsp/WorkspaceFolderGate.ts
+++ b/src/sourcekit-lsp/WorkspaceFolderGate.ts
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import * as vscode from "vscode";
+
+import { isPathInsidePath } from "../utilities/filesystem";
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+type PendingRequest = {
+    readonly documentUri: vscode.Uri;
+    readonly resolve: () => void;
+    readonly cleanup: () => void;
+};
+
+export class WorkspaceFolderGate implements vscode.Disposable {
+    private knownFolders: Set<string>;
+    private pendingRequests: Set<PendingRequest>;
+
+    constructor(rootUri: vscode.Uri) {
+        this.knownFolders = new Set([rootUri.fsPath]);
+        this.pendingRequests = new Set();
+    }
+
+    waitForFolder(
+        documentUri: vscode.Uri,
+        timeoutMs: number = DEFAULT_TIMEOUT_MS,
+        cancellationToken?: vscode.CancellationToken
+    ): Promise<void> {
+        if (this.isInsideKnownFolder(documentUri)) {
+            return Promise.resolve();
+        }
+
+        return new Promise<void>(resolve => {
+            const timeoutHandle = setTimeout(() => {
+                this.removePendingRequest(request);
+                resolve();
+            }, timeoutMs);
+
+            const tokenListener = cancellationToken?.onCancellationRequested(() => {
+                this.removePendingRequest(request);
+                resolve();
+            });
+
+            const request: PendingRequest = {
+                documentUri,
+                resolve,
+                cleanup: () => {
+                    clearTimeout(timeoutHandle);
+                    tokenListener?.dispose();
+                },
+            };
+
+            this.pendingRequests = new Set([...this.pendingRequests, request]);
+        });
+    }
+
+    folderAdded(folderUri: vscode.Uri): void {
+        this.knownFolders = new Set([...this.knownFolders, folderUri.fsPath]);
+        this.resolveMatchingRequests(folderUri);
+    }
+
+    folderRemoved(folderUri: vscode.Uri): void {
+        const updated = new Set(this.knownFolders);
+        updated.delete(folderUri.fsPath);
+        this.knownFolders = updated;
+    }
+
+    dispose(): void {
+        for (const request of this.pendingRequests) {
+            request.cleanup();
+            request.resolve();
+        }
+        this.pendingRequests = new Set();
+    }
+
+    private isInsideKnownFolder(documentUri: vscode.Uri): boolean {
+        return [...this.knownFolders].some(folder => isPathInsidePath(documentUri.fsPath, folder));
+    }
+
+    private resolveMatchingRequests(folderUri: vscode.Uri): void {
+        const remaining = new Set<PendingRequest>();
+        for (const request of this.pendingRequests) {
+            if (isPathInsidePath(request.documentUri.fsPath, folderUri.fsPath)) {
+                request.cleanup();
+                request.resolve();
+            } else {
+                remaining.add(request);
+            }
+        }
+        this.pendingRequests = remaining;
+    }
+
+    private removePendingRequest(request: PendingRequest): void {
+        request.cleanup();
+        const updated = new Set(this.pendingRequests);
+        updated.delete(request);
+        this.pendingRequests = updated;
+    }
+}

--- a/src/sourcekit-lsp/WorkspaceFolderGate.ts
+++ b/src/sourcekit-lsp/WorkspaceFolderGate.ts
@@ -14,6 +14,7 @@
 import * as vscode from "vscode";
 
 import { SwiftLogger } from "../logging/SwiftLogger";
+import { Disposable } from "../utilities/Disposable";
 import { isPathInsidePath } from "../utilities/filesystem";
 
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -24,7 +25,7 @@ type PendingRequest = {
     readonly cleanup: () => void;
 };
 
-export class WorkspaceFolderGate implements vscode.Disposable {
+export class WorkspaceFolderGate implements Disposable {
     private knownFolders: Set<string>;
     private pendingRequests: Set<PendingRequest>;
 

--- a/test/integration-tests/ExtensionActivation.test.ts
+++ b/test/integration-tests/ExtensionActivation.test.ts
@@ -119,9 +119,7 @@ tag("medium").suite("Extension Activation/Deactivation Tests", () => {
             assert(folder);
 
             const languageClient = workspaceContext.languageClientManager.get(folder);
-            const lspWorkspaces = languageClient.subFolderWorkspaces.map(
-                ({ folder }) => folder.fsPath
-            );
+            const lspWorkspaces = languageClient.addedFolders.map(({ folder }) => folder.fsPath);
             assertContains(lspWorkspaces, testAssetUri("cmake").fsPath);
         });
 
@@ -130,9 +128,7 @@ tag("medium").suite("Extension Activation/Deactivation Tests", () => {
             assert(folder);
 
             const languageClient = workspaceContext.languageClientManager.get(folder);
-            const lspWorkspaces = languageClient.subFolderWorkspaces.map(
-                ({ folder }) => folder.fsPath
-            );
+            const lspWorkspaces = languageClient.addedFolders.map(({ folder }) => folder.fsPath);
             assertContains(lspWorkspaces, testAssetUri("cmake-compile-flags").fsPath);
         });
     });

--- a/test/integration-tests/testexplorer/LSPTestDiscovery.test.ts
+++ b/test/integration-tests/testexplorer/LSPTestDiscovery.test.ts
@@ -184,21 +184,20 @@ suite("LSPTestDiscovery Suite", () => {
             }));
         });
 
+        function convertForComparison(items: TestClass[]): unknown[] {
+            return items.map(item => ({
+                ...item,
+                location: item.location?.uri.path,
+                range: item.location?.range,
+                children: convertForComparison(item.children),
+            }));
+        }
+
         function assertEqual(items: TestClass[], expected: TestClass[]) {
             // There is an issue comparing vscode.Uris directly.
             // The internal `_fsPath` is not initialized immediately, and so
             // could be undefined, or maybe not.
-            const convertedItems = items.map(item => ({
-                ...item,
-                location: item.location?.uri.path,
-                range: item.location?.range,
-            }));
-            const convertedExpected = expected.map(item => ({
-                ...item,
-                location: item.location?.uri.path,
-                range: item.location?.range,
-            }));
-            assert.deepStrictEqual(convertedItems, convertedExpected);
+            assert.deepStrictEqual(convertForComparison(items), convertForComparison(expected));
         }
 
         test(TextDocumentTestsRequest.method, async () => {

--- a/test/integration-tests/testexplorer/LSPTestDiscovery.test.ts
+++ b/test/integration-tests/testexplorer/LSPTestDiscovery.test.ts
@@ -231,6 +231,143 @@ suite("LSPTestDiscovery Suite", () => {
             assertEqual(testClasses, expected);
         });
 
+        test("deduplicates items with identical IDs", async () => {
+            const location = Location.create(
+                file.fsPath,
+                Range.create(Position.create(1, 0), Position.create(2, 0))
+            );
+            items = [
+                {
+                    id: "topLevelTest()/File.swift:12:3",
+                    label: "topLevelTest()",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location,
+                    children: [],
+                },
+                {
+                    id: "topLevelTest()/File.swift:12:3",
+                    label: "topLevelTest()",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location,
+                    children: [],
+                },
+            ];
+            expected = [
+                {
+                    id: "topLevelTest()",
+                    label: "topLevelTest()",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location: client.languageClient.protocol2CodeConverter.asLocation(location),
+                    children: [],
+                },
+            ];
+
+            client.setResponse(WorkspaceTestsRequest.type, items);
+
+            const testClasses = await discoverer.getWorkspaceTests(pkg);
+            assertEqual(testClasses, expected);
+        });
+
+        test("does not modify items without duplicates", async () => {
+            const location = Location.create(
+                file.fsPath,
+                Range.create(Position.create(1, 0), Position.create(2, 0))
+            );
+            items = [
+                {
+                    id: "topLevelTest()",
+                    label: "topLevelTest()",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location,
+                    children: [],
+                },
+            ];
+            expected = [
+                {
+                    id: "topLevelTest()",
+                    label: "topLevelTest()",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location: client.languageClient.protocol2CodeConverter.asLocation(location),
+                    children: [],
+                },
+            ];
+
+            client.setResponse(WorkspaceTestsRequest.type, items);
+
+            const testClasses = await discoverer.getWorkspaceTests(pkg);
+            assertEqual(testClasses, expected);
+        });
+
+        test("deduplicates children with identical IDs", async () => {
+            const location = Location.create(
+                file.fsPath,
+                Range.create(Position.create(1, 0), Position.create(2, 0))
+            );
+            const childLocation = Location.create(
+                file.fsPath,
+                Range.create(Position.create(3, 0), Position.create(4, 0))
+            );
+            const duplicateChild: LSPTestItem = {
+                id: "childTest()/File.swift:3:0",
+                label: "childTest()",
+                disabled: false,
+                style: "swift-testing",
+                tags: [],
+                location: childLocation,
+                children: [],
+            };
+            items = [
+                {
+                    id: "TestSuite",
+                    label: "TestSuite",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location,
+                    children: [duplicateChild, duplicateChild],
+                },
+            ];
+            expected = [
+                {
+                    id: "TestSuite",
+                    label: "TestSuite",
+                    disabled: false,
+                    style: "swift-testing",
+                    tags: [],
+                    location: client.languageClient.protocol2CodeConverter.asLocation(location),
+                    children: [
+                        {
+                            id: "childTest()",
+                            label: "childTest()",
+                            disabled: false,
+                            style: "swift-testing",
+                            tags: [],
+                            location:
+                                client.languageClient.protocol2CodeConverter.asLocation(
+                                    childLocation
+                                ),
+                            children: [],
+                        },
+                    ],
+                },
+            ];
+
+            client.setResponse(WorkspaceTestsRequest.type, items);
+
+            const testClasses = await discoverer.getWorkspaceTests(pkg);
+            assertEqual(testClasses, expected);
+        });
+
         test("Prepends test target to ID", async () => {
             const testTargetName = "TestTargetC99Name";
             expected = expected.map(item => ({

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -42,6 +42,7 @@ import {
 } from "@src/sourcekit-lsp/extensions/DidChangeActiveDocumentRequest";
 import { BuildFlags } from "@src/toolchain/BuildFlags";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
+import { Disposable } from "@src/utilities/Disposable";
 import { Version } from "@src/utilities/version";
 
 import {
@@ -103,9 +104,7 @@ suite("LanguageClientManager Suite", () => {
         mockedVSCodeWorkspace.getConfiguration
             .withArgs("files")
             .returns({ get: () => ({}) } as any);
-        mockedVSCodeWorkspace.registerTextDocumentContentProvider.returns(
-            new vscode.Disposable(() => {})
-        );
+        mockedVSCodeWorkspace.registerTextDocumentContentProvider.returns(new Disposable(() => {}));
         // Mock the WorkspaceContext and SwiftToolchain
         mockedBuildFlags = mockObject<BuildFlags>({
             buildPathFlags: mockFn(s => s.returns([])),
@@ -836,7 +835,7 @@ suite("LanguageClientManager Suite", () => {
 
         setup(() => {
             mockedWorkspace.globalToolchainSwiftVersion = new Version(6, 1, 0);
-            mockWindow.onDidChangeActiveTextEditor.returns(new vscode.Disposable(() => {}));
+            mockWindow.onDidChangeActiveTextEditor.returns(new Disposable(() => {}));
         });
 
         teardown(async () => {

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -513,6 +513,40 @@ suite("LanguageClientManager Suite", () => {
         );
     });
 
+    test("pre-populates initial non-root folder into subFolderWorkspaces on startup", async () => {
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(languageClientMock.sendNotification).to.have.been.calledWithExactly(
+            DidChangeWorkspaceFoldersNotification.type,
+            {
+                event: {
+                    added: [{ name: "folder1", uri: path.normalize("/folder1") }],
+                    removed: [],
+                },
+            } as DidChangeWorkspaceFoldersParams
+        );
+    });
+
+    test("addFolder does not duplicate notification for pre-registered folder", async () => {
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        await waitForReturnedPromises(languageClientMock.start);
+
+        const notificationCalls = languageClientMock.sendNotification.getCalls().filter(call => {
+            const params = call.args[1] as DidChangeWorkspaceFoldersParams | undefined;
+            return params?.event?.added?.some(f => f.uri === path.normalize("/folder1")) === true;
+        });
+        expect(notificationCalls).to.have.lengthOf(1);
+    });
+
     test("doesn't launch SourceKit-LSP if disabled by the user", async () => {
         mockedLspConfig.disable = true;
         const sut = new LanguageClientManager(
@@ -930,152 +964,6 @@ suite("LanguageClientManager Suite", () => {
                     },
                 } as DidChangeActiveDocumentParams
             );
-        });
-    });
-
-    suite("SourceKit-LSP version doesn't support workspace folders", () => {
-        let folder1: MockedObject<FolderContext>;
-        let folder2: MockedObject<FolderContext>;
-
-        setup(() => {
-            mockedToolchain.swiftVersion = new Version(5, 6, 0);
-            mockedWorkspace.globalToolchainSwiftVersion = new Version(5, 6, 0);
-            const workspaceFolder = {
-                uri: vscode.Uri.file("/folder1"),
-                name: "folder1",
-                index: 0,
-            };
-            const folderContext = mockObject<FolderContext>({
-                workspaceContext: instance(mockedWorkspace),
-                workspaceFolder,
-                toolchain: instance(mockedToolchain),
-                logger: instance(mockLogger),
-            });
-            mockedFolder.swiftVersion = mockedToolchain.swiftVersion;
-            mockedWorkspace = mockObject<WorkspaceContext>({
-                ...mockedWorkspace,
-                globalToolchain: instance(mockedToolchain),
-                currentFolder: instance(folderContext),
-                get globalToolchainSwiftVersion() {
-                    return mockedToolchain.swiftVersion;
-                },
-                folders: [instance(mockedFolder)],
-            });
-            folder1 = mockObject<FolderContext>({
-                isRootFolder: false,
-                folder: vscode.Uri.file("/folder1"),
-                workspaceFolder,
-                workspaceContext: instance(mockedWorkspace),
-                toolchain: instance(mockedToolchain),
-                swiftVersion: mockedToolchain.swiftVersion,
-                logger: instance(mockLogger),
-            });
-            folder2 = mockObject<FolderContext>({
-                isRootFolder: false,
-                folder: vscode.Uri.file("/folder2"),
-                workspaceFolder: {
-                    uri: vscode.Uri.file("/folder2"),
-                    name: "folder2",
-                    index: 1,
-                },
-                workspaceContext: instance(mockedWorkspace),
-                toolchain: instance(mockedToolchain),
-                swiftVersion: mockedToolchain.swiftVersion,
-                logger: instance(mockLogger),
-            });
-        });
-
-        test("doesn't launch SourceKit-LSP on startup", async () => {
-            const sut = new LanguageClientManager(
-                instance(mockedFolder),
-                {},
-                languageClientFactoryMock
-            );
-            await waitForReturnedPromises(languageClientMock.start);
-
-            expect(sut.state).to.equal(State.Stopped);
-            expect(languageClientFactoryMock.createLanguageClient).to.not.have.been.called;
-            expect(languageClientMock.start).to.not.have.been.called;
-        });
-
-        test("launches SourceKit-LSP when a Swift file is opened", async () => {
-            mockedVSCodeWindow.activeTextEditor = instance(
-                mockObject<vscode.TextEditor>({
-                    document: instance(
-                        mockObject<vscode.TextDocument>({
-                            uri: vscode.Uri.file("/folder1/file.swift"),
-                        })
-                    ),
-                })
-            );
-            const factory = new LanguageClientToolchainCoordinator(
-                instance(mockedWorkspace),
-                {},
-                languageClientFactoryMock
-            );
-
-            const sut = factory.get(instance(mockedFolder));
-            await waitForReturnedPromises(languageClientMock.start);
-
-            // Add the folder to the workspace
-            await didChangeFoldersEmitter.fire({
-                operation: FolderOperation.add,
-                folder: instance(folder1),
-                workspace: instance(mockedWorkspace),
-            });
-
-            expect(sut.state).to.equal(
-                State.Running,
-                "Expected LSP client to be running but it wasn't"
-            );
-            expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledWith(
-                /* id */ match.string,
-                /* name */ match.string,
-                /* serverOptions */ match.object,
-                /* clientOptions */ match.hasNested("workspaceFolder.uri.path", "/folder1")
-            );
-            expect(languageClientMock.start).to.have.been.called;
-        });
-
-        test("changes SourceKit-LSP's workspaceFolder when a new folder is focussed", async () => {
-            const mockedTextDocument = mockObject<vscode.TextDocument>({
-                uri: vscode.Uri.file("/folder1/file.swift"),
-            });
-            mockedVSCodeWindow.activeTextEditor = instance(
-                mockObject<vscode.TextEditor>({
-                    document: instance(mockedTextDocument),
-                })
-            );
-            const factory = new LanguageClientToolchainCoordinator(
-                instance(mockedWorkspace),
-                {},
-                languageClientFactoryMock
-            );
-
-            const sut = factory.get(instance(mockedFolder));
-            await waitForReturnedPromises(languageClientMock.start);
-
-            // Trigger a focus event for the second folder
-            mockedTextDocument.uri = vscode.Uri.file("/folder2/file.swift");
-            await didChangeFoldersEmitter.fire({
-                operation: FolderOperation.focus,
-                folder: instance(folder2),
-                workspace: instance(mockedWorkspace),
-            });
-
-            expect(sut.state).to.equal(
-                State.Running,
-                "Expected LSP client to be running but it wasn't"
-            );
-            expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledTwice;
-            expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledWith(
-                /* id */ match.string,
-                /* name */ match.string,
-                /* serverOptions */ match.object,
-                /* clientOptions */ match.hasNested("workspaceFolder.uri.path", "/folder2")
-            );
-            expect(languageClientMock.start).to.have.been.calledTwice;
-            expect(languageClientMock.start).to.have.been.calledAfter(languageClientMock.stop);
         });
     });
 });

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -25,6 +25,7 @@ import {
     StateChangeEvent,
 } from "vscode-languageclient/node";
 
+import { DiagnosticsManager } from "@src/DiagnosticsManager";
 import { FolderContext } from "@src/FolderContext";
 import { FolderEvent, FolderOperation, WorkspaceContext } from "@src/WorkspaceContext";
 import configuration from "@src/configuration";
@@ -102,6 +103,9 @@ suite("LanguageClientManager Suite", () => {
         mockedVSCodeWorkspace.getConfiguration
             .withArgs("files")
             .returns({ get: () => ({}) } as any);
+        mockedVSCodeWorkspace.registerTextDocumentContentProvider.returns(
+            new vscode.Disposable(() => {})
+        );
         // Mock the WorkspaceContext and SwiftToolchain
         mockedBuildFlags = mockObject<BuildFlags>({
             buildPathFlags: mockFn(s => s.returns([])),
@@ -137,6 +141,11 @@ suite("LanguageClientManager Suite", () => {
                     globalToolchainSwiftVersion: new Version(6, 0, 0),
                     logger: instance(mockLogger),
                     loggerFactory: instance(mockLoggerFactory),
+                    diagnostics: instance(
+                        mockObject<DiagnosticsManager>({
+                            handleDiagnostics: mockFn(),
+                        })
+                    ),
                 })
             ),
             swiftVersion: new Version(6, 0, 0),
@@ -208,6 +217,7 @@ suite("LanguageClientManager Suite", () => {
             sendNotification: mockFn(s => s.resolves()),
             onNotification: mockFn(s => s.returns({ dispose() {} })),
             onDidChangeState: mockFn(s => s.callsFake(changeStateEmitter.event)),
+            dispose: mockFn(s => s.resolves()),
         });
         // `new LanguageClient()` will always return the mocked LanguageClient
         languageClientFactoryMock = mockObject<LanguageClientFactory>({
@@ -239,6 +249,7 @@ suite("LanguageClientManager Suite", () => {
                 {},
                 languageClientFactoryMock
             );
+            await factory.initialized;
 
             const sut1 = factory.get(instance(mockedFolder));
             const sut2 = factory.get(instance(mockedFolder));
@@ -267,6 +278,7 @@ suite("LanguageClientManager Suite", () => {
                 {},
                 languageClientFactoryMock
             );
+            await factory.initialized;
 
             const sut1 = factory.get(instance(mockedFolder));
             const sut2 = factory.get(instance(newFolder));
@@ -303,63 +315,12 @@ suite("LanguageClientManager Suite", () => {
                 {},
                 languageClientFactoryMock
             );
+            await factory.initialized;
 
-            const sut1 = factory.get(instance(mockedFolder));
-            const sut2 = factory.get(instance(newFolder));
-
-            expect(sut1).to.not.equal(sut2, "Expected different LanguageClients to be returned");
+            factory.get(instance(mockedFolder));
+            factory.get(instance(newFolder));
             expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledTwice;
         });
-    });
-
-    test("launches SourceKit-LSP on startup", async () => {
-        const factory = new LanguageClientToolchainCoordinator(
-            instance(mockedWorkspace),
-            {},
-            languageClientFactoryMock
-        );
-
-        const sut = factory.get(instance(mockedFolder));
-        await waitForReturnedPromises(languageClientMock.start);
-
-        expect(sut.state).to.equal(
-            State.Running,
-            "Expected LSP client to be running but it wasn't"
-        );
-        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
-            /* id */ match.string,
-            /* name */ match.string,
-            /* serverOptions */ match.has("command", "/path/to/toolchain/bin/sourcekit-lsp"),
-            /* clientOptions */ match.object
-        );
-        expect(languageClientMock.start).to.have.been.calledOnce;
-    });
-
-    test("launches SourceKit-LSP on startup with swiftSDK", async () => {
-        mockedConfig.swiftSDK = "arm64-apple-ios";
-        const factory = new LanguageClientToolchainCoordinator(
-            instance(mockedWorkspace),
-            {},
-            languageClientFactoryMock
-        );
-
-        const sut = factory.get(instance(mockedFolder));
-        await waitForReturnedPromises(languageClientMock.start);
-
-        expect(sut.state).to.equal(
-            State.Running,
-            "Expected LSP client to be running but it wasn't"
-        );
-        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
-            /* id */ match.string,
-            /* name */ match.string,
-            /* serverOptions */ match.has("command", "/path/to/toolchain/bin/sourcekit-lsp"),
-            /* clientOptions */ match.hasNested(
-                "initializationOptions.swiftPM.swiftSDK",
-                "arm64-apple-ios"
-            )
-        );
-        expect(languageClientMock.start).to.have.been.calledOnce;
     });
 
     test("chooses the correct backgroundIndexing value is auto, swift version if 6.0.0", async () => {
@@ -513,31 +474,13 @@ suite("LanguageClientManager Suite", () => {
         );
     });
 
-    test("pre-populates initial non-root folder into subFolderWorkspaces on startup", async () => {
-        coordinator = new LanguageClientToolchainCoordinator(
-            instance(mockedWorkspace),
-            {},
-            languageClientFactoryMock
-        );
-        await waitForReturnedPromises(languageClientMock.start);
-
-        expect(languageClientMock.sendNotification).to.have.been.calledWithExactly(
-            DidChangeWorkspaceFoldersNotification.type,
-            {
-                event: {
-                    added: [{ name: "folder1", uri: path.normalize("/folder1") }],
-                    removed: [],
-                },
-            } as DidChangeWorkspaceFoldersParams
-        );
-    });
-
     test("addFolder does not duplicate notification for pre-registered folder", async () => {
         coordinator = new LanguageClientToolchainCoordinator(
             instance(mockedWorkspace),
             {},
             languageClientFactoryMock
         );
+        await coordinator.initialized;
         await waitForReturnedPromises(languageClientMock.start);
 
         const folder1Notifications = languageClientMock.sendNotification
@@ -553,7 +496,7 @@ suite("LanguageClientManager Suite", () => {
 
     test("doesn't launch SourceKit-LSP if disabled by the user", async () => {
         mockedLspConfig.disable = true;
-        const sut = new LanguageClientManager(
+        const sut = await LanguageClientManager.create(
             instance(mockedFolder),
             {},
             languageClientFactoryMock
@@ -572,9 +515,9 @@ suite("LanguageClientManager Suite", () => {
             {},
             languageClientFactoryMock
         );
+        await factory.initialized;
 
         const sut = factory.get(instance(mockedFolder));
-        await waitForReturnedPromises(languageClientMock.start);
 
         expect(sut.state).to.equal(
             State.Running,
@@ -640,7 +583,7 @@ suite("LanguageClientManager Suite", () => {
         expect(middleware).to.have.property("provideCodeLenses");
         await expect(
             middleware.provideCodeLenses!(
-                { uri: vscode.Uri.file("/path/to/doc.swift") } as any,
+                { uri: vscode.Uri.file("/folder1/doc.swift") } as any,
                 {} as any,
                 codelensesFromSourceKitLSP
             )
@@ -689,7 +632,7 @@ suite("LanguageClientManager Suite", () => {
             mockParameterHintsEnabled.setValue(() => true);
 
             document = mockObject<vscode.TextDocument>({
-                uri: vscode.Uri.file("/test/file.swift"),
+                uri: vscode.Uri.file("/folder1/file.swift"),
             });
 
             coordinator = new LanguageClientToolchainCoordinator(
@@ -893,9 +836,11 @@ suite("LanguageClientManager Suite", () => {
 
         setup(() => {
             mockedWorkspace.globalToolchainSwiftVersion = new Version(6, 1, 0);
+            mockWindow.onDidChangeActiveTextEditor.returns(new vscode.Disposable(() => {}));
         });
 
-        teardown(() => {
+        teardown(async () => {
+            await clientManager?.stop();
             clientManager?.dispose();
         });
 
@@ -912,7 +857,7 @@ suite("LanguageClientManager Suite", () => {
                 return { dispose: () => {} };
             });
 
-            clientManager = new LanguageClientManager(
+            clientManager = await LanguageClientManager.create(
                 instance(mockedFolder),
                 {},
                 languageClientFactoryMock
@@ -948,7 +893,7 @@ suite("LanguageClientManager Suite", () => {
                     document,
                 })
             );
-            clientManager = new LanguageClientManager(
+            clientManager = await LanguageClientManager.create(
                 instance(mockedFolder),
                 {},
                 languageClientFactoryMock
@@ -971,6 +916,202 @@ suite("LanguageClientManager Suite", () => {
         });
     });
 
+    suite("WorkspaceFolderGate integration", () => {
+        test("addFolder signals the gate after sending didChangeWorkspaceFolders", async () => {
+            const sut = await LanguageClientManager.create(
+                instance(mockedFolder),
+                {},
+                languageClientFactoryMock
+            );
+            await waitForReturnedPromises(languageClientMock.start);
+
+            const docUri = vscode.Uri.file("/folder22/Sources/main.swift");
+            let resolved = false;
+            const waitPromise = sut.folderGate.waitForFolder(docUri, 2000).then(() => {
+                resolved = true;
+            });
+
+            await new Promise(r => setTimeout(r, 50));
+            expect(resolved).to.be.false;
+
+            const newFolder = mockObject<FolderContext>({
+                isRootFolder: false,
+                folder: vscode.Uri.file("/folder22"),
+                workspaceFolder: {
+                    uri: vscode.Uri.file("/folder22"),
+                    name: "folder22",
+                    index: 1,
+                },
+                workspaceContext: instance(mockedWorkspace),
+                swiftVersion: new Version(6, 0, 0),
+                toolchain: instance(mockedToolchain),
+                logger: instance(mockLogger),
+            });
+
+            await sut.addFolder(instance(newFolder));
+            await waitPromise;
+
+            expect(resolved).to.be.true;
+        });
+
+        test("removeFolder removes the folder from the gate", async () => {
+            const sut = await LanguageClientManager.create(
+                instance(mockedFolder),
+                {},
+                languageClientFactoryMock
+            );
+            await waitForReturnedPromises(languageClientMock.start);
+
+            const newFolder = mockObject<FolderContext>({
+                isRootFolder: false,
+                folder: vscode.Uri.file("/folder22"),
+                workspaceFolder: {
+                    uri: vscode.Uri.file("/folder22"),
+                    name: "folder22",
+                    index: 1,
+                },
+                workspaceContext: instance(mockedWorkspace),
+                swiftVersion: new Version(6, 0, 0),
+                toolchain: instance(mockedToolchain),
+                logger: instance(mockLogger),
+            });
+
+            await sut.addFolder(instance(newFolder));
+
+            const docUri = vscode.Uri.file("/folder22/Sources/main.swift");
+            let resolvedImmediately = false;
+            await sut.folderGate.waitForFolder(docUri, 100).then(() => {
+                resolvedImmediately = true;
+            });
+            expect(resolvedImmediately).to.be.true;
+
+            await sut.removeFolder(instance(newFolder));
+
+            let resolvedAfterRemoval = false;
+            const waitPromise = sut.folderGate.waitForFolder(docUri, 200).then(() => {
+                resolvedAfterRemoval = true;
+            });
+
+            await new Promise(r => setTimeout(r, 50));
+            expect(resolvedAfterRemoval).to.be.false;
+
+            await waitPromise;
+        });
+    });
+
+    suite("middleware folder gating", () => {
+        let middleware: Middleware;
+
+        setup(async () => {
+            coordinator = new LanguageClientToolchainCoordinator(
+                instance(mockedWorkspace),
+                {},
+                languageClientFactoryMock
+            );
+            await waitForReturnedPromises(languageClientMock.start);
+            middleware = languageClientFactoryMock.createLanguageClient.args[0][3].middleware!;
+        });
+
+        test("didOpen is deferred for documents in unregistered folders", async () => {
+            const document = instance(
+                mockObject<vscode.TextDocument>({
+                    uri: vscode.Uri.file("/unregistered/Sources/lib.swift"),
+                })
+            );
+            let nextCalled = false;
+            const next = async () => {
+                nextCalled = true;
+            };
+
+            const openPromise = middleware.didOpen!(document, next);
+            await new Promise(r => setTimeout(r, 50));
+            expect(nextCalled).to.be.false;
+
+            const newFolder = mockObject<FolderContext>({
+                isRootFolder: false,
+                folder: vscode.Uri.file("/unregistered"),
+                workspaceFolder: {
+                    uri: vscode.Uri.file("/unregistered"),
+                    name: "unregistered",
+                    index: 1,
+                },
+                workspaceContext: instance(mockedWorkspace),
+                swiftVersion: new Version(6, 0, 0),
+                toolchain: instance(mockedToolchain),
+                logger: instance(mockLogger),
+            });
+            mockedWorkspace.folders.push(instance(newFolder));
+            await didChangeFoldersEmitter.fire({
+                operation: FolderOperation.add,
+                folder: instance(newFolder),
+                workspace: instance(mockedWorkspace),
+            });
+
+            await openPromise;
+            expect(nextCalled).to.be.true;
+        });
+
+        test("didOpen passes through immediately for documents in known folders", async () => {
+            const document = instance(
+                mockObject<vscode.TextDocument>({
+                    uri: vscode.Uri.file("/folder1/Sources/lib.swift"),
+                })
+            );
+            let nextCalled = false;
+            const next = async () => {
+                nextCalled = true;
+            };
+
+            await middleware.didOpen!(document, next);
+            expect(nextCalled).to.be.true;
+        });
+
+        test("provideDiagnostics is deferred for documents in unregistered folders", async () => {
+            const document = instance(
+                mockObject<vscode.TextDocument>({
+                    uri: vscode.Uri.file("/unregistered/Sources/lib.swift"),
+                })
+            );
+            let nextCalled = false;
+            const next = async () => {
+                nextCalled = true;
+                return undefined;
+            };
+
+            const diagnosticsPromise = middleware.provideDiagnostics!(
+                document as any,
+                "prev",
+                new vscode.CancellationTokenSource().token,
+                next
+            );
+            await new Promise(r => setTimeout(r, 50));
+            expect(nextCalled).to.be.false;
+
+            const newFolder = mockObject<FolderContext>({
+                isRootFolder: false,
+                folder: vscode.Uri.file("/unregistered"),
+                workspaceFolder: {
+                    uri: vscode.Uri.file("/unregistered"),
+                    name: "unregistered",
+                    index: 1,
+                },
+                workspaceContext: instance(mockedWorkspace),
+                swiftVersion: new Version(6, 0, 0),
+                toolchain: instance(mockedToolchain),
+                logger: instance(mockLogger),
+            });
+            mockedWorkspace.folders.push(instance(newFolder));
+            await didChangeFoldersEmitter.fire({
+                operation: FolderOperation.add,
+                folder: instance(newFolder),
+                workspace: instance(mockedWorkspace),
+            });
+
+            await diagnosticsPromise;
+            expect(nextCalled).to.be.true;
+        });
+    });
+
     test("disposes old output channel before creating new client on restart", async () => {
         const callOrder: string[] = [];
 
@@ -990,8 +1131,8 @@ suite("LanguageClientManager Suite", () => {
             {},
             languageClientFactoryMock
         );
+        await coordinator.initialized;
         const sut = coordinator.get(instance(mockedFolder));
-        await waitForReturnedPromises(languageClientMock.start);
 
         expect(sut.state).to.equal(State.Running);
 

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -970,4 +970,45 @@ suite("LanguageClientManager Suite", () => {
             );
         });
     });
+
+    test("disposes old output channel before creating new client on restart", async () => {
+        const callOrder: string[] = [];
+
+        const firstOutputChannel = mockObject<SwiftOutputChannel>({
+            dispose: mockFn(s =>
+                s.callsFake(() => {
+                    callOrder.push("dispose-old-output-channel");
+                })
+            ),
+            warn: mockFn(),
+        });
+
+        languageClientMock.outputChannel = instance(firstOutputChannel);
+
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        const sut = coordinator.get(instance(mockedFolder));
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(sut.state).to.equal(State.Running);
+
+        const secondOutputChannel = mockObject<SwiftOutputChannel>({
+            dispose: mockFn(),
+            warn: mockFn(),
+        });
+
+        languageClientFactoryMock.createLanguageClient.callsFake(() => {
+            callOrder.push("create-new-client");
+            languageClientMock.outputChannel = instance(secondOutputChannel);
+            return instance(languageClientMock);
+        });
+
+        await sut.restart();
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(callOrder).to.deep.equal(["dispose-old-output-channel", "create-new-client"]);
+    });
 });

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -540,11 +540,15 @@ suite("LanguageClientManager Suite", () => {
         );
         await waitForReturnedPromises(languageClientMock.start);
 
-        const notificationCalls = languageClientMock.sendNotification.getCalls().filter(call => {
-            const params = call.args[1] as DidChangeWorkspaceFoldersParams | undefined;
-            return params?.event?.added?.some(f => f.uri === path.normalize("/folder1")) === true;
-        });
-        expect(notificationCalls).to.have.lengthOf(1);
+        const folder1Notifications = languageClientMock.sendNotification
+            .getCalls()
+            .filter(
+                call =>
+                    call.args[1]?.event?.added?.some(
+                        (f: { uri: string }) => f.uri === path.normalize("/folder1")
+                    ) === true
+            );
+        expect(folder1Notifications).to.have.lengthOf(1);
     });
 
     test("doesn't launch SourceKit-LSP if disabled by the user", async () => {

--- a/test/unit-tests/sourcekit-lsp/OutputChannelTransport.test.ts
+++ b/test/unit-tests/sourcekit-lsp/OutputChannelTransport.test.ts
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+import * as vscode from "vscode";
+
+import { OutputChannelTransport } from "@src/logging/OutputChannelTransport";
+
+import { MockedObject, mockFn, mockObject } from "../../MockUtils";
+
+suite("OutputChannelTransport Suite", () => {
+    function createMockChannel(): MockedObject<vscode.OutputChannel> {
+        return mockObject<vscode.OutputChannel>({
+            append: mockFn(s => s.returns(undefined)),
+            appendLine: mockFn(s => s.returns(undefined)),
+        });
+    }
+
+    test("does not throw when output channel is undefined", done => {
+        const transport = new OutputChannelTransport(undefined as unknown as vscode.OutputChannel);
+        transport.log({ message: "test", [Symbol.for("message")]: "test" }, () => {
+            done();
+        });
+    });
+
+    test("calls append on the output channel when append is true", done => {
+        const mockChannel = createMockChannel();
+
+        const transport = new OutputChannelTransport(
+            mockChannel as unknown as vscode.OutputChannel
+        );
+
+        transport.log(
+            { message: "continuation", append: true, [Symbol.for("message")]: "formatted" },
+            () => {
+                expect(mockChannel.append).to.have.been.calledOnce;
+                done();
+            }
+        );
+    });
+
+    test("calls appendLine on the output channel when append is falsy", done => {
+        const mockChannel = createMockChannel();
+
+        const transport = new OutputChannelTransport(
+            mockChannel as unknown as vscode.OutputChannel
+        );
+        transport.log({ message: "hello", [Symbol.for("message")]: "formatted" }, () => {
+            expect(mockChannel.appendLine).to.have.been.calledOnceWith("formatted");
+            done();
+        });
+    });
+});

--- a/test/unit-tests/sourcekit-lsp/WorkspaceFolderGate.test.ts
+++ b/test/unit-tests/sourcekit-lsp/WorkspaceFolderGate.test.ts
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+import * as vscode from "vscode";
+
+import { WorkspaceFolderGate } from "@src/sourcekit-lsp/WorkspaceFolderGate";
+
+suite("WorkspaceFolderGate Suite", () => {
+    const rootUri = vscode.Uri.file("/root/project");
+    const subfolderUri = vscode.Uri.file("/root/project/subfolder");
+    const otherUri = vscode.Uri.file("/other/project");
+
+    function createGate(): WorkspaceFolderGate {
+        return new WorkspaceFolderGate(rootUri);
+    }
+
+    suite("waitForFolder", () => {
+        test("resolves immediately for documents inside the root folder", async () => {
+            const gate = createGate();
+            const documentUri = vscode.Uri.file("/root/project/Sources/main.swift");
+            await gate.waitForFolder(documentUri);
+        });
+
+        test("resolves immediately for documents inside a known subfolder", async () => {
+            const gate = createGate();
+            gate.folderAdded(subfolderUri);
+            const documentUri = vscode.Uri.file("/root/project/subfolder/file.swift");
+            await gate.waitForFolder(documentUri);
+        });
+
+        test("waits and resolves when the containing folder is added", async () => {
+            const gate = createGate();
+            const documentUri = vscode.Uri.file("/other/project/Sources/file.swift");
+
+            const promise = gate.waitForFolder(documentUri);
+            gate.folderAdded(otherUri);
+
+            await promise;
+        });
+
+        test("times out when the containing folder is never added", async () => {
+            const gate = createGate();
+            const documentUri = vscode.Uri.file("/other/project/Sources/file.swift");
+
+            await gate.waitForFolder(documentUri, 50);
+        });
+
+        test("resolves via cancellation token", async () => {
+            const gate = createGate();
+            const documentUri = vscode.Uri.file("/other/project/Sources/file.swift");
+            const tokenSource = new vscode.CancellationTokenSource();
+
+            const promise = gate.waitForFolder(documentUri, 30000, tokenSource.token);
+            tokenSource.cancel();
+
+            await promise;
+            tokenSource.dispose();
+        });
+
+        test("resolves multiple pending requests when a folder is added", async () => {
+            const gate = createGate();
+            const doc1 = vscode.Uri.file("/other/project/Sources/a.swift");
+            const doc2 = vscode.Uri.file("/other/project/Sources/b.swift");
+
+            const promise1 = gate.waitForFolder(doc1);
+            const promise2 = gate.waitForFolder(doc2);
+            gate.folderAdded(otherUri);
+
+            await Promise.all([promise1, promise2]);
+        });
+
+        test("does not resolve requests for unrelated folders", async () => {
+            const gate = createGate();
+            const documentUri = vscode.Uri.file("/other/project/Sources/file.swift");
+            const unrelatedUri = vscode.Uri.file("/unrelated/folder");
+
+            let resolved = false;
+            const promise = gate.waitForFolder(documentUri, 100).then(() => {
+                resolved = true;
+            });
+
+            gate.folderAdded(unrelatedUri);
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(resolved).to.be.false;
+
+            gate.folderAdded(otherUri);
+            await promise;
+            expect(resolved).to.be.true;
+        });
+    });
+
+    suite("folderRemoved", () => {
+        test("removes a known folder so documents inside it must wait again", async () => {
+            const gate = createGate();
+            gate.folderAdded(otherUri);
+            gate.folderRemoved(otherUri);
+
+            const documentUri = vscode.Uri.file("/other/project/Sources/file.swift");
+            let resolved = false;
+            const promise = gate.waitForFolder(documentUri, 100).then(() => {
+                resolved = true;
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 50));
+            expect(resolved).to.be.false;
+
+            gate.folderAdded(otherUri);
+            await promise;
+            expect(resolved).to.be.true;
+        });
+    });
+
+    suite("dispose", () => {
+        test("resolves all pending requests on dispose", async () => {
+            const gate = createGate();
+            const doc1 = vscode.Uri.file("/other/project/Sources/a.swift");
+            const doc2 = vscode.Uri.file("/third/project/Sources/b.swift");
+
+            const promise1 = gate.waitForFolder(doc1);
+            const promise2 = gate.waitForFolder(doc2);
+
+            gate.dispose();
+
+            await Promise.all([promise1, promise2]);
+        });
+    });
+});


### PR DESCRIPTION
## Description
Subfolders were not being registered as workspace folders with SourceKit-LSP unless a file from the sub folder was focused when the package was added. Consequently diagnostics requests may never have been produced for files in those packages. 

Refactor LSP creation to add folders to the workspace as they are discovered. Hold back the initial LSP requests for a folder until the `workspace/didChangeWorkspaceFolders` response has been received, ensuring the LSP knows about a folder before receiving requests for it.

Also removes the legacy pre-5.7 single-server codepath that is no longer needed.

Issue: #2166

## Tasks
- [X] Required tests have been written
- [X] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
