### PR TITLE
Add determinate progress bar to build status notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix false positive workspace detection for non-Swift projects with `build/` or `out/` directories ([#2156](https://github.com/swiftlang/vscode-swift/pull/2156))
+- Fix build status notification to show a determinate progress bar ([#2188](https://github.com/swiftlang/vscode-swift/pull/2188))
 
 ## 2.16.3 - 2026-04-02
 

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -39,6 +39,7 @@ interface SwiftProgress {
 export class SwiftBuildStatus implements vscode.Disposable {
     private onDidStartTaskDisposible: vscode.Disposable;
     private lockedRegex = /Another instance of SwiftPM \(PID: \d+\) is already running/g;
+    private debt = 0;
 
     constructor() {
         this.onDidStartTaskDisposible = vscode.tasks.onDidStartTask(event => {
@@ -67,14 +68,15 @@ export class SwiftBuildStatus implements vscode.Disposable {
 
         const execution = task.execution as SwiftExecution;
         const isBuildTask = task.group === vscode.TaskGroup.Build;
-        const handleTaskOutput = (update: (message: string) => void) =>
-            this.awaitTaskCompletion(task, execution, isBuildTask, showBuildStatus, update);
+        const handleTaskOutput = (
+            update: (report: { message: string; increment?: number }) => void
+        ) => this.awaitTaskCompletion(task, execution, isBuildTask, showBuildStatus, update);
         const location =
             showBuildStatus === "notification"
                 ? vscode.ProgressLocation.Notification
                 : vscode.ProgressLocation.Window;
         void vscode.window.withProgress<void>({ location }, progress =>
-            handleTaskOutput(message => progress.report({ message }))
+            handleTaskOutput(report => progress.report(report))
         );
     }
 
@@ -83,7 +85,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
         execution: SwiftExecution,
         isBuildTask: boolean,
         showBuildStatus: ShowBuildStatusOptions,
-        update: (message: string) => void
+        update: (report: { message: string; increment?: number }) => void
     ): Promise<void> {
         const disposables: vscode.Disposable[] = [];
         return new Promise<void>(res => {
@@ -115,10 +117,11 @@ export class SwiftBuildStatus implements vscode.Disposable {
         execution: SwiftExecution,
         isBuildTask: boolean,
         showBuildStatus: ShowBuildStatusOptions,
-        update: (message: string) => void,
+        update: (report: { message: string; increment?: number }) => void,
         done: () => void
     ): vscode.Disposable {
         let started = false;
+        let lastPercentage = 0;
 
         const parseEvents = (data: string) => {
             const sanitizedData = stripAnsi(data);
@@ -129,22 +132,31 @@ export class SwiftBuildStatus implements vscode.Disposable {
             for (const line of lines) {
                 const lockedFolderPID = this.checkIfBuildFolderLocked(line);
                 if (lockedFolderPID > 0) {
-                    update(
-                        `${name}: Build folder locked by pid ${lockedFolderPID}. Wait for this process to complete, or terminate it to continue.`
-                    );
+                    update({
+                        message: `${name}: Build folder locked by pid ${lockedFolderPID}. Wait for this process to complete, or terminate it to continue.`,
+                    });
                 }
                 if (checkIfBuildComplete(line)) {
-                    update(name);
+                    update({ message: name });
                     return !isBuildTask;
                 }
                 const progress = this.findBuildProgress(line);
                 if (progress) {
-                    update(`${name}: [${progress.completed}/${progress.total}]`);
                     started = true;
+
+                    const percentage = Math.floor((progress.completed / progress.total) * 100);
+                    const increment = percentage - lastPercentage;
+                    const reportedIncrement = this.applyDebt(increment);
+
+                    lastPercentage = percentage;
+                    update({
+                        message: `${name}: [${progress.completed}/${progress.total}]`,
+                        increment: reportedIncrement,
+                    });
                     return false;
                 }
                 if (this.checkIfFetching(line)) {
-                    update(`${name}: Fetching Dependencies`);
+                    update({ message: `${name}: Fetching Dependencies` });
                     started = true;
                     return false;
                 }
@@ -155,7 +167,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
         // Begin by showing a message that the build is preparing, as there is sometimes
         // a delay before building starts, especially in large projects.
         if (!started && showBuildStatus !== "never") {
-            update(`${name}: Preparing...`);
+            update({ message: `${name}: Preparing...` });
         }
 
         return execution.onDidWrite(data => {
@@ -188,5 +200,22 @@ export class SwiftBuildStatus implements vscode.Disposable {
         if (match) {
             return { completed: parseInt(match[1]), total: parseInt(match[2]) };
         }
+    }
+
+    private applyDebt(increment: number): number {
+        if (increment < 0) {
+            this.debt += Math.abs(increment);
+            return 0;
+        }
+        if (this.debt <= 0) {
+            return increment;
+        }
+        if (increment <= this.debt) {
+            this.debt -= increment;
+            return 0;
+        }
+        const result = increment - this.debt;
+        this.debt = 0;
+        return result;
     }
 }

--- a/test/unit-tests/ui/SwiftBuildStatus.test.ts
+++ b/test/unit-tests/ui/SwiftBuildStatus.test.ts
@@ -163,13 +163,86 @@ suite("SwiftBuildStatus Unit Test Suite", function () {
         );
 
         const expected = "My Task: [7/7]";
-        expect(mockedProgress.report).to.have.been.calledWith({ message: expected });
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: expected,
+            increment: 100,
+        });
 
         // Ignore old stuff
         expect(mockedProgress.report).to.not.have.been.calledWith({
             message: "My Task: Fetching Dependencies",
         });
         expect(mockedProgress.report).to.not.have.been.calledWith({ message: "My Task: [6/7]" });
+    });
+
+    test("Reports incremental progress across multiple writes", async () => {
+        configurationMock.setValue("progress");
+        buildStatus = new SwiftBuildStatus();
+        await didStartTaskMock.fire({ execution: mockedTaskExecution });
+
+        testSwiftProcess.write("[1/4] Compiling A.swift\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [1/4]",
+            increment: 25,
+        });
+
+        testSwiftProcess.write("[3/4] Compiling C.swift\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [3/4]",
+            increment: 50,
+        });
+
+        testSwiftProcess.write("[4/4] Applying MyCLI\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [4/4]",
+            increment: 25,
+        });
+    });
+
+    test("Reports zero increment when total increases and progress goes backwards", async () => {
+        configurationMock.setValue("progress");
+        buildStatus = new SwiftBuildStatus();
+        await didStartTaskMock.fire({ execution: mockedTaskExecution });
+
+        // [5/10] = 50%
+        testSwiftProcess.write("[5/10] Compiling\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [5/10]",
+            increment: 50,
+        });
+
+        // New targets discovered: [5/20] = 25%, a backwards step of -25%.
+        // Reported increment should be 0, not negative.
+        testSwiftProcess.write("[5/20] Compiling\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [5/20]",
+            increment: 0,
+        });
+
+        // [10/20] = 50%, which matches the last reported percentage.
+        // Debt of 25 absorbs this entire +25 increment, so reported is still 0.
+        testSwiftProcess.write("[10/20] Compiling\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [10/20]",
+            increment: 0,
+        });
+
+        // [15/20] = 75%, a +25 gain. Debt is fully repaid, so reported increment resumes.
+        testSwiftProcess.write("[15/20] Compiling\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [15/20]",
+            increment: 25,
+        });
+    });
+
+    test("Preparing phase reports no increment", async () => {
+        configurationMock.setValue("progress");
+        buildStatus = new SwiftBuildStatus();
+        await didStartTaskMock.fire({ execution: mockedTaskExecution });
+
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: Preparing...",
+        });
     });
 
     test("Build complete", async () => {


### PR DESCRIPTION
Currently the build progress dialog always shows indeterminate progress. The small progress bar in the dialog doesn't show definitive progress when the build switches to building individual build targets showing text like [12/100].

Track build progress percentage from [X/Y] output and report incremental progress to VS Code's progress API. The progress bar shows as indeterminate during the "Preparing..." phase and switches to a determinate bar once compilation begins. Handles backwards progress (when new build targets are discovered mid-build) by tracking debt and suppressing increments until progress catches up.

## Tasks
- [X] Required tests have been written
- [x] ~Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
