### PR TITLE
Add custom ESLint rules

### DIFF
--- a/eslint-plugin-vscode-swift/index.mjs
+++ b/eslint-plugin-vscode-swift/index.mjs
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import { defineConfig } from "eslint/config";
 
+import noExclusiveTests from "./no-exclusive-tests.mjs";
 import useCustomDisposable from "./use-custom-disposable.mjs";
 
 const plugin = {
@@ -23,6 +24,7 @@ const plugin = {
     },
     rules: {
         "use-custom-disposable": useCustomDisposable,
+        "no-exclusive-tests": noExclusiveTests,
     },
 };
 
@@ -33,6 +35,7 @@ export default {
             plugins: { "vscode-swift": plugin },
             rules: {
                 "vscode-swift/use-custom-disposable": "error",
+                "vscode-swift/no-exclusive-tests": "error",
             },
         }),
     },

--- a/eslint-plugin-vscode-swift/index.mjs
+++ b/eslint-plugin-vscode-swift/index.mjs
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { defineConfig } from "eslint/config";
+
+import useCustomDisposable from "./use-custom-disposable.mjs";
+
+const plugin = {
+    meta: {
+        name: "eslint-plugin-vscode-swift",
+        version: "1.0.0",
+        namespace: "vscode-swift",
+    },
+    rules: {
+        "use-custom-disposable": useCustomDisposable,
+    },
+};
+
+export default {
+    ...plugin,
+    configs: {
+        recommended: defineConfig({
+            plugins: { "vscode-swift": plugin },
+            rules: {
+                "vscode-swift/use-custom-disposable": "error",
+            },
+        }),
+    },
+};

--- a/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
+++ b/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
@@ -14,7 +14,7 @@
 // @ts-check
 import { ESLintUtils } from "@typescript-eslint/utils";
 
-import { createRule, isDeclaredIn } from "./utilities.mjs";
+import { createRule, isSymbolDeclaredIn } from "./utilities.mjs";
 
 export default createRule({
     create(context) {
@@ -23,7 +23,11 @@ export default createRule({
                 const services = ESLintUtils.getParserServices(context);
                 const type = services.getTypeAtLocation(node.callee);
 
-                if (!isDeclaredIn(type.symbol, sourceFile => sourceFile.includes("@types/mocha"))) {
+                if (
+                    !isSymbolDeclaredIn(type.symbol, sourceFile =>
+                        sourceFile.includes("@types/mocha")
+                    )
+                ) {
                     return;
                 }
 

--- a/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
+++ b/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
@@ -18,26 +18,26 @@ import { createRule, isDeclaredIn } from "./utilities.mjs";
 export default createRule({
     create(context) {
         return {
-            Identifier(node) {
-                if (node.name !== "Disposable") {
-                    return;
-                }
-
+            CallExpression(node) {
                 const services = ESLintUtils.getParserServices(context);
-                const type = services.getTypeFromTypeNode(node);
-                if (!type.symbol || type.symbol.name !== "Disposable") {
+                const type = services.getTypeAtLocation(node.callee);
+
+                if (!isDeclaredIn(type.symbol, sourceFile => sourceFile.includes("@types/mocha"))) {
                     return;
                 }
 
-                if (
-                    isDeclaredIn(
-                        type.symbol,
-                        sourceFile => !sourceFile.includes("src/utilities/Disposable")
-                    )
-                ) {
+                if (type.symbol.name === "ExclusiveSuiteFunction") {
                     context.report({
-                        messageId: "useCustomDisposable",
-                        node,
+                        messageId: "noExclusiveSuites",
+                        node: node.callee,
+                    });
+                    return;
+                }
+
+                if (type.symbol.name === "ExclusiveTestFunction") {
+                    context.report({
+                        messageId: "noExclusiveTests",
+                        node: node.callee,
                     });
                 }
             },
@@ -45,15 +45,15 @@ export default createRule({
     },
     meta: {
         docs: {
-            description: "Prefer using vscode-swift's custom disposable types.",
+            description: "Prohibit the use of suite.only() and test.only().",
         },
         messages: {
-            useCustomDisposable:
-                "Use one of the disposable types from `src/utilities/Disposable.ts`.",
+            noExclusiveTests: "Remove .only() from your test case.",
+            noExclusiveSuites: "Remove .only() from your test suite.",
         },
         type: "suggestion",
         schema: [],
         defaultOptions: [],
     },
-    name: "use-custom-disposable",
+    name: "no-exclusive-tests",
 });

--- a/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
+++ b/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+// @ts-check
 import { ESLintUtils } from "@typescript-eslint/utils";
 
 import { createRule, isDeclaredIn } from "./utilities.mjs";

--- a/eslint-plugin-vscode-swift/use-custom-disposable.mjs
+++ b/eslint-plugin-vscode-swift/use-custom-disposable.mjs
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { dirname } from "path";
+import * as ts from "typescript";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const createRule = ESLintUtils.RuleCreator(ruleName => `file://${__dirname}/${ruleName}.mjs`);
+
+export default createRule({
+    create(context) {
+        return {
+            Identifier(node) {
+                if (node.name !== "Disposable") {
+                    return;
+                }
+
+                const services = ESLintUtils.getParserServices(context);
+                const type = services.getTypeFromTypeNode(node);
+                if (!type.symbol || type.symbol.name !== "Disposable") {
+                    return;
+                }
+
+                for (const declaration of type.symbol.declarations) {
+                    let sourceFile = declaration.parent;
+                    while (!!sourceFile && sourceFile.kind !== ts.SyntaxKind.SourceFile) {
+                        sourceFile = sourceFile.parent;
+                    }
+                    if (!sourceFile.fileName.includes("src/utilities/Disposable")) {
+                        context.report({
+                            messageId: "useCustomDisposable",
+                            node,
+                        });
+                    }
+                }
+            },
+        };
+    },
+    meta: {
+        docs: {
+            description: "Prefer using vscode-swift's custom disposable types.",
+        },
+        messages: {
+            useCustomDisposable:
+                "Use one of the disposable types from `src/utilities/Disposable.ts`.",
+        },
+        type: "suggestion",
+        schema: [],
+        defaultOptions: [],
+    },
+    name: "use-custom-disposable",
+});

--- a/eslint-plugin-vscode-swift/use-custom-disposable.mjs
+++ b/eslint-plugin-vscode-swift/use-custom-disposable.mjs
@@ -14,7 +14,7 @@
 // @ts-check
 import { ESLintUtils } from "@typescript-eslint/utils";
 
-import { createRule, isDeclaredIn } from "./utilities.mjs";
+import { createRule, isSymbolDeclaredIn } from "./utilities.mjs";
 
 export default createRule({
     create(context) {
@@ -31,7 +31,7 @@ export default createRule({
                 }
 
                 if (
-                    isDeclaredIn(
+                    isSymbolDeclaredIn(
                         type.symbol,
                         sourceFile => !sourceFile.includes("src/utilities/Disposable")
                     )

--- a/eslint-plugin-vscode-swift/use-custom-disposable.mjs
+++ b/eslint-plugin-vscode-swift/use-custom-disposable.mjs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+// @ts-check
 import { ESLintUtils } from "@typescript-eslint/utils";
 
 import { createRule, isDeclaredIn } from "./utilities.mjs";
@@ -24,7 +25,7 @@ export default createRule({
                 }
 
                 const services = ESLintUtils.getParserServices(context);
-                const type = services.getTypeFromTypeNode(node);
+                const type = services.getTypeAtLocation(node);
                 if (!type.symbol || type.symbol.name !== "Disposable") {
                     return;
                 }

--- a/eslint-plugin-vscode-swift/utilities.mjs
+++ b/eslint-plugin-vscode-swift/utilities.mjs
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { dirname } from "path";
+import * as ts from "typescript";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const createRule = ESLintUtils.RuleCreator(
+    ruleName => `file://${__dirname}/${ruleName}.mjs`
+);
+
+/**
+ * Determines whether the symbol's source file name passes the provided predicate.
+ *
+ * @param {ts.Symbol | undefined} symbol The symbol to check.
+ * @param {(fileName: string) => boolean} predicate A function that returns true if the source file matches some criteria.
+ * @returns {boolean} True if the symbol is declared in a source file that matches the predicate.
+ */
+export function isDeclaredIn(symbol, predicate) {
+    if (!symbol?.declarations) {
+        return false;
+    }
+
+    return (
+        symbol.declarations.findIndex(decl => {
+            const sourceFile = findNameOfSourceFile(decl);
+            if (!sourceFile) {
+                return false;
+            }
+            return predicate(sourceFile);
+        }) >= 0
+    );
+}
+
+/**
+ * Finds the name of the source file that contains the provided declaration, if any.
+ *
+ * @param {ts.Declaration} decl The declaration.
+ * @returns {string | undefined} The name of the source file if found.
+ */
+function findNameOfSourceFile(decl) {
+    while (!!decl && decl.kind !== ts.SyntaxKind.SourceFile) {
+        decl = decl.parent;
+    }
+    if (!decl) {
+        return undefined;
+    }
+    return decl.fileName;
+}

--- a/eslint-plugin-vscode-swift/utilities.mjs
+++ b/eslint-plugin-vscode-swift/utilities.mjs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+// @ts-check
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { dirname } from "path";
 import * as ts from "typescript";
@@ -53,11 +54,12 @@ export function isDeclaredIn(symbol, predicate) {
  * @returns {string | undefined} The name of the source file if found.
  */
 function findNameOfSourceFile(decl) {
-    while (!!decl && decl.kind !== ts.SyntaxKind.SourceFile) {
-        decl = decl.parent;
+    let currentNode = decl.parent;
+    while (!!currentNode && !ts.isSourceFile(currentNode)) {
+        currentNode = currentNode.parent;
     }
-    if (!decl) {
+    if (!currentNode) {
         return undefined;
     }
-    return decl.fileName;
+    return currentNode.fileName;
 }

--- a/eslint-plugin-vscode-swift/utilities.mjs
+++ b/eslint-plugin-vscode-swift/utilities.mjs
@@ -31,7 +31,7 @@ export const createRule = ESLintUtils.RuleCreator(
  * @param {(fileName: string) => boolean} predicate A function that returns true if the source file matches some criteria.
  * @returns {boolean} True if the symbol is declared in a source file that matches the predicate.
  */
-export function isDeclaredIn(symbol, predicate) {
+export function isSymbolDeclaredIn(symbol, predicate) {
     if (!symbol?.declarations) {
         return false;
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,8 @@ import sonarjs from "eslint-plugin-sonarjs";
 import { defineConfig, globalIgnores } from "eslint/config";
 import globals from "globals";
 
+import vscodeSwiftPlugin from "./eslint-plugin-vscode-swift/index.mjs";
+
 const baseLanguageOptions = {
     ecmaVersion: 2022,
     sourceType: "module",
@@ -49,6 +51,7 @@ export default defineConfig([
             tsESLint.configs["flat/recommended"],
             sonarjs.configs.recommended,
             eslintPluginPrettierRecommended,
+            vscodeSwiftPlugin.configs.recommended,
         ],
         plugins: {
             "@typescript-eslint": tsESLint,
@@ -117,6 +120,12 @@ export default defineConfig([
             // These should be progressively enabled over time as we fix the underlying issues
             "sonarjs/no-ignored-exceptions": "off",
             "sonarjs/no-async-constructor": "off",
+        },
+    },
+    {
+        files: ["src/documentation/webview/**/*.ts"],
+        rules: {
+            "vscode-swift/use-custom-disposable": "off",
         },
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,7 +14,6 @@
 import js from "@eslint/js";
 import tsESLint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
-import mocha from "eslint-plugin-mocha";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import sonarjs from "eslint-plugin-sonarjs";
 import { defineConfig, globalIgnores } from "eslint/config";
@@ -71,12 +70,6 @@ export default defineConfig([
             "no-restricted-syntax": [
                 "error",
                 {
-                    selector:
-                        "CallExpression[callee.object.object.callee.name='tag'][callee.property.name='only']",
-                    message:
-                        "Unexpected exclusive mocha test with tag().suite.only() or tag().test.only()",
-                },
-                {
                     selector: "ImportExpression",
                     message:
                         "Dynamic imports using 'import()' are not allowed. Use static imports at the top of the file instead.",
@@ -120,6 +113,9 @@ export default defineConfig([
             // These should be progressively enabled over time as we fix the underlying issues
             "sonarjs/no-ignored-exceptions": "off",
             "sonarjs/no-async-constructor": "off",
+
+            // We have our own rule that uses type information from TypeScript to properly detect .only() in tests
+            "sonarjs/no-exclusive-tests": "off",
         },
     },
     {
@@ -130,11 +126,8 @@ export default defineConfig([
     },
     {
         files: ["./test/**/*.ts"],
-        plugins: { mocha },
         rules: {
             "no-console": "off",
-
-            "mocha/no-exclusive-tests": "error",
 
             "@typescript-eslint/no-explicit-any": "off",
             "@typescript-eslint/no-unused-expressions": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "esbuild": "^0.27.4",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-mocha": "^11.2.0",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-sonarjs": "^4.0.2",
         "globals": "^17.4.0",
@@ -5948,33 +5947,6 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-mocha": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.2.0.tgz",
-      "integrity": "sha512-nMdy3tEXZac8AH5Z/9hwUkSfWu8xHf4XqwB5UEQzyTQGKcNlgFeciRAjLjliIKC3dR1Ex/a2/5sqgQzvYRkkkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.1",
-        "globals": "^15.14.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-mocha/node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -16587,24 +16559,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "requires": {}
-    },
-    "eslint-plugin-mocha": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.2.0.tgz",
-      "integrity": "sha512-nMdy3tEXZac8AH5Z/9hwUkSfWu8xHf4XqwB5UEQzyTQGKcNlgFeciRAjLjliIKC3dR1Ex/a2/5sqgQzvYRkkkA==",
-      "dev": true,
-      "requires": {
-        "@eslint-community/eslint-utils": "^4.4.1",
-        "globals": "^15.14.0"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "15.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-          "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
-          "dev": true
-        }
-      }
     },
     "eslint-plugin-prettier": {
       "version": "5.5.5",

--- a/package.json
+++ b/package.json
@@ -2149,7 +2149,6 @@
     "esbuild": "^0.27.4",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-mocha": "^11.2.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-sonarjs": "^4.0.2",
     "globals": "^17.4.0",

--- a/src/BackgroundCompilation.ts
+++ b/src/BackgroundCompilation.ts
@@ -17,15 +17,16 @@ import { FolderContext } from "./FolderContext";
 import configuration from "./configuration";
 import { getBuildAllTask } from "./tasks/SwiftTaskProvider";
 import { TaskOperation } from "./tasks/TaskQueue";
+import { Disposable } from "./utilities/Disposable";
 import { validFileTypes } from "./utilities/filesystem";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import debounce = require("lodash.debounce");
 
-export class BackgroundCompilation implements vscode.Disposable {
+export class BackgroundCompilation implements Disposable {
     private workspaceFileWatcher?: vscode.FileSystemWatcher;
-    private configurationEventDisposable?: vscode.Disposable;
-    private disposables: vscode.Disposable[] = [];
+    private configurationEventDisposable?: Disposable;
+    private disposables: Disposable[] = [];
     private _disposed = false;
 
     constructor(private folderContext: FolderContext) {

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -18,6 +18,7 @@ import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
 import configuration from "./configuration";
 import { SwiftExecution } from "./tasks/SwiftExecution";
+import { Disposable } from "./utilities/Disposable";
 import { validFileTypes } from "./utilities/filesystem";
 import { checkIfBuildComplete, lineBreakRegex } from "./utilities/tasks";
 
@@ -55,7 +56,7 @@ const isSourceKit: DiagnosticPredicate = diagnostic =>
  * external clients to call {@link handleDiagnostics} to provide
  * thier own diagnostics.
  */
-export class DiagnosticsManager implements vscode.Disposable {
+export class DiagnosticsManager implements Disposable {
     private static readonly swiftc: string = "swiftc";
     static readonly isSourcekit: SourcePredicate = source => this.swiftc !== source;
     static readonly isSwiftc: SourcePredicate = source => this.swiftc === source;
@@ -298,7 +299,7 @@ export class DiagnosticsManager implements vscode.Disposable {
     private parseDiagnostics(swiftExecution: SwiftExecution): Promise<DiagnosticsMap> {
         return new Promise<DiagnosticsMap>(res => {
             const diagnostics = new Map();
-            const disposables: vscode.Disposable[] = [];
+            const disposables: Disposable[] = [];
             const done = () => {
                 disposables.forEach(d => d.dispose());
                 res(diagnostics);
@@ -481,8 +482,8 @@ export class DiagnosticsManager implements vscode.Disposable {
         return diagnostic;
     };
 
-    private onDidStartTaskDisposible: vscode.Disposable;
-    private onDidChangeConfigurationDisposible: vscode.Disposable;
-    private onDidDeleteDisposible: vscode.Disposable;
+    private onDidStartTaskDisposible: Disposable;
+    private onDidChangeConfigurationDisposible: Disposable;
+    private onDidDeleteDisposible: Disposable;
     private workspaceFileWatcher: vscode.FileSystemWatcher;
 }

--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -29,9 +29,10 @@ import { PlaygroundProvider } from "./playgrounds/PlaygroundProvider";
 import { TaskQueue } from "./tasks/TaskQueue";
 import { SwiftToolchain } from "./toolchain/toolchain";
 import { showToolchainError } from "./ui/ToolchainSelection";
+import { Disposable } from "./utilities/Disposable";
 import { isPathInsidePath } from "./utilities/filesystem";
 
-export class FolderContext implements ExternalFolderContext, vscode.Disposable {
+export class FolderContext implements ExternalFolderContext, Disposable {
     public backgroundCompilation: BackgroundCompilation;
     public hasResolveErrors = false;
     public taskQueue: TaskQueue;

--- a/src/PackageWatcher.ts
+++ b/src/PackageWatcher.ts
@@ -21,6 +21,7 @@ import configuration from "./configuration";
 import { SwiftLogger } from "./logging/SwiftLogger";
 import { BuildFlags } from "./toolchain/BuildFlags";
 import { showReloadExtensionNotification } from "./ui/ReloadExtension";
+import { Disposable } from "./utilities/Disposable";
 import { fileExists } from "./utilities/filesystem";
 import { Version } from "./utilities/version";
 
@@ -35,7 +36,7 @@ import debounce = require("lodash.debounce");
  */
 export class PackageWatcher {
     private packageFileWatcher?: vscode.FileSystemWatcher;
-    private resolvedChangedDisposable?: vscode.Disposable;
+    private resolvedChangedDisposable?: Disposable;
     private resolvedFileWatcher?: vscode.FileSystemWatcher;
     private workspaceStateFileWatcher?: vscode.FileSystemWatcher;
     private snippetWatcher?: vscode.FileSystemWatcher;

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -33,6 +33,7 @@ import { showPackageDependencies } from "./commands/dependencies/show";
 import { SwiftLogger } from "./logging/SwiftLogger";
 import { BuildFlags } from "./toolchain/BuildFlags";
 import { SwiftToolchain } from "./toolchain/toolchain";
+import { Disposable } from "./utilities/Disposable";
 import { fileExists, isPathInsidePath } from "./utilities/filesystem";
 import { lineBreakRegex } from "./utilities/tasks";
 import { execSwift, getErrorDescription, hashString, unwrapPromise } from "./utilities/utilities";
@@ -162,7 +163,7 @@ function isError(state: SwiftPackageState): state is Error {
 /**
  * Class holding Swift Package Manager Package
  */
-export class SwiftPackage implements ExternalSwiftPackage, vscode.Disposable {
+export class SwiftPackage implements ExternalSwiftPackage, Disposable {
     public plugins: PackagePlugin[] = [];
     private _contents: SwiftPackageState | undefined;
     private contentsPromise: Promise<SwiftPackageState>;

--- a/src/TestExplorer/TestCodeLensProvider.ts
+++ b/src/TestExplorer/TestCodeLensProvider.ts
@@ -14,13 +14,14 @@
 import * as vscode from "vscode";
 
 import configuration, { ValidCodeLens } from "../configuration";
+import { Disposable } from "../utilities/Disposable";
 import { TestExplorer } from "./TestExplorer";
 import { flattenTestItemCollection } from "./TestUtils";
 
-export class TestCodeLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
+export class TestCodeLensProvider implements vscode.CodeLensProvider, Disposable {
     private onDidChangeCodeLensesEmitter = new vscode.EventEmitter<void>();
     public onDidChangeCodeLenses = this.onDidChangeCodeLensesEmitter.event;
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
 
     constructor(private testExplorer: TestExplorer) {
         this.disposables = [

--- a/src/TestExplorer/TestExplorer.ts
+++ b/src/TestExplorer/TestExplorer.ts
@@ -21,6 +21,7 @@ import { SwiftLogger } from "../logging/SwiftLogger";
 import { buildOptions, getBuildAllTask } from "../tasks/SwiftTaskProvider";
 import { TaskManager } from "../tasks/TaskManager";
 import { SwiftExecOperation, TaskOperation } from "../tasks/TaskQueue";
+import { Disposable } from "../utilities/Disposable";
 import { getErrorDescription } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { parseTestsFromDocumentSymbols } from "./DocumentSymbolTestDiscovery";
@@ -39,7 +40,7 @@ export class TestExplorer {
     public testRunProfiles: vscode.TestRunProfile[];
 
     private lspTestDiscovery: LSPTestDiscovery;
-    private subscriptions: vscode.Disposable[];
+    private subscriptions: Disposable[];
     private tokenSource = new vscode.CancellationTokenSource();
 
     // Emits after the `vscode.TestController` has been updated.
@@ -55,9 +56,7 @@ export class TestExplorer {
         public folderContext: FolderContext,
         private tasks: TaskManager,
         private logger: SwiftLogger,
-        private onDidChangeSwiftFiles: (
-            listener: (event: SwiftFileEvent) => void
-        ) => vscode.Disposable
+        private onDidChangeSwiftFiles: (listener: (event: SwiftFileEvent) => void) => Disposable
     ) {
         this.onTestItemsDidChange = this.onTestItemsDidChangeEmitter.event;
         this.onCreateTestRun = this.onDidCreateTestRunEmitter.event;
@@ -177,7 +176,7 @@ export class TestExplorer {
     /**
      * Configure test discovery for updated tests after a build task has completed.
      */
-    private discoverUpdatedTestsAfterBuild(folderContext: FolderContext): vscode.Disposable {
+    private discoverUpdatedTestsAfterBuild(folderContext: FolderContext): Disposable {
         let testFileEdited = true;
         const endProcessDisposable = this.tasks.onDidEndTaskProcess(event => {
             const task = event.execution.task;
@@ -212,7 +211,7 @@ export class TestExplorer {
             }
         });
 
-        return vscode.Disposable.from(endProcessDisposable, didChangeSwiftFileDisposable);
+        return Disposable.from(endProcessDisposable, didChangeSwiftFileDisposable);
     }
 
     /**
@@ -221,7 +220,7 @@ export class TestExplorer {
      * @param workspaceContext Workspace context for extension
      * @returns Observer disposable
      */
-    public static observeFolders(workspaceContext: WorkspaceContext): vscode.Disposable {
+    public static observeFolders(workspaceContext: WorkspaceContext): Disposable {
         const tokenSource = new vscode.CancellationTokenSource();
         const disposable = workspaceContext.onDidChangeFolders(({ folder, operation }) => {
             switch (operation) {
@@ -233,7 +232,7 @@ export class TestExplorer {
                     break;
             }
         });
-        return vscode.Disposable.from(tokenSource, disposable);
+        return Disposable.from(tokenSource, disposable);
     }
 
     /**

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -29,6 +29,7 @@ import {
 import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
 import { createSwiftTask } from "../tasks/SwiftTaskProvider";
 import { TaskOperation } from "../tasks/TaskQueue";
+import { Disposable } from "../utilities/Disposable";
 import {
     CompositeCancellationToken,
     CompositeCancellationTokenSource,
@@ -696,7 +697,7 @@ export class TestRunner {
         }
 
         const testRunTime = Date.now();
-        const subscriptions: vscode.Disposable[] = [];
+        const subscriptions: Disposable[] = [];
         const buildConfigs: Array<vscode.DebugConfiguration | undefined> = [];
         const fifoPipePath = this.generateFifoPipePath(testRunTime);
 
@@ -802,7 +803,7 @@ export class TestRunner {
     private startDebugSession(
         config: vscode.DebugConfiguration,
         runState: TestRunnerTestRunState,
-        subscriptions: vscode.Disposable[],
+        subscriptions: Disposable[],
         fifoPipePath: string
     ): Promise<void> {
         return new Promise<void>((resolve, reject) => {

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -42,6 +42,7 @@ import { SwiftToolchain } from "./toolchain/toolchain";
 import { ProjectPanelProvider } from "./ui/ProjectPanelProvider";
 import { StatusItem } from "./ui/StatusItem";
 import { SwiftBuildStatus } from "./ui/SwiftBuildStatus";
+import { Disposable } from "./utilities/Disposable";
 import { isExcluded, isPathInsidePath } from "./utilities/filesystem";
 import { swiftLibraryPathKey } from "./utilities/utilities";
 import { isValidWorkspaceFolder, searchForPackages } from "./utilities/workspace";
@@ -59,7 +60,7 @@ export interface FolderEvent extends ExternalFolderEvent {
  * Context for whole workspace. Holds array of contexts for each workspace folder
  * and the ExtensionContext
  */
-export class WorkspaceContext implements ExternalWorkspaceContext, vscode.Disposable {
+export class WorkspaceContext implements ExternalWorkspaceContext, Disposable {
     public folders: FolderContext[] = [];
     public currentFolder: FolderContext | null | undefined;
     public currentDocument: vscode.Uri | null;
@@ -71,7 +72,7 @@ export class WorkspaceContext implements ExternalWorkspaceContext, vscode.Dispos
     public taskProvider: SwiftTaskProvider;
     public pluginProvider: SwiftPluginTaskProvider;
     public launchProvider: LLDBDebugConfigurationProvider;
-    public subscriptions: vscode.Disposable[];
+    public subscriptions: Disposable[];
     public commentCompletionProvider: CommentCompletionProviders;
     public documentation: DocumentationManager;
     public testRunManager: TestRunManager;
@@ -493,7 +494,7 @@ export class WorkspaceContext implements ExternalWorkspaceContext, vscode.Dispos
         this.folders = this.folders.filter(folder => folder.workspaceFolder !== workspaceFolder);
     }
 
-    onDidChangeFolders(listener: (event: FolderEvent) => unknown): vscode.Disposable {
+    onDidChangeFolders(listener: (event: FolderEvent) => unknown): Disposable {
         this.observers.add(listener);
 
         // https://github.com/swiftlang/vscode-swift/issues/1944
@@ -512,7 +513,7 @@ export class WorkspaceContext implements ExternalWorkspaceContext, vscode.Dispos
         return { dispose: () => this.observers.delete(listener) };
     }
 
-    onDidChangeSwiftFiles(listener: (event: SwiftFileEvent) => unknown): vscode.Disposable {
+    onDidChangeSwiftFiles(listener: (event: SwiftFileEvent) => unknown): Disposable {
         this.swiftFileObservers.add(listener);
         return { dispose: () => this.swiftFileObservers.delete(listener) };
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,6 +52,7 @@ import { extractTestItemsAndCount, runTestMultipleTimes } from "./commands/testM
 import { SwiftLogger } from "./logging/SwiftLogger";
 import { PackageNode, PlaygroundNode } from "./ui/ProjectPanelProvider";
 import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
+import { Disposable } from "./utilities/Disposable";
 
 /**
  * References:
@@ -65,7 +66,7 @@ import { showToolchainSelectionQuickPick } from "./ui/ToolchainSelection";
 export function registerToolchainCommands(
     ctx: WorkspaceContext | undefined,
     logger: SwiftLogger
-): vscode.Disposable[] {
+): Disposable[] {
     return [
         vscode.commands.registerCommand("swift.createNewProject", () =>
             createNewProject(ctx?.globalToolchain)
@@ -122,7 +123,7 @@ export enum Commands {
 /**
  * Registers this extension's commands in the given {@link vscode.ExtensionContext context}.
  */
-export function register(ctx: WorkspaceContext): vscode.Disposable[] {
+export function register(ctx: WorkspaceContext): Disposable[] {
     return [
         vscode.commands.registerCommand(
             "swift.generateLaunchConfigurations",

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -18,6 +18,7 @@ import { FolderContext } from "../FolderContext";
 import { WorkspaceContext } from "../WorkspaceContext";
 import configuration from "../configuration";
 import { selectFolder } from "../ui/SelectFolderQuickPick";
+import { Disposable } from "../utilities/Disposable";
 import restartLSPServer from "./restartLSPServer";
 
 const sourcekitDotFolder: string = ".sourcekit-lsp";
@@ -219,9 +220,7 @@ export async function handleSchemaUpdate(
     await checkDocumentSchema(doc, workspaceContext);
 }
 
-export function registerSourceKitSchemaWatcher(
-    workspaceContext: WorkspaceContext
-): vscode.Disposable {
+export function registerSourceKitSchemaWatcher(workspaceContext: WorkspaceContext): Disposable {
     const onDidOpenDisposable = vscode.workspace.onDidOpenTextDocument(doc => {
         void handleSchemaUpdate(doc, workspaceContext);
     });
@@ -237,7 +236,7 @@ export function registerSourceKitSchemaWatcher(
     const onDidCreateDisposable = configFileWatcher.onDidCreate(async uri => {
         await handleConfigFileChange(uri, workspaceContext);
     });
-    return vscode.Disposable.from(
+    return Disposable.from(
         onDidOpenDisposable,
         configFileWatcher,
         onDidChangeDisposable,

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -18,6 +18,7 @@ import { WorkspaceContext } from "../WorkspaceContext";
 import configuration from "../configuration";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { SwiftToolchain } from "../toolchain/toolchain";
+import { Disposable } from "../utilities/Disposable";
 import { fileExists } from "../utilities/filesystem";
 import { getErrorDescription, swiftRuntimeEnv } from "../utilities/utilities";
 import { DebugAdapter, LaunchConfigType, SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
@@ -31,8 +32,8 @@ import { registerLoggingDebugAdapterTracker } from "./logTracker";
  * @param workspaceContext  The workspace context
  * @returns A disposable to be disposed when the extension is deactivated
  */
-export function registerDebugger(workspaceContext: WorkspaceContext): vscode.Disposable {
-    let subscriptions: vscode.Disposable[] = [];
+export function registerDebugger(workspaceContext: WorkspaceContext): Disposable {
+    let subscriptions: Disposable[] = [];
 
     // Monitor the swift.debugger.disable setting and register automatically
     // when the setting is changed to enable.
@@ -55,7 +56,7 @@ export function registerDebugger(workspaceContext: WorkspaceContext): vscode.Dis
         register();
     }
 
-    return vscode.Disposable.from(configurationEvent, ...subscriptions);
+    return Disposable.from(configurationEvent, ...subscriptions);
 }
 
 /**
@@ -63,7 +64,7 @@ export function registerDebugger(workspaceContext: WorkspaceContext): vscode.Dis
  * @param workspaceContext The workspace context
  * @returns A disposable to be disposed when the extension is deactivated
  */
-function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): vscode.Disposable {
+function registerLLDBDebugAdapter(workspaceContext: WorkspaceContext): Disposable {
     return vscode.debug.registerDebugConfigurationProvider(
         SWIFT_LAUNCH_CONFIG_TYPE,
         workspaceContext.launchProvider

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -14,6 +14,7 @@
 import * as vscode from "vscode";
 
 import { SwiftLogger } from "../logging/SwiftLogger";
+import { Disposable } from "../utilities/Disposable";
 import { LaunchConfigType } from "./debugAdapter";
 
 /**
@@ -44,17 +45,17 @@ interface DebugMessage {
  * Register the LoggingDebugAdapterTrackerFactory with the VS Code debug adapter tracker
  * @returns A disposable to be disposed when the extension is deactivated
  */
-export function registerLoggingDebugAdapterTracker(): vscode.Disposable {
+export function registerLoggingDebugAdapterTracker(): Disposable {
     // Register the factory for both lldb-dap and CodeLLDB since either could be used when
     // resolving a Swift launch configuration.
     const trackerFactory = new LoggingDebugAdapterTrackerFactory();
-    const subscriptions: vscode.Disposable[] = [
+    const subscriptions: Disposable[] = [
         vscode.debug.registerDebugAdapterTrackerFactory(LaunchConfigType.CODE_LLDB, trackerFactory),
         vscode.debug.registerDebugAdapterTrackerFactory(LaunchConfigType.LLDB_DAP, trackerFactory),
     ];
 
     // Return a disposable that cleans everything up.
-    return vscode.Disposable.from(...subscriptions);
+    return Disposable.from(...subscriptions);
 }
 
 /**

--- a/src/documentation/DocumentationManager.ts
+++ b/src/documentation/DocumentationManager.ts
@@ -14,10 +14,11 @@
 import * as vscode from "vscode";
 
 import { WorkspaceContext } from "../WorkspaceContext";
+import { Disposable } from "../utilities/Disposable";
 import { DocumentationPreviewEditor } from "./DocumentationPreviewEditor";
 import { WebviewContent } from "./webview/WebviewMessage";
 
-export class DocumentationManager implements vscode.Disposable {
+export class DocumentationManager implements Disposable {
     private previewEditor?: DocumentationPreviewEditor;
     private editorUpdatedContentEmitter = new vscode.EventEmitter<WebviewContent>();
     private editorRenderedEmitter = new vscode.EventEmitter<void>();
@@ -45,7 +46,7 @@ export class DocumentationManager implements vscode.Disposable {
                 this.extension,
                 this.workspaceContext
             );
-            const subscriptions: vscode.Disposable[] = [
+            const subscriptions: Disposable[] = [
                 this.previewEditor.onDidUpdateContent(content => {
                     this.editorUpdatedContentEmitter.fire(content);
                 }),

--- a/src/documentation/DocumentationPreviewEditor.ts
+++ b/src/documentation/DocumentationPreviewEditor.ts
@@ -18,6 +18,7 @@ import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 
 import { WorkspaceContext } from "../WorkspaceContext";
 import { DocCDocumentationRequest, DocCDocumentationResponse } from "../sourcekit-lsp/extensions";
+import { Disposable } from "../utilities/Disposable";
 import { RenderNode, WebviewContent, WebviewMessage } from "./webview/WebviewMessage";
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -29,7 +30,7 @@ export enum PreviewEditorConstant {
     UNSUPPORTED_EDITOR_ERROR_MESSAGE = "The active text editor does not support Swift Documentation Live Preview",
 }
 
-export class DocumentationPreviewEditor implements vscode.Disposable {
+export class DocumentationPreviewEditor implements Disposable {
     static async create(
         extension: vscode.ExtensionContext,
         context: WorkspaceContext
@@ -98,7 +99,7 @@ export class DocumentationPreviewEditor implements vscode.Disposable {
 
     private activeTextEditor?: vscode.TextEditor;
     private activeTextEditorSelection?: vscode.Selection;
-    private subscriptions: vscode.Disposable[] = [];
+    private subscriptions: Disposable[] = [];
     private isDisposed: boolean = false;
 
     private disposeEmitter = new vscode.EventEmitter<void>();

--- a/src/editor/CommentCompletion.ts
+++ b/src/editor/CommentCompletion.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { Disposable } from "../utilities/Disposable";
 import { DocumentParser } from "./DocumentParser";
 
 function isLineComment(document: vscode.TextDocument, line: number): boolean {
@@ -252,11 +253,11 @@ class FunctionDocumentationCompletionProvider implements vscode.CompletionItemPr
 /**
  * Interface to comment completion providers
  */
-export class CommentCompletionProviders implements vscode.Disposable {
+export class CommentCompletionProviders implements Disposable {
     functionCommentCompletion: FunctionDocumentationCompletionProvider;
     docCommentCompletion: DocCommentCompletionProvider;
-    functionCommentCompletionProvider: vscode.Disposable;
-    docCommentCompletionProvider: vscode.Disposable;
+    functionCommentCompletionProvider: Disposable;
+    docCommentCompletionProvider: Disposable;
 
     constructor() {
         this.functionCommentCompletion = new FunctionDocumentationCompletionProvider();

--- a/src/logging/SwiftLogger.ts
+++ b/src/logging/SwiftLogger.ts
@@ -16,6 +16,7 @@ import * as winston from "winston";
 import type * as Transport from "winston-transport";
 
 import configuration from "../configuration";
+import { Disposable } from "../utilities/Disposable";
 import { IS_RUNNING_UNDER_DEBUGGER, IS_RUNNING_UNDER_TEST } from "../utilities/utilities";
 import { FileTransport } from "./FileTransport";
 import { OutputChannelTransport } from "./OutputChannelTransport";
@@ -25,8 +26,8 @@ import { RollingLogTransport } from "./RollingLogTransport";
 type LogMessageOptions = { append: boolean };
 type SwiftLoggerOptions = { logConsole?: boolean };
 
-export class SwiftLogger implements vscode.Disposable {
-    private subscriptions: vscode.Disposable[] = [];
+export class SwiftLogger implements Disposable {
+    private subscriptions: Disposable[] = [];
     private logger: winston.Logger;
     protected rollingLog: RollingLog;
     protected outputChannel: vscode.OutputChannel;

--- a/src/playgrounds/PlaygroundProvider.ts
+++ b/src/playgrounds/PlaygroundProvider.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { FolderOperation, WorkspaceContext } from "../WorkspaceContext";
 import { SwiftLogger } from "../logging/SwiftLogger";
+import { Disposable } from "../utilities/Disposable";
 import { LSPPlaygroundsDiscovery, Playground } from "./LSPPlaygroundsDiscovery";
 
 export { Playground };
@@ -31,7 +32,7 @@ interface PlaygroundChangeEvent {
  * added, or if any methods have been removed and edits the test items based on
  * these results.
  */
-export class PlaygroundProvider implements vscode.Disposable {
+export class PlaygroundProvider implements Disposable {
     private hasFetched: boolean = false;
     private fetchPromise: Promise<Playground[]> | undefined;
     private documentPlaygrounds: Map<string, Playground[]> = new Map();
@@ -54,7 +55,7 @@ export class PlaygroundProvider implements vscode.Disposable {
      * @param workspaceContext Workspace context for extension
      * @returns Observer disposable
      */
-    public static observeFolders(workspaceContext: WorkspaceContext): vscode.Disposable {
+    public static observeFolders(workspaceContext: WorkspaceContext): Disposable {
         return workspaceContext.onDidChangeFolders(({ folder, operation }) => {
             switch (operation) {
                 case FolderOperation.add:

--- a/src/sourcekit-lsp/LanguageClientManager.ts
+++ b/src/sourcekit-lsp/LanguageClientManager.ts
@@ -30,6 +30,7 @@ import { FolderContext } from "../FolderContext";
 import configuration from "../configuration";
 import { SwiftOutputChannel } from "../logging/SwiftOutputChannel";
 import { ArgumentFilter, BuildFlags } from "../toolchain/BuildFlags";
+import { Disposable } from "../utilities/Disposable";
 import { swiftRuntimeEnv } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 import { LSPLogger, LSPOutputChannel } from "./LSPOutputChannel";
@@ -63,7 +64,7 @@ interface LanguageClientManageOptions {
  * Manages the creation and destruction of Language clients as we move between
  * workspace folders
  */
-export class LanguageClientManager implements vscode.Disposable {
+export class LanguageClientManager implements Disposable {
     // known log names
     static readonly indexingLogName = "SourceKit-LSP: Indexing";
 
@@ -87,10 +88,10 @@ export class LanguageClientManager implements vscode.Disposable {
      */
     private languageClient: LanguageClient | null | undefined;
     private cancellationToken?: vscode.CancellationTokenSource;
-    private legacyInlayHints?: vscode.Disposable;
-    private peekDocuments?: vscode.Disposable;
-    private getReferenceDocument?: vscode.Disposable;
-    private didChangeActiveDocument?: vscode.Disposable;
+    private legacyInlayHints?: Disposable;
+    private peekDocuments?: Disposable;
+    private getReferenceDocument?: Disposable;
+    private didChangeActiveDocument?: Disposable;
     private restartedPromise?: Promise<void>;
     private currentWorkspaceFolder?: FolderContext;
     private waitingOnRestartCount: number;
@@ -99,7 +100,7 @@ export class LanguageClientManager implements vscode.Disposable {
         document: vscode.TextDocument,
         symbols: vscode.DocumentSymbol[] | null | undefined
     ) => void;
-    private subscriptions: vscode.Disposable[];
+    private subscriptions: Disposable[];
     private singleServerSupport: boolean;
     // used by single server support to keep a record of the project folders
     // that are not at the root of their workspace

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -15,6 +15,7 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "../FolderContext";
 import { FolderOperation, WorkspaceContext } from "../WorkspaceContext";
+import { Disposable } from "../utilities/Disposable";
 import { isExcluded } from "../utilities/filesystem";
 import { Version } from "../utilities/version";
 import { LanguageClientFactory } from "./LanguageClientFactory";
@@ -27,8 +28,8 @@ import { LanguageClientManager } from "./LanguageClientManager";
  * folders share the same toolchain version then they will share the same LanguageClient.
  * This ensures that a folder always uses the LanguageClient bundled with its desired toolchain.
  */
-export class LanguageClientToolchainCoordinator implements vscode.Disposable {
-    private subscriptions: vscode.Disposable[] = [];
+export class LanguageClientToolchainCoordinator implements Disposable {
+    private subscriptions: Disposable[] = [];
     private clients: Map<string, LanguageClientManager> = new Map();
 
     public constructor(

--- a/src/sourcekit-lsp/didChangeActiveDocument.ts
+++ b/src/sourcekit-lsp/didChangeActiveDocument.ts
@@ -14,6 +14,7 @@
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 
+import { Disposable } from "../utilities/Disposable";
 import { checkExperimentalCapability } from "./LanguageClientManager";
 import { DidChangeActiveDocumentNotification } from "./extensions/DidChangeActiveDocumentRequest";
 
@@ -43,7 +44,7 @@ export class LSPActiveDocumentManager {
         await next(document);
     }
 
-    public activateDidChangeActiveDocument(client: langclient.LanguageClient): vscode.Disposable {
+    public activateDidChangeActiveDocument(client: langclient.LanguageClient): Disposable {
         // Fire an inital notification on startup if there is an open document.
         this.sendNotification(client, vscode.window.activeTextEditor?.document);
 

--- a/src/sourcekit-lsp/getReferenceDocument.ts
+++ b/src/sourcekit-lsp/getReferenceDocument.ts
@@ -14,9 +14,10 @@
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 
+import { Disposable } from "../utilities/Disposable";
 import { GetReferenceDocumentParams, GetReferenceDocumentRequest } from "./extensions";
 
-export function activateGetReferenceDocument(client: langclient.LanguageClient): vscode.Disposable {
+export function activateGetReferenceDocument(client: langclient.LanguageClient): Disposable {
     const getReferenceDocument = vscode.workspace.registerTextDocumentContentProvider(
         "sourcekit-lsp",
         {

--- a/src/sourcekit-lsp/peekDocuments.ts
+++ b/src/sourcekit-lsp/peekDocuments.ts
@@ -14,6 +14,7 @@
 import * as vscode from "vscode";
 import * as langclient from "vscode-languageclient/node";
 
+import { Disposable } from "../utilities/Disposable";
 import { PeekDocumentsParams, PeekDocumentsRequest } from "./extensions";
 
 /**
@@ -77,7 +78,7 @@ async function openPeekedEditorIn(
     );
 }
 
-export function activatePeekDocuments(client: langclient.LanguageClient): vscode.Disposable {
+export function activatePeekDocuments(client: langclient.LanguageClient): Disposable {
     const peekDocuments = client.onRequest(
         PeekDocumentsRequest.method,
         async (params: PeekDocumentsParams) => {

--- a/src/tasks/SwiftExecution.ts
+++ b/src/tasks/SwiftExecution.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { Disposable } from "../utilities/Disposable";
 import { ReadOnlySwiftProcess, SwiftProcess, SwiftPtyProcess } from "./SwiftProcess";
 import { SwiftPseudoterminal } from "./SwiftPseudoterminal";
 
@@ -26,12 +27,12 @@ interface SwiftExecutionOptions extends vscode.ProcessExecutionOptions {
  * control over how the task and `swift` process is executed and allows
  * us to capture and process the output of the `swift` process
  */
-export class SwiftExecution extends vscode.CustomExecution implements vscode.Disposable {
+export class SwiftExecution extends vscode.CustomExecution implements Disposable {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
         number | void
     >();
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
 
     constructor(
         public readonly command: string,

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -15,11 +15,12 @@ import * as child_process from "child_process";
 import type * as nodePty from "node-pty";
 import * as vscode from "vscode";
 
+import { Disposable } from "../utilities/Disposable";
 import { requireNativeModule } from "../utilities/native";
 
 const { spawn } = requireNativeModule<typeof nodePty>("node-pty");
 
-export interface SwiftProcess extends vscode.Disposable {
+export interface SwiftProcess extends Disposable {
     /**
      * Resolved path to the `swift` executable
      */
@@ -73,7 +74,7 @@ export interface SwiftProcess extends vscode.Disposable {
     setDimensions(dimensions: vscode.TerminalDimensions): void;
 }
 
-class CloseHandler implements vscode.Disposable {
+class CloseHandler implements Disposable {
     private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
         number | void
     >();
@@ -114,7 +115,7 @@ export class SwiftPtyProcess implements SwiftProcess {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly errorEmitter: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
     private readonly closeHandler: CloseHandler = new CloseHandler();
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
 
     private spawnedProcess?: nodePty.IPty;
 
@@ -218,7 +219,7 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly errorEmitter: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
     private readonly closeHandler: CloseHandler = new CloseHandler();
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
 
     private spawnedProcess: child_process.ChildProcessWithoutNullStreams | undefined;
 

--- a/src/tasks/SwiftPseudoterminal.ts
+++ b/src/tasks/SwiftPseudoterminal.ts
@@ -13,13 +13,14 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { Disposable } from "../utilities/Disposable";
 import { SwiftProcess } from "./SwiftProcess";
 
 /**
  * Implements {@link vscode.Pseudoterminal} to spawn a {@link SwiftProcess} for tasks
  * that provide a custom {@link vscode.CustomExecution}
  */
-export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Disposable {
+export class SwiftPseudoterminal implements vscode.Pseudoterminal, Disposable {
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly closeEmitter: vscode.EventEmitter<number | void> = new vscode.EventEmitter<
         number | void
@@ -31,7 +32,7 @@ export class SwiftPseudoterminal implements vscode.Pseudoterminal, vscode.Dispos
         private options: vscode.TaskPresentationOptions
     ) {}
 
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
 
     open(initialDimensions: vscode.TerminalDimensions | undefined): void {
         this.swiftProcess = this.createSwiftProcess();

--- a/src/tasks/TaskManager.ts
+++ b/src/tasks/TaskManager.ts
@@ -14,9 +14,10 @@
 import * as vscode from "vscode";
 
 import { WorkspaceContext } from "../WorkspaceContext";
+import { Disposable } from "../utilities/Disposable";
 
 /** Manage task execution and completion handlers */
-export class TaskManager implements vscode.Disposable {
+export class TaskManager implements Disposable {
     constructor(private workspaceContext: WorkspaceContext) {
         this.onDidEndTaskProcessDisposible = vscode.tasks.onDidEndTaskProcess(event => {
             this.taskEndObservers.forEach(observer => observer(event));
@@ -51,7 +52,7 @@ export class TaskManager implements vscode.Disposable {
      * @param observer function called when task completes
      * @returns disposable handle. Once you have finished with the observer call dispose on this
      */
-    onDidEndTaskProcess(observer: TaskEndObserver): vscode.Disposable {
+    onDidEndTaskProcess(observer: TaskEndObserver): Disposable {
         this.taskEndObservers.add(observer);
         return {
             dispose: () => {
@@ -154,9 +155,9 @@ export class TaskManager implements vscode.Disposable {
     }
 
     private taskEndObservers: Set<TaskEndObserver> = new Set();
-    private onDidEndTaskProcessDisposible: vscode.Disposable;
-    private onDidEndTaskDisposible: vscode.Disposable;
-    private onDidStartTaskDisposible: vscode.Disposable;
+    private onDidEndTaskProcessDisposible: Disposable;
+    private onDidEndTaskDisposible: Disposable;
+    private onDidStartTaskDisposible: Disposable;
     private taskStartObserver: TaskStartObserver | undefined;
     private taskId = 0;
     private startingTaskPromise: Promise<void> | undefined;

--- a/src/tasks/TaskQueue.ts
+++ b/src/tasks/TaskQueue.ts
@@ -15,6 +15,7 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "../FolderContext";
 import { WorkspaceContext } from "../WorkspaceContext";
+import { Disposable } from "../utilities/Disposable";
 import { execSwift, poll } from "../utilities/utilities";
 
 interface SwiftOperationOptions {
@@ -163,7 +164,7 @@ class QueuedOperation {
  *
  * Queue swift task operations to be executed serially
  */
-export class TaskQueue implements vscode.Disposable {
+export class TaskQueue implements Disposable {
     queue: QueuedOperation[];
     activeOperation?: QueuedOperation;
     workspaceContext: WorkspaceContext;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -14,6 +14,7 @@
 import * as vscode from "vscode";
 
 import configuration from "./configuration";
+import { Disposable } from "./utilities/Disposable";
 
 /** The separator to use between paths in the PATH environment variable */
 const pathSeparator = () => (process.platform === "win32" ? ";" : ":");
@@ -22,8 +23,8 @@ const pathSeparator = () => (process.platform === "win32" ? ";" : ":");
  * Configures Swift environment variables for VS Code. Will automatically update
  * whenever the configuration changes.
  */
-export class SwiftEnvironmentVariablesManager implements vscode.Disposable {
-    private subscriptions: vscode.Disposable[] = [];
+export class SwiftEnvironmentVariablesManager implements Disposable {
+    private subscriptions: Disposable[] = [];
 
     constructor(private context: vscode.ExtensionContext) {
         this.update();
@@ -97,7 +98,7 @@ export class SwiftTerminalProfileProvider implements vscode.TerminalProfileProvi
      * Registers the Swift terminal profile provider with VS Code.
      * @returns A disposable that unregisters the provider when disposed.
      */
-    public static register(): vscode.Disposable {
+    public static register(): Disposable {
         return vscode.window.registerTerminalProfileProvider(
             "swift.terminalProfile",
             new SwiftTerminalProfileProvider()

--- a/src/toolchain/SelectedXcodeWatcher.ts
+++ b/src/toolchain/SelectedXcodeWatcher.ts
@@ -18,8 +18,9 @@ import configuration from "../configuration";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { showReloadExtensionNotification } from "../ui/ReloadExtension";
 import { removeToolchainPath, selectToolchain } from "../ui/ToolchainSelection";
+import { Disposable } from "../utilities/Disposable";
 
-export class SelectedXcodeWatcher implements vscode.Disposable {
+export class SelectedXcodeWatcher implements Disposable {
     private xcodePath: string | undefined;
     private disposed: boolean = false;
     private interval: NodeJS.Timeout | undefined;

--- a/src/ui/LanguageStatusItems.ts
+++ b/src/ui/LanguageStatusItems.ts
@@ -17,8 +17,9 @@ import { Command } from "vscode-languageclient";
 import { FolderOperation, WorkspaceContext } from "../WorkspaceContext";
 import { Commands } from "../commands";
 import { LanguagerClientDocumentSelectors } from "../sourcekit-lsp/LanguageClientConfiguration";
+import { Disposable } from "../utilities/Disposable";
 
-export class LanguageStatusItems implements vscode.Disposable {
+export class LanguageStatusItems implements Disposable {
     constructor(workspaceContext: WorkspaceContext) {
         // Swift language version item
         const swiftVersionItem = vscode.languages.createLanguageStatusItem(

--- a/src/ui/ProjectPanelProvider.ts
+++ b/src/ui/ProjectPanelProvider.ts
@@ -24,6 +24,7 @@ import { FolderOperation } from "../WorkspaceContext";
 import configuration from "../configuration";
 import { Playground } from "../playgrounds/PlaygroundProvider";
 import { SwiftTask, TaskPlatformSpecificConfig } from "../tasks/SwiftTaskProvider";
+import { Disposable } from "../utilities/Disposable";
 import { getPlatformConfig, resolveTaskCwd } from "../utilities/tasks";
 import { Version } from "../utilities/version";
 
@@ -544,13 +545,13 @@ export class ProjectPanelProvider implements vscode.TreeDataProvider<TreeNode> {
     private didChangeTreeDataEmitter = new vscode.EventEmitter<
         TreeNode | undefined | null | void
     >();
-    private workspaceObserver?: vscode.Disposable;
-    private disposables: vscode.Disposable[] = [];
+    private workspaceObserver?: Disposable;
+    private disposables: Disposable[] = [];
     private activeTasks: Set<string> = new Set();
     private lastComputedNodes: TreeNode[] = [];
     private buildPluginOutputWatcher?: vscode.FileSystemWatcher;
-    private buildPluginFolderWatcher?: vscode.Disposable;
-    private playgroundWatcher?: vscode.Disposable;
+    private buildPluginFolderWatcher?: Disposable;
+    private playgroundWatcher?: Disposable;
 
     onDidChangeTreeData = this.didChangeTreeDataEmitter.event;
 
@@ -939,7 +940,7 @@ export class ProjectPanelProvider implements vscode.TreeDataProvider<TreeNode> {
  * A simple task poller that checks for changes in the tasks every 5 seconds.
  * This is a workaround for the lack of an event when tasks are added or removed.
  */
-class TaskPoller implements vscode.Disposable {
+class TaskPoller implements Disposable {
     private previousTasks: SwiftTask[] = [];
     private timeout?: NodeJS.Timeout;
     private static POLL_INTERVAL = 5000;
@@ -992,7 +993,7 @@ function watchForFolder(
     folderPath: string,
     onAvailable: () => void,
     onDeleted: () => void
-): vscode.Disposable {
+): Disposable {
     const POLL_INTERVAL = 2500;
     let folderExists = existsSync(folderPath);
 

--- a/src/ui/ReadOnlyDocumentProvider.ts
+++ b/src/ui/ReadOnlyDocumentProvider.ts
@@ -14,11 +14,13 @@
 import * as fs from "fs/promises";
 import * as vscode from "vscode";
 
+import { Disposable } from "../utilities/Disposable";
+
 /**
  * Registers a {@link vscode.TextDocumentContentProvider TextDocumentContentProvider} that will display
  * a readonly version of a file
  */
-export function getReadOnlyDocumentProvider(): vscode.Disposable {
+export function getReadOnlyDocumentProvider(): Disposable {
     const provider = vscode.workspace.registerTextDocumentContentProvider("readonly", {
         provideTextDocumentContent: async uri => {
             try {

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -15,6 +15,7 @@ import * as vscode from "vscode";
 
 import configuration, { ShowBuildStatusOptions } from "../configuration";
 import { SwiftExecution } from "../tasks/SwiftExecution";
+import { Disposable } from "../utilities/Disposable";
 import { checkIfBuildComplete, lineBreakRegex } from "../utilities/tasks";
 import { StatusItem } from "./StatusItem";
 
@@ -36,8 +37,8 @@ interface SwiftProgress {
  *
  * @see {@link SwiftExecution} to see what and where the events come from
  */
-export class SwiftBuildStatus implements vscode.Disposable {
-    private onDidStartTaskDisposible: vscode.Disposable;
+export class SwiftBuildStatus implements Disposable {
+    private onDidStartTaskDisposible: Disposable;
     private lockedRegex = /Another instance of SwiftPM \(PID: \d+\) is already running/g;
     private debt = 0;
 
@@ -87,7 +88,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
         showBuildStatus: ShowBuildStatusOptions,
         update: (report: { message: string; increment?: number }) => void
     ): Promise<void> {
-        const disposables: vscode.Disposable[] = [];
+        const disposables: Disposable[] = [];
         return new Promise<void>(res => {
             const done = () => {
                 disposables.forEach(d => d.dispose());
@@ -119,7 +120,7 @@ export class SwiftBuildStatus implements vscode.Disposable {
         showBuildStatus: ShowBuildStatusOptions,
         update: (report: { message: string; increment?: number }) => void,
         done: () => void
-    ): vscode.Disposable {
+    ): Disposable {
         let started = false;
         let lastPercentage = 0;
 

--- a/src/ui/withDelayedProgress.ts
+++ b/src/ui/withDelayedProgress.ts
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { Disposable } from "../utilities/Disposable";
+
 /**
  * A wrapper around {@link vscode.Progress} that allows for delaying progress reporting.
  */
@@ -52,7 +54,7 @@ export async function withDelayedProgress<R>(
 ): Promise<R> {
     const cancellationTokenSource = new vscode.CancellationTokenSource();
     const progressWrapper = new ProgressWrapper<{ message?: string; increment?: number }>();
-    const disposables: vscode.Disposable[] = [cancellationTokenSource];
+    const disposables: Disposable[] = [cancellationTokenSource];
     const taskPromise = task(progressWrapper, cancellationTokenSource.token);
     // Trigger vscode.window.withProgress() after a delay
     const nodeTimeout = setTimeout(() => {

--- a/src/utilities/Disposable.ts
+++ b/src/utilities/Disposable.ts
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+export class Disposable {
+    static from(...disposables: Disposable[]): Disposable {
+        return {
+            dispose(): void {
+                disposables.forEach(d => d.dispose());
+            },
+        };
+    }
+
+    constructor(public dispose: () => void) {}
+}

--- a/src/utilities/cancellation.ts
+++ b/src/utilities/cancellation.ts
@@ -13,13 +13,15 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { Disposable } from "./Disposable";
+
 /**
  * An implementation of `vscode.CancellationToken` that monitors multiple child
  * tokens and emits on the `onCancellationRequested` event when any of them are cancelled.
  */
-export class CompositeCancellationToken implements vscode.CancellationToken, vscode.Disposable {
+export class CompositeCancellationToken implements vscode.CancellationToken, Disposable {
     private tokens: vscode.CancellationToken[] = [];
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
     private cancellationRequestedEmitter: vscode.EventEmitter<unknown> = new vscode.EventEmitter();
     private cancelled: boolean = false;
 
@@ -57,10 +59,10 @@ export class CompositeCancellationToken implements vscode.CancellationToken, vsc
  * child tokens for cancellation, and cancels the token sources token when any of the child tokens are cancelled.
  */
 export class CompositeCancellationTokenSource
-    implements vscode.CancellationTokenSource, vscode.Disposable
+    implements vscode.CancellationTokenSource, Disposable
 {
     private tokenSource: vscode.CancellationTokenSource;
-    private disposables: vscode.Disposable[] = [];
+    private disposables: Disposable[] = [];
 
     /**
      * Creates a new cancellation token source that is cancelled when any of the provided tokens are cancelled

--- a/src/utilities/tempFolder.ts
+++ b/src/utilities/tempFolder.ts
@@ -14,8 +14,8 @@
 import * as fs from "fs/promises";
 import { tmpdir } from "os";
 import * as path from "path";
-import { Disposable } from "vscode";
 
+import { Disposable } from "./Disposable";
 import { randomString } from "./utilities";
 
 export class TemporaryFolder {

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -19,6 +19,7 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import configuration from "../configuration";
 import { SwiftToolchain } from "../toolchain/toolchain";
+import { Disposable } from "./Disposable";
 
 /**
  * Whether or not this is a production build.
@@ -217,7 +218,7 @@ export async function execFileStreamOutput(
         }
     }
     return new Promise<void>((resolve, reject) => {
-        let cancellation: vscode.Disposable;
+        let cancellation: Disposable;
         const p = cp.execFile(executable, args, options, error => {
             if (error) {
                 reject(error);

--- a/test/MockUtils.ts
+++ b/test/MockUtils.ts
@@ -14,6 +14,8 @@
 import { SinonStub, stub } from "sinon";
 import * as vscode from "vscode";
 
+import { Disposable } from "@src/utilities/Disposable";
+
 /**
  * Waits for all promises returned by a MockedFunction to resolve. Useful when
  * the code you're testing doesn't await the function being mocked, but instead
@@ -500,9 +502,9 @@ export function mockGlobalEvent<T, K extends EventsOf<T>>(
 export class AsyncEventEmitter<T> {
     private listeners: Set<(event: T) => any> = new Set();
 
-    event: vscode.Event<T> = (listener: (event: T) => unknown): vscode.Disposable => {
+    event: vscode.Event<T> = (listener: (event: T) => unknown): Disposable => {
         this.listeners.add(listener);
-        return new vscode.Disposable(() => this.listeners.delete(listener));
+        return new Disposable(() => this.listeners.delete(listener));
     };
 
     async fire(event: T): Promise<void> {

--- a/test/integration-tests/BackgroundCompilation.test.ts
+++ b/test/integration-tests/BackgroundCompilation.test.ts
@@ -18,6 +18,7 @@ import { BackgroundCompilation } from "@src/BackgroundCompilation";
 import { FolderContext } from "@src/FolderContext";
 import { WorkspaceContext } from "@src/WorkspaceContext";
 import { createSwiftTask, getBuildAllTask } from "@src/tasks/SwiftTaskProvider";
+import { Disposable } from "@src/utilities/Disposable";
 
 import { mockGlobalObject } from "../MockUtils";
 import { testAssetUri } from "../fixtures";
@@ -42,7 +43,7 @@ tag("large").suite("BackgroundCompilation Test Suite", () => {
     }
 
     suite("build all on save", () => {
-        let subscriptions: vscode.Disposable[];
+        let subscriptions: Disposable[];
 
         activateExtensionForSuite({
             async setup(ctx) {

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -21,6 +21,7 @@ import { WorkspaceContext } from "@src/WorkspaceContext";
 import { DiagnosticStyle } from "@src/configuration";
 import { createBuildAllTask, resetBuildAllTaskCache } from "@src/tasks/SwiftTaskProvider";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
+import { Disposable } from "@src/utilities/Disposable";
 import { Version } from "@src/utilities/version";
 
 import { testAssetUri, testSwiftTask } from "../fixtures";
@@ -80,7 +81,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
     let cUri: vscode.Uri;
     let cppUri: vscode.Uri;
     let cppHeaderUri: vscode.Uri;
-    let diagnosticWaiterDisposable: vscode.Disposable | undefined;
+    let diagnosticWaiterDisposable: Disposable | undefined;
     let remainingExpectedDiagnostics: {
         [uri: string]: vscode.Diagnostic[];
     };
@@ -224,7 +225,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 expected: () => ExpectedDiagnostics,
                 callback?: () => void
             ) {
-                suite(`${style} diagnosticsStyle`, async function () {
+                suite(`${style} diagnosticsStyle`, function () {
                     let resetSettings: (() => Promise<void>) | undefined;
                     suiteTeardown(async () => {
                         if (resetSettings) {

--- a/test/integration-tests/WorkspaceContext.test.ts
+++ b/test/integration-tests/WorkspaceContext.test.ts
@@ -19,6 +19,7 @@ import { FolderContext } from "@src/FolderContext";
 import { FolderOperation, WorkspaceContext } from "@src/WorkspaceContext";
 import { SwiftExecution } from "@src/tasks/SwiftExecution";
 import { createBuildAllTask } from "@src/tasks/SwiftTaskProvider";
+import { Disposable } from "@src/utilities/Disposable";
 import { resolveScope } from "@src/utilities/tasks";
 import { Version } from "@src/utilities/version";
 
@@ -53,7 +54,7 @@ tag("medium").suite("WorkspaceContext Test Suite", () => {
         });
 
         test("Add", async () => {
-            let observer: vscode.Disposable | undefined;
+            let observer: Disposable | undefined;
             let recordedFolders: {
                 folder: FolderContext | null;
                 operation: FolderOperation;

--- a/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
+++ b/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
@@ -113,7 +113,7 @@ suite("Generate SourceKit-LSP configuration Command", function () {
         );
     });
 
-    suite("handleSchemaUpdate", async () => {
+    suite("handleSchemaUpdate", () => {
         const mockWindow = mockGlobalObject(vscode, "window");
         const mockRestartLSPServerModule = mockGlobalModule(restartLSPServerModule);
 

--- a/test/tags.ts
+++ b/test/tags.ts
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-/* eslint-disable mocha/no-exclusive-tests */
+/* eslint-disable vscode-swift/no-exclusive-tests */
 import type { AsyncFunc, Func, Suite, Test } from "mocha";
 
 /** The set of all available test sizes that can be applied to a test or suite. */
@@ -165,7 +165,6 @@ export function tag(size: TestSize): MochaFunctions {
     };
     wrappedTest.only = (titleOrFn: string | AsyncFunc | Func, fn?: AsyncFunc | Func): Test => {
         return applyTags(
-            // eslint-disable-next-line sonarjs/no-exclusive-tests
             typeof titleOrFn === "string" ? test.only(titleOrFn, fn) : test.only(titleOrFn)
         );
     };

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -206,7 +206,7 @@ suite("LanguageClientManager Suite", () => {
             ),
             onRequest: mockFn(),
             sendNotification: mockFn(s => s.resolves()),
-            onNotification: mockFn(s => s.returns(new vscode.Disposable(() => {}))),
+            onNotification: mockFn(s => s.returns({ dispose() {} })),
             onDidChangeState: mockFn(s => s.callsFake(changeStateEmitter.event)),
         });
         // `new LanguageClient()` will always return the mocked LanguageClient

--- a/test/unit-tests/terminal.test.ts
+++ b/test/unit-tests/terminal.test.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 
 import configuration from "@src/configuration";
 import { SwiftEnvironmentVariablesManager, SwiftTerminalProfileProvider } from "@src/terminal";
+import { Disposable } from "@src/utilities/Disposable";
 
 import {
     MockedObject,
@@ -51,7 +52,7 @@ suite("Terminal", () => {
         let manager: SwiftEnvironmentVariablesManager;
         let mockedExtensionContext: MockedObject<vscode.ExtensionContext>;
         let mockedEnvironmentVariableCollection: MockedObject<vscode.GlobalEnvironmentVariableCollection>;
-        let mockedDisposable: MockedObject<vscode.Disposable>;
+        let mockedDisposable: MockedObject<Disposable>;
 
         const mockedWorkspace = mockGlobalObject(vscode, "workspace");
 
@@ -72,7 +73,7 @@ suite("Terminal", () => {
                 environmentVariableCollection: instance(mockedEnvironmentVariableCollection),
             });
 
-            mockedDisposable = mockObject<vscode.Disposable>({
+            mockedDisposable = mockObject<Disposable>({
                 dispose: () => {},
             });
 
@@ -204,7 +205,7 @@ suite("Terminal", () => {
         // Mock configuration values
         const mockedWindow = mockGlobalObject(vscode, "window");
         let mockedTerminal: MockedObject<vscode.Terminal>;
-        let mockedDisposable: MockedObject<vscode.Disposable>;
+        let mockedDisposable: MockedObject<Disposable>;
 
         setup(() => {
             // Create mocks
@@ -212,7 +213,7 @@ suite("Terminal", () => {
                 sendText: () => {},
             });
 
-            mockedDisposable = mockObject<vscode.Disposable>({
+            mockedDisposable = mockObject<Disposable>({
                 dispose: () => {},
             });
 

--- a/test/utilities/tasks.ts
+++ b/test/utilities/tasks.ts
@@ -15,6 +15,7 @@ import { AssertionError } from "chai";
 import * as vscode from "vscode";
 
 import { SwiftTask } from "@src/tasks/SwiftTaskProvider";
+import { Disposable } from "@src/utilities/Disposable";
 
 import { SwiftTaskFixture } from "../fixtures";
 
@@ -128,10 +129,10 @@ export function waitForNoRunningTasks(options?: { timeout: number }): Promise<vo
  * **Note:** Use {@link withTaskWatcher} to limit the scope to the duration of a test and clean up
  * listeners upon test completion.
  */
-export class TaskWatcher implements vscode.Disposable {
+export class TaskWatcher implements Disposable {
     /** An array containing all of the tasks that have already completed. */
     public completedTasks: vscode.Task[] = [];
-    private subscriptions: vscode.Disposable[];
+    private subscriptions: Disposable[];
 
     constructor() {
         this.subscriptions = [
@@ -184,7 +185,7 @@ export async function withTaskWatcher(
  */
 export function waitForEndTaskProcess(task: vscode.Task): Promise<number | undefined> {
     return new Promise<number | undefined>(res => {
-        const disposables: vscode.Disposable[] = [];
+        const disposables: Disposable[] = [];
         disposables.push(
             vscode.tasks.onDidEndTaskProcess(e => {
                 if (task.detail !== e.execution.task.detail) {
@@ -207,7 +208,7 @@ export function waitForEndTaskProcess(task: vscode.Task): Promise<number | undef
  */
 export function waitForStartTaskProcess(task: vscode.Task): Promise<void> {
     return new Promise<void>(res => {
-        const disposables: vscode.Disposable[] = [];
+        const disposables: Disposable[] = [];
         disposables.push(
             vscode.tasks.onDidStartTaskProcess(e => {
                 if (task.detail !== e.execution.task.detail) {


### PR DESCRIPTION
## Description
Adds a custom ESLint plugin to the repo that has two rules:
- `vscode-swift/use-custom-disposable`: Forces the use of our own `Disposable` type that lives in `src/utitlities/Disposable.ts`. VS Code's built-in `Disposable` type returns `any` which makes it impossible to distinguish between asynchronous and synchronous disposable types.
- `vscode-swift/no-exclusive-tests`: A type aware rule that prohibits the use of `.only()` in tests. Replaces `mocha/no-exclusive-tests` and `sonarjs/no-exclusive-tests` which do not work well with our `tag()` infrastructure since they aren't type aware.


## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
