### PR TITLE
Add per-target debug session support for swiftbuild build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /out
 /dist
 /coverage
+!src/coverage
 /test-results
 /userdocs/userdocs.docc/.docc-build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix false positive workspace detection for non-Swift projects with `build/` or `out/` directories ([#2156](https://github.com/swiftlang/vscode-swift/pull/2156))
 - Fix build status notification to show a determinate progress bar ([#2188](https://github.com/swiftlang/vscode-swift/pull/2188))
+- Fix debugging when running tests with the swiftbuild build system ([#2191](https://github.com/swiftlang/vscode-swift/pull/2191))
 
 ## 2.16.3 - 2026-04-02
 

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -18,6 +18,7 @@ import * as stream from "stream";
 import * as vscode from "vscode";
 
 import { FolderContext } from "../FolderContext";
+import { TargetType } from "../SwiftPackage";
 import { WorkspaceContext } from "../WorkspaceContext";
 import configuration from "../configuration";
 import {
@@ -25,6 +26,8 @@ import {
     SwiftTestingBuildAguments,
     SwiftTestingConfigurationSetup,
     TestingConfigurationFactory,
+    effectiveBuildSystem,
+    groupTestsByTarget,
 } from "../debugger/buildConfig";
 import { LoggingDebugAdapterTracker } from "../debugger/logTracker";
 import { createSwiftTask } from "../tasks/SwiftTaskProvider";
@@ -701,13 +704,19 @@ export class TestRunner {
         const fifoPipePath = this.generateFifoPipePath(testRunTime);
 
         await TemporaryFolder.withNamedTemporaryFiles([fifoPipePath], async () => {
+            const allBuildArgs = [
+                ...configuration.buildArguments,
+                ...configuration.folder(this.folderContext.workspaceFolder).additionalTestArguments,
+            ];
+            const buildSystem = effectiveBuildSystem(this.folderContext.swiftVersion, allBuildArgs);
+
             if (this.testArgs.hasSwiftTestingTests) {
                 // macOS/Linux require us to create the named pipe before we use it.
                 // Windows just lets us communicate by specifying a pipe path without any ceremony.
                 if (process.platform !== "win32") {
                     await execFile("mkfifo", [fifoPipePath], undefined, this.folderContext);
                 }
-                // Create the swift-testing configuration JSON file, peparing any
+                // Create the swift-testing configuration JSON file, preparing any
                 // directories the configuration may require.
                 const attachmentFolder = await SwiftTestingConfigurationSetup.setupAttachmentFolder(
                     this.folderContext,
@@ -718,63 +727,20 @@ export class TestRunner {
                     attachmentFolder
                 );
 
-                const swiftTestBuildConfig = await TestingConfigurationFactory.swiftTestingConfig(
-                    this.folderContext,
-                    swiftTestingArgs,
-                    this.testKind,
-                    this.testArgs.swiftTestArgs,
-                    true
-                );
-
-                if (swiftTestBuildConfig !== null) {
-                    swiftTestBuildConfig.testType = TestLibrary.swiftTesting;
-                    swiftTestBuildConfig.preLaunchTask = null;
-
-                    // If we're testing in both frameworks we're going to start more than one debugging
-                    // session. If both build configurations have the same name LLDB will replace the
-                    // output of the first one in the Debug Console with the output of the second one.
-                    // If they each have a unique name the Debug Console gets a nice dropdown the user
-                    // can switch between to see the output for both sessions.
-                    swiftTestBuildConfig.name = `Swift Testing: ${swiftTestBuildConfig.name}`;
-
-                    // output test build configuration
-                    if (configuration.diagnostics) {
-                        const configJSON = JSON.stringify(swiftTestBuildConfig);
-                        this.workspaceContext.logger.debug(
-                            `swift-testing Debug Config: ${configJSON}`,
-                            this.folderContext.name
-                        );
-                    }
-
-                    buildConfigs.push(swiftTestBuildConfig);
-                }
+                const configs =
+                    buildSystem === "swiftbuild"
+                        ? await this.swiftbuildSwiftTestingConfigs(swiftTestingArgs)
+                        : await this.nativeSwiftTestingConfigs(swiftTestingArgs);
+                buildConfigs.push(...configs);
             }
 
             // create launch config for testing
             if (this.testArgs.hasXCTests) {
-                const xcTestBuildConfig = await TestingConfigurationFactory.xcTestConfig(
-                    this.folderContext,
-                    this.testKind,
-                    this.testArgs.xcTestArgs,
-                    true
-                );
-
-                if (xcTestBuildConfig !== null) {
-                    xcTestBuildConfig.testType = TestLibrary.xctest;
-                    xcTestBuildConfig.preLaunchTask = null;
-                    xcTestBuildConfig.name = `XCTest: ${xcTestBuildConfig.name}`;
-
-                    // output test build configuration
-                    if (configuration.diagnostics) {
-                        const configJSON = JSON.stringify(xcTestBuildConfig);
-                        this.workspaceContext.logger.debug(
-                            `XCTest Debug Config: ${configJSON}`,
-                            this.folderContext.name
-                        );
-                    }
-
-                    buildConfigs.push(xcTestBuildConfig);
-                }
+                const configs =
+                    buildSystem === "swiftbuild"
+                        ? await this.swiftbuildXCTestConfigs()
+                        : await this.nativeXCTestConfigs();
+                buildConfigs.push(...configs);
             }
 
             const validBuildConfigs = buildConfigs.filter(
@@ -797,6 +763,157 @@ export class TestRunner {
         });
 
         return this.testRun.runState;
+    }
+
+    // Creates one swift-testing debug configuration per test target for the swiftbuild build system.
+    private async swiftbuildSwiftTestingConfigs(
+        swiftTestingArgs: SwiftTestingBuildAguments
+    ): Promise<vscode.DebugConfiguration[]> {
+        const targets = await this.targetNamesForBuildSystem(this.testArgs.swiftTestArgs);
+        const pkgName = await this.folderContext.swiftPackage.name;
+        const configs: vscode.DebugConfiguration[] = [];
+
+        for (const [targetName, testSubset] of targets) {
+            const config = await TestingConfigurationFactory.swiftTestingConfig(
+                this.folderContext,
+                swiftTestingArgs,
+                this.testKind,
+                testSubset,
+                true,
+                targetName
+            );
+
+            if (config !== null) {
+                config.testType = TestLibrary.swiftTesting;
+                config.preLaunchTask = null;
+                config.name = `Swift Testing (${targetName}): Test ${pkgName}`;
+
+                if (configuration.diagnostics) {
+                    const configJSON = JSON.stringify(config);
+                    this.workspaceContext.logger.debug(
+                        `swift-testing Debug Config: ${configJSON}`,
+                        this.folderContext.name
+                    );
+                }
+
+                configs.push(config);
+            }
+        }
+
+        return configs;
+    }
+
+    // Creates one XCTest debug configuration per test target for the swiftbuild build system.
+    private async swiftbuildXCTestConfigs(): Promise<vscode.DebugConfiguration[]> {
+        const targets = await this.targetNamesForBuildSystem(this.testArgs.xcTestArgs);
+        const pkgName = await this.folderContext.swiftPackage.name;
+        const configs: vscode.DebugConfiguration[] = [];
+
+        for (const [targetName, testSubset] of targets) {
+            const config = await TestingConfigurationFactory.xcTestConfig(
+                this.folderContext,
+                this.testKind,
+                testSubset,
+                true,
+                targetName
+            );
+
+            if (config !== null) {
+                config.testType = TestLibrary.xctest;
+                config.preLaunchTask = null;
+                config.name = `XCTest (${targetName}): Test ${pkgName}`;
+
+                if (configuration.diagnostics) {
+                    const configJSON = JSON.stringify(config);
+                    this.workspaceContext.logger.debug(
+                        `XCTest Debug Config: ${configJSON}`,
+                        this.folderContext.name
+                    );
+                }
+
+                configs.push(config);
+            }
+        }
+
+        return configs;
+    }
+
+    // Creates a single swift-testing debug configuration for the native build system.
+    private async nativeSwiftTestingConfigs(
+        swiftTestingArgs: SwiftTestingBuildAguments
+    ): Promise<vscode.DebugConfiguration[]> {
+        const swiftTestBuildConfig = await TestingConfigurationFactory.swiftTestingConfig(
+            this.folderContext,
+            swiftTestingArgs,
+            this.testKind,
+            this.testArgs.swiftTestArgs,
+            true
+        );
+
+        if (swiftTestBuildConfig === null) {
+            return [];
+        }
+
+        swiftTestBuildConfig.testType = TestLibrary.swiftTesting;
+        swiftTestBuildConfig.preLaunchTask = null;
+
+        // If we're testing in both frameworks we're going to start more than one debugging
+        // session. If both build configurations have the same name LLDB will replace the
+        // output of the first one in the Debug Console with the output of the second one.
+        // If they each have a unique name the Debug Console gets a nice dropdown the user
+        // can switch between to see the output for both sessions.
+        swiftTestBuildConfig.name = `Swift Testing: ${swiftTestBuildConfig.name}`;
+
+        // output test build configuration
+        if (configuration.diagnostics) {
+            const configJSON = JSON.stringify(swiftTestBuildConfig);
+            this.workspaceContext.logger.debug(
+                `swift-testing Debug Config: ${configJSON}`,
+                this.folderContext.name
+            );
+        }
+
+        return [swiftTestBuildConfig];
+    }
+
+    // Creates a single XCTest debug configuration for the native build system.
+    private async nativeXCTestConfigs(): Promise<vscode.DebugConfiguration[]> {
+        const xcTestBuildConfig = await TestingConfigurationFactory.xcTestConfig(
+            this.folderContext,
+            this.testKind,
+            this.testArgs.xcTestArgs,
+            true
+        );
+
+        if (xcTestBuildConfig === null) {
+            return [];
+        }
+
+        xcTestBuildConfig.testType = TestLibrary.xctest;
+        xcTestBuildConfig.preLaunchTask = null;
+        xcTestBuildConfig.name = `XCTest: ${xcTestBuildConfig.name}`;
+
+        // output test build configuration
+        if (configuration.diagnostics) {
+            const configJSON = JSON.stringify(xcTestBuildConfig);
+            this.workspaceContext.logger.debug(
+                `XCTest Debug Config: ${configJSON}`,
+                this.folderContext.name
+            );
+        }
+
+        return [xcTestBuildConfig];
+    }
+
+    // Groups test args by target, or enumerates all test targets for the "run all" case.
+    private async targetNamesForBuildSystem(
+        testArgs: readonly string[]
+    ): Promise<ReadonlyMap<string, string[]>> {
+        if (testArgs.length === 0) {
+            const testTargets = await this.folderContext.swiftPackage.getTargets(TargetType.test);
+            return new Map(testTargets.map(t => [t.name, []]));
+        }
+        return groupTestsByTarget(testArgs) as Map<string, string[]>;
     }
 
     private startDebugSession(

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -788,13 +788,11 @@ export class TestRunner {
                 config.preLaunchTask = null;
                 config.name = `Swift Testing (${targetName}): Test ${pkgName}`;
 
-                if (configuration.diagnostics) {
-                    const configJSON = JSON.stringify(config);
-                    this.workspaceContext.logger.debug(
-                        `swift-testing Debug Config: ${configJSON}`,
-                        this.folderContext.name
-                    );
-                }
+                const configJSON = JSON.stringify(config);
+                this.workspaceContext.logger.debug(
+                    `swift-testing Debug Config: ${configJSON}`,
+                    this.folderContext.name
+                );
 
                 configs.push(config);
             }
@@ -823,13 +821,11 @@ export class TestRunner {
                 config.preLaunchTask = null;
                 config.name = `XCTest (${targetName}): Test ${pkgName}`;
 
-                if (configuration.diagnostics) {
-                    const configJSON = JSON.stringify(config);
-                    this.workspaceContext.logger.debug(
-                        `XCTest Debug Config: ${configJSON}`,
-                        this.folderContext.name
-                    );
-                }
+                const configJSON = JSON.stringify(config);
+                this.workspaceContext.logger.debug(
+                    `XCTest Debug Config: ${configJSON}`,
+                    this.folderContext.name
+                );
 
                 configs.push(config);
             }
@@ -865,13 +861,11 @@ export class TestRunner {
         swiftTestBuildConfig.name = `Swift Testing: ${swiftTestBuildConfig.name}`;
 
         // output test build configuration
-        if (configuration.diagnostics) {
-            const configJSON = JSON.stringify(swiftTestBuildConfig);
-            this.workspaceContext.logger.debug(
-                `swift-testing Debug Config: ${configJSON}`,
-                this.folderContext.name
-            );
-        }
+        const configJSON = JSON.stringify(swiftTestBuildConfig);
+        this.workspaceContext.logger.debug(
+            `swift-testing Debug Config: ${configJSON}`,
+            this.folderContext.name
+        );
 
         return [swiftTestBuildConfig];
     }
@@ -894,13 +888,11 @@ export class TestRunner {
         xcTestBuildConfig.name = `XCTest: ${xcTestBuildConfig.name}`;
 
         // output test build configuration
-        if (configuration.diagnostics) {
-            const configJSON = JSON.stringify(xcTestBuildConfig);
-            this.workspaceContext.logger.debug(
-                `XCTest Debug Config: ${configJSON}`,
-                this.folderContext.name
-            );
-        }
+        const configJSON = JSON.stringify(xcTestBuildConfig);
+        this.workspaceContext.logger.debug(
+            `XCTest Debug Config: ${configJSON}`,
+            this.folderContext.name
+        );
 
         return [xcTestBuildConfig];
     }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -901,11 +901,12 @@ export class TestRunner {
     private async targetNamesForBuildSystem(
         testArgs: readonly string[]
     ): Promise<ReadonlyMap<string, string[]>> {
+        const testTargets = await this.folderContext.swiftPackage.getTargets(TargetType.test);
         if (testArgs.length === 0) {
-            const testTargets = await this.folderContext.swiftPackage.getTargets(TargetType.test);
             return new Map(testTargets.map(t => [t.name, []]));
         }
-        return groupTestsByTarget(testArgs) as Map<string, string[]>;
+        const c99ToName = new Map(testTargets.map(t => [t.c99name, t.name]));
+        return groupTestsByTarget(testArgs, c99ToName) as Map<string, string[]>;
     }
 
     private startDebugSession(

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -23,7 +23,7 @@ import { TargetType } from "../SwiftPackage";
 import { TestKind } from "../TestExplorer/TestKind";
 import { TestLibrary } from "../TestExplorer/TestRunner";
 import configuration from "../configuration";
-import { TestingConfigurationFactory } from "../debugger/buildConfig";
+import { TestingConfigurationFactory, effectiveBuildSystem } from "../debugger/buildConfig";
 import { BuildFlags } from "../toolchain/BuildFlags";
 import { DisposableFileCollection, TemporaryFolder } from "../utilities/tempFolder";
 import { execFileStreamOutput } from "../utilities/utilities";
@@ -140,28 +140,16 @@ export class TestCoverage {
      * Exports a `.profdata` file using `llvm-cov export`, returning the result as a `Buffer`.
      */
     private async exportProfdata(types: TestLibrary[], mergedProfileFile: string): Promise<Buffer> {
-        const coveredBinaries = new Set<string>();
-        if (types.includes(TestLibrary.xctest)) {
-            let xcTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
-                this.folderContext,
-                TestKind.coverage,
-                TestLibrary.xctest
-            );
-            if (process.platform === "darwin") {
-                const packageName = await this.folderContext.swiftPackage.name;
-                xcTestBinary += `/Contents/MacOS/${packageName}PackageTests`;
-            }
-            coveredBinaries.add(xcTestBinary);
-        }
+        const allBuildArgs = [
+            ...configuration.buildArguments,
+            ...configuration.folder(this.folderContext.workspaceFolder).additionalTestArguments,
+        ];
+        const buildSystem = effectiveBuildSystem(this.folderContext.swiftVersion, allBuildArgs);
 
-        if (types.includes(TestLibrary.swiftTesting)) {
-            const swiftTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
-                this.folderContext,
-                TestKind.coverage,
-                TestLibrary.swiftTesting
-            );
-            coveredBinaries.add(swiftTestBinary);
-        }
+        const coveredBinaries =
+            buildSystem === "swiftbuild"
+                ? await this.swiftbuildCoveredBinaries(types)
+                : await this.nativeCoveredBinaries(types);
 
         let buffer = Buffer.alloc(0);
         const writableStream = new Writable({
@@ -192,6 +180,67 @@ export class TestCoverage {
         );
 
         return buffer;
+    }
+
+    // Collects coverage binary paths for the native build system (one binary per package).
+    private async nativeCoveredBinaries(types: TestLibrary[]): Promise<string[]> {
+        const coveredBinaries = new Set<string>();
+        if (types.includes(TestLibrary.xctest)) {
+            let xcTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
+                this.folderContext,
+                TestKind.coverage,
+                TestLibrary.xctest
+            );
+            if (process.platform === "darwin") {
+                const packageName = await this.folderContext.swiftPackage.name;
+                xcTestBinary += `/Contents/MacOS/${packageName}PackageTests`;
+            }
+            coveredBinaries.add(xcTestBinary);
+        }
+
+        if (types.includes(TestLibrary.swiftTesting)) {
+            const swiftTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
+                this.folderContext,
+                TestKind.coverage,
+                TestLibrary.swiftTesting
+            );
+            coveredBinaries.add(swiftTestBinary);
+        }
+
+        return [...coveredBinaries];
+    }
+
+    // Collects coverage binary paths for the swiftbuild build system (one binary per test target).
+    private async swiftbuildCoveredBinaries(types: TestLibrary[]): Promise<string[]> {
+        const testTargets = await this.folderContext.swiftPackage.getTargets(TargetType.test);
+        const coveredBinaries = new Set<string>();
+
+        for (const target of testTargets) {
+            if (types.includes(TestLibrary.xctest)) {
+                let xcTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
+                    this.folderContext,
+                    TestKind.coverage,
+                    TestLibrary.xctest,
+                    target.name
+                );
+                if (process.platform === "darwin") {
+                    xcTestBinary += `/Contents/MacOS/${target.name}`;
+                }
+                coveredBinaries.add(xcTestBinary);
+            }
+
+            if (types.includes(TestLibrary.swiftTesting)) {
+                const swiftTestBinary = await TestingConfigurationFactory.testExecutableOutputPath(
+                    this.folderContext,
+                    TestKind.coverage,
+                    TestLibrary.swiftTesting,
+                    target.name
+                );
+                coveredBinaries.add(swiftTestBinary);
+            }
+        }
+
+        return [...coveredBinaries];
     }
 
     /**

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -53,11 +53,13 @@ export function effectiveBuildSystem(
 }
 
 export function groupTestsByTarget(
-    testArgs: readonly string[]
+    testArgs: readonly string[],
+    c99ToName?: ReadonlyMap<string, string>
 ): ReadonlyMap<string, readonly string[]> {
     return testArgs.reduce((map, arg) => {
         const dotIndex = arg.indexOf(".");
-        const target = dotIndex === -1 ? arg : arg.substring(0, dotIndex);
+        const c99Target = dotIndex === -1 ? arg : arg.substring(0, dotIndex);
+        const target = c99ToName?.get(c99Target) ?? c99Target;
         const existing = map.get(target) ?? [];
         return new Map([...map, [target, [...existing, arg]]]);
     }, new Map<string, readonly string[]>());

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -277,7 +277,8 @@ export class TestingConfigurationFactory {
     public static testExecutableOutputPath(
         ctx: FolderContext,
         testKind: TestKind,
-        testLibrary: TestLibrary
+        testLibrary: TestLibrary,
+        targetName?: string
     ): Promise<string> {
         return new TestingConfigurationFactory(
             ctx,
@@ -285,7 +286,8 @@ export class TestingConfigurationFactory {
             testLibrary,
             [],
             undefined,
-            true
+            true,
+            targetName
         ).testExecutableOutputPath();
     }
 

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -31,18 +31,25 @@ import { updateLaunchConfigForCI } from "./lldb";
 
 type BuildSystem = "native" | "swiftbuild";
 
+const validBuildSystems: readonly BuildSystem[] = ["native", "swiftbuild"];
+
+const isValidBuildSystem = (value: string): value is BuildSystem =>
+    validBuildSystems.includes(value as BuildSystem);
+
+/**
+ * Determine which build system to use based on explicit `--build-system` arguments
+ * and the Swift toolchain version. If the build arguments specify a build system, use
+ * that, otherwise Swift >= 6.4.0 defaults to `"swiftbuild"` and earlier
+ * versions default to `"native"`.
+ */
 export function effectiveBuildSystem(
     swiftVersion: Version,
     buildArgs: readonly string[]
 ): BuildSystem {
-    const buildSystemIndex = buildArgs.lastIndexOf("--build-system");
-    if (buildSystemIndex !== -1 && buildSystemIndex + 1 < buildArgs.length) {
-        const explicit = buildArgs[buildSystemIndex + 1];
-        if (explicit === "native" || explicit === "swiftbuild") {
-            return explicit;
-        }
-    }
-    return swiftVersion.isGreaterThanOrEqual(new Version(6, 4, 0)) ? "swiftbuild" : "native";
+    return (
+        BuildFlags.lastFlagValue(buildArgs, "--build-system", isValidBuildSystem) ??
+        (swiftVersion.isGreaterThanOrEqual(new Version(6, 4, 0)) ? "swiftbuild" : "native")
+    );
 }
 
 export function groupTestsByTarget(

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -29,6 +29,33 @@ import { Version } from "../utilities/version";
 import { SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 import { updateLaunchConfigForCI } from "./lldb";
 
+type BuildSystem = "native" | "swiftbuild";
+
+export function effectiveBuildSystem(
+    swiftVersion: Version,
+    buildArgs: readonly string[]
+): BuildSystem {
+    const buildSystemIndex = buildArgs.lastIndexOf("--build-system");
+    if (buildSystemIndex !== -1 && buildSystemIndex + 1 < buildArgs.length) {
+        const explicit = buildArgs[buildSystemIndex + 1];
+        if (explicit === "native" || explicit === "swiftbuild") {
+            return explicit;
+        }
+    }
+    return swiftVersion.isGreaterThanOrEqual(new Version(6, 4, 0)) ? "swiftbuild" : "native";
+}
+
+export function groupTestsByTarget(
+    testArgs: readonly string[]
+): ReadonlyMap<string, readonly string[]> {
+    return testArgs.reduce((map, arg) => {
+        const dotIndex = arg.indexOf(".");
+        const target = dotIndex === -1 ? arg : arg.substring(0, dotIndex);
+        const existing = map.get(target) ?? [];
+        return new Map([...map, [target, [...existing, arg]]]);
+    }, new Map<string, readonly string[]>());
+}
+
 export class BuildConfigurationFactory {
     public static buildAll(
         ctx: FolderContext,
@@ -215,7 +242,8 @@ export class TestingConfigurationFactory {
         buildArguments: SwiftTestingBuildAguments,
         testKind: TestKind,
         testList: string[],
-        expandEnvVariables = false
+        expandEnvVariables = false,
+        targetName?: string
     ): Promise<vscode.DebugConfiguration | null> {
         return new TestingConfigurationFactory(
             ctx,
@@ -223,7 +251,8 @@ export class TestingConfigurationFactory {
             TestLibrary.swiftTesting,
             testList,
             buildArguments,
-            expandEnvVariables
+            expandEnvVariables,
+            targetName
         ).build();
     }
 
@@ -231,7 +260,8 @@ export class TestingConfigurationFactory {
         ctx: FolderContext,
         testKind: TestKind,
         testList: string[],
-        expandEnvVariables = false
+        expandEnvVariables = false,
+        targetName?: string
     ): Promise<vscode.DebugConfiguration | null> {
         return new TestingConfigurationFactory(
             ctx,
@@ -239,7 +269,8 @@ export class TestingConfigurationFactory {
             TestLibrary.xctest,
             testList,
             undefined,
-            expandEnvVariables
+            expandEnvVariables,
+            targetName
         ).build();
     }
 
@@ -264,7 +295,8 @@ export class TestingConfigurationFactory {
         private testLibrary: TestLibrary,
         private testList: string[],
         private swiftTestingArguments?: SwiftTestingBuildAguments,
-        private expandEnvVariables = false
+        private expandEnvVariables = false,
+        private targetName?: string
     ) {}
 
     /**
@@ -592,8 +624,11 @@ export class TestingConfigurationFactory {
     }
 
     private async xcTestOutputPath(): Promise<string> {
-        const packageName = await this.ctx.swiftPackage.name;
         const binPath = await this.getBuildBinaryPath();
+        if (this.targetName) {
+            return path.join(binPath, `${this.targetName}.xctest`);
+        }
+        const packageName = await this.ctx.swiftPackage.name;
         return path.join(binPath, `${packageName}PackageTests.xctest`);
     }
 
@@ -602,13 +637,8 @@ export class TestingConfigurationFactory {
         // is named the same as the old style .xctest binary. The swiftpm-testing-helper
         // requires the full path to the binary.
         if (process.platform === "darwin") {
-            const packageName = await this.ctx.swiftPackage.name;
-            return path.join(
-                await this.xcTestOutputPath(),
-                "Contents",
-                "MacOS",
-                `${packageName}PackageTests`
-            );
+            const binaryName = this.targetName ?? `${await this.ctx.swiftPackage.name}PackageTests`;
+            return path.join(await this.xcTestOutputPath(), "Contents", "MacOS", binaryName);
         } else {
             return this.xcTestOutputPath();
         }

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -625,13 +625,29 @@ export class TestingConfigurationFactory {
         }
     }
 
+    private get buildSystem(): "native" | "swiftbuild" {
+        const allBuildArgs = [
+            ...configuration.buildArguments,
+            ...configuration.folder(this.ctx.workspaceFolder).additionalTestArguments,
+        ];
+        return effectiveBuildSystem(this.ctx.swiftVersion, allBuildArgs);
+    }
+
+    private testProductBinaryName(baseName: string): string {
+        if (this.buildSystem === "native" || process.platform === "darwin") {
+            return `${baseName}.xctest`;
+        }
+        const suffix = process.platform === "win32" ? ".exe" : "";
+        return `${baseName}-test-runner${suffix}`;
+    }
+
     private async xcTestOutputPath(): Promise<string> {
         const binPath = await this.getBuildBinaryPath();
         if (this.targetName) {
-            return path.join(binPath, `${this.targetName}.xctest`);
+            return path.join(binPath, this.testProductBinaryName(this.targetName));
         }
-        const packageName = await this.ctx.swiftPackage.name;
-        return path.join(binPath, `${packageName}PackageTests.xctest`);
+        const name = await this.ctx.swiftPackage.name;
+        return path.join(binPath, this.testProductBinaryName(`${name}PackageTests`));
     }
 
     private async unifiedTestingOutputPath(): Promise<string> {

--- a/src/toolchain/BuildFlags.ts
+++ b/src/toolchain/BuildFlags.ts
@@ -392,4 +392,38 @@ export class BuildFlags {
     private static isCombinedArgMatch(arg: string, filter: ArgumentFilter[]): boolean {
         return filter.some(item => item.include === 1 && arg.startsWith(item.argument + "="));
     }
+
+    /**
+     * Find the value of the last occurrence of a flag in an argument list,
+     * supporting both `--flag value` and `--flag=value` formats.
+     *
+     * @param args The argument list to search
+     * @param flag The flag name to look for (e.g. `"--build-system"`)
+     * @param validate Optional type guard to restrict which values are accepted.
+     *                 When provided, occurrences whose value fails validation are
+     *                 skipped and the search continues to the next match.
+     * @returns The value of the last valid occurrence, or `undefined` if none match
+     */
+    static lastFlagValue<T extends string = string>(
+        args: readonly string[],
+        flag: string,
+        validate?: (value: string) => value is T
+    ): T | undefined {
+        for (let i = args.length - 1; i >= 0; i--) {
+            const arg = args[i];
+            const prefix = `${flag}=`;
+            if (arg.startsWith(prefix)) {
+                const value = arg.substring(prefix.length);
+                if (!validate || validate(value)) {
+                    return value as T;
+                }
+            } else if (arg === flag && i + 1 < args.length) {
+                const value = args[i + 1];
+                if (!validate || validate(value)) {
+                    return value as T;
+                }
+            }
+        }
+        return undefined;
+    }
 }

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -130,16 +130,11 @@ tag("large").suite("Test Explorer Suite", function () {
             });
         }
 
-        suite("lldb-dap", () => {
+        suite.only("lldb-dap", () => {
             let resetSettings: (() => Promise<void>) | undefined;
             beforeEach(async function () {
                 // lldb-dap is only present/functional in the toolchain in 6.0.2 and up.
                 if (folderContext.swiftVersion.isLessThan(new Version(6, 0, 2))) {
-                    this.skip();
-                }
-
-                // Temporarily disable this test until debugging is fixed for --build-sytem swiftbuild
-                if (folderContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 4, 0))) {
                     this.skip();
                 }
 

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -130,7 +130,7 @@ tag("large").suite("Test Explorer Suite", function () {
             });
         }
 
-        suite.only("lldb-dap", () => {
+        suite("lldb-dap", () => {
             let resetSettings: (() => Promise<void>) | undefined;
             beforeEach(async function () {
                 // lldb-dap is only present/functional in the toolchain in 6.0.2 and up.

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -300,6 +300,35 @@ suite("BuildConfig Test Suite", () => {
             ).to.equal("swiftbuild");
         });
 
+        test("equals format --build-system=swiftbuild overrides < 6.4.0 default", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 3, 0), ["--build-system=swiftbuild"])
+            ).to.equal("swiftbuild");
+        });
+
+        test("equals format --build-system=native overrides 6.4.0+ default", () => {
+            expect(effectiveBuildSystem(new Version(6, 4, 0), ["--build-system=native"])).to.equal(
+                "native"
+            );
+        });
+
+        test("last --build-system wins across mixed formats", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 4, 0), [
+                    "--build-system=swiftbuild",
+                    "--build-system",
+                    "native",
+                ])
+            ).to.equal("native");
+            expect(
+                effectiveBuildSystem(new Version(6, 4, 0), [
+                    "--build-system",
+                    "native",
+                    "--build-system=swiftbuild",
+                ])
+            ).to.equal("swiftbuild");
+        });
+
         test("last --build-system wins when duplicated", () => {
             expect(
                 effectiveBuildSystem(new Version(6, 4, 0), [

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -356,12 +356,11 @@ suite("BuildConfig Test Suite", () => {
     suite("groupTestsByTarget", () => {
         test("empty array returns empty map", () => {
             const result = groupTestsByTarget([]);
-            expect(result.size).to.equal(0);
+            expect(result).to.deep.equal(new Map());
         });
 
         test("single target, single test", () => {
             const result = groupTestsByTarget(["FooTests.Bar.baz"]);
-            expect(result.size).to.equal(1);
             expect(result.get("FooTests")).to.deep.equal(["FooTests.Bar.baz"]);
         });
 
@@ -371,7 +370,6 @@ suite("BuildConfig Test Suite", () => {
                 "BarTests.Qux.quux",
                 "FooTests.Other.test",
             ]);
-            expect(result.size).to.equal(2);
             expect(result.get("FooTests")).to.deep.equal([
                 "FooTests.Bar.baz",
                 "FooTests.Other.test",
@@ -381,33 +379,28 @@ suite("BuildConfig Test Suite", () => {
 
         test("target-level wildcard", () => {
             const result = groupTestsByTarget(["FooTests.*"]);
-            expect(result.size).to.equal(1);
             expect(result.get("FooTests")).to.deep.equal(["FooTests.*"]);
         });
 
         test("bare target name without dot", () => {
             const result = groupTestsByTarget(["FooTests"]);
-            expect(result.size).to.equal(1);
             expect(result.get("FooTests")).to.deep.equal(["FooTests"]);
         });
 
         test("remaps c99 target name to original target name", () => {
             const c99ToName = new Map([["My_Target", "My-Target"]]);
             const result = groupTestsByTarget(["My_Target.SomeTests.test"], c99ToName);
-            expect(result.size).to.equal(1);
             expect(result.get("My-Target")).to.deep.equal(["My_Target.SomeTests.test"]);
         });
 
         test("uses c99 name as-is when no mapping provided", () => {
             const result = groupTestsByTarget(["My_Target.SomeTests.test"]);
-            expect(result.size).to.equal(1);
             expect(result.get("My_Target")).to.deep.equal(["My_Target.SomeTests.test"]);
         });
 
         test("falls back to c99 name when not present in map", () => {
             const c99ToName = new Map([["Other_Target", "Other-Target"]]);
             const result = groupTestsByTarget(["My_Target.SomeTests.test"], c99ToName);
-            expect(result.size).to.equal(1);
             expect(result.get("My_Target")).to.deep.equal(["My_Target.SomeTests.test"]);
         });
     });

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -308,9 +308,9 @@ suite("BuildConfig Test Suite", () => {
         });
 
         test("ignores --build-system with no following value", () => {
-            expect(
-                effectiveBuildSystem(new Version(6, 4, 0), ["--build-system"])
-            ).to.equal("swiftbuild");
+            expect(effectiveBuildSystem(new Version(6, 4, 0), ["--build-system"])).to.equal(
+                "swiftbuild"
+            );
         });
 
         test("ignores --build-system with unrecognized value", () => {

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -390,6 +390,26 @@ suite("BuildConfig Test Suite", () => {
             expect(result.size).to.equal(1);
             expect(result.get("FooTests")).to.deep.equal(["FooTests"]);
         });
+
+        test("remaps c99 target name to original target name", () => {
+            const c99ToName = new Map([["My_Target", "My-Target"]]);
+            const result = groupTestsByTarget(["My_Target.SomeTests.test"], c99ToName);
+            expect(result.size).to.equal(1);
+            expect(result.get("My-Target")).to.deep.equal(["My_Target.SomeTests.test"]);
+        });
+
+        test("uses c99 name as-is when no mapping provided", () => {
+            const result = groupTestsByTarget(["My_Target.SomeTests.test"]);
+            expect(result.size).to.equal(1);
+            expect(result.get("My_Target")).to.deep.equal(["My_Target.SomeTests.test"]);
+        });
+
+        test("falls back to c99 name when not present in map", () => {
+            const c99ToName = new Map([["Other_Target", "Other-Target"]]);
+            const result = groupTestsByTarget(["My_Target.SomeTests.test"], c99ToName);
+            expect(result.size).to.equal(1);
+            expect(result.get("My_Target")).to.deep.equal(["My_Target.SomeTests.test"]);
+        });
     });
 
     suite("testExecutableOutputPath", () => {

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -18,7 +18,11 @@ import { FolderContext } from "@src/FolderContext";
 import { LinuxMain } from "@src/LinuxMain";
 import { SwiftPackage } from "@src/SwiftPackage";
 import configuration, { FolderConfiguration } from "@src/configuration";
-import { BuildConfigurationFactory } from "@src/debugger/buildConfig";
+import {
+    BuildConfigurationFactory,
+    effectiveBuildSystem,
+    groupTestsByTarget,
+} from "@src/debugger/buildConfig";
 import { BuildFlags } from "@src/toolchain/BuildFlags";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
 import { Version } from "@src/utilities/version";
@@ -264,6 +268,94 @@ suite("BuildConfig Test Suite", () => {
             expect(filter.some((f: any) => f.argument === "--sdk")).to.be.false;
             expect(filter.some((f: any) => f.argument === "--verbose")).to.be.false;
             expect(filter.some((f: any) => f.argument === "--configuration")).to.be.false;
+        });
+    });
+
+    suite("effectiveBuildSystem", () => {
+        test("returns native for Swift < 6.4.0", () => {
+            expect(effectiveBuildSystem(new Version(6, 3, 0), [])).to.equal("native");
+        });
+
+        test("returns swiftbuild for Swift >= 6.4.0", () => {
+            expect(effectiveBuildSystem(new Version(6, 4, 0), [])).to.equal("swiftbuild");
+        });
+
+        test("returns swiftbuild for Swift > 6.4.0", () => {
+            expect(effectiveBuildSystem(new Version(7, 0, 0), [])).to.equal("swiftbuild");
+        });
+
+        test("explicit --build-system native overrides 6.4.0+ default", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 4, 0), ["--build-system", "native"])
+            ).to.equal("native");
+        });
+
+        test("explicit --build-system swiftbuild overrides < 6.4.0 default", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 3, 0), ["--build-system", "swiftbuild"])
+            ).to.equal("swiftbuild");
+        });
+
+        test("last --build-system wins when duplicated", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 4, 0), [
+                    "--build-system",
+                    "swiftbuild",
+                    "--build-system",
+                    "native",
+                ])
+            ).to.equal("native");
+        });
+
+        test("ignores --build-system with no following value", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 4, 0), ["--build-system"])
+            ).to.equal("swiftbuild");
+        });
+
+        test("ignores --build-system with unrecognized value", () => {
+            expect(
+                effectiveBuildSystem(new Version(6, 4, 0), ["--build-system", "xcodebuild"])
+            ).to.equal("swiftbuild");
+        });
+    });
+
+    suite("groupTestsByTarget", () => {
+        test("empty array returns empty map", () => {
+            const result = groupTestsByTarget([]);
+            expect(result.size).to.equal(0);
+        });
+
+        test("single target, single test", () => {
+            const result = groupTestsByTarget(["FooTests.Bar.baz"]);
+            expect(result.size).to.equal(1);
+            expect(result.get("FooTests")).to.deep.equal(["FooTests.Bar.baz"]);
+        });
+
+        test("multiple targets grouped correctly", () => {
+            const result = groupTestsByTarget([
+                "FooTests.Bar.baz",
+                "BarTests.Qux.quux",
+                "FooTests.Other.test",
+            ]);
+            expect(result.size).to.equal(2);
+            expect(result.get("FooTests")).to.deep.equal([
+                "FooTests.Bar.baz",
+                "FooTests.Other.test",
+            ]);
+            expect(result.get("BarTests")).to.deep.equal(["BarTests.Qux.quux"]);
+        });
+
+        test("target-level wildcard", () => {
+            const result = groupTestsByTarget(["FooTests.*"]);
+            expect(result.size).to.equal(1);
+            expect(result.get("FooTests")).to.deep.equal(["FooTests.*"]);
+        });
+
+        test("bare target name without dot", () => {
+            const result = groupTestsByTarget(["FooTests"]);
+            expect(result.size).to.equal(1);
+            expect(result.get("FooTests")).to.deep.equal(["FooTests"]);
         });
     });
 });

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -17,9 +17,13 @@ import * as sinon from "sinon";
 import { FolderContext } from "@src/FolderContext";
 import { LinuxMain } from "@src/LinuxMain";
 import { SwiftPackage } from "@src/SwiftPackage";
+import { TestKind } from "@src/TestExplorer/TestKind";
+import { TestLibrary } from "@src/TestExplorer/TestRunner";
+import { WorkspaceContext } from "@src/WorkspaceContext";
 import configuration, { FolderConfiguration } from "@src/configuration";
 import {
     BuildConfigurationFactory,
+    TestingConfigurationFactory,
     effectiveBuildSystem,
     groupTestsByTarget,
 } from "@src/debugger/buildConfig";
@@ -356,6 +360,202 @@ suite("BuildConfig Test Suite", () => {
             const result = groupTestsByTarget(["FooTests"]);
             expect(result.size).to.equal(1);
             expect(result.get("FooTests")).to.deep.equal(["FooTests"]);
+        });
+    });
+
+    suite("testExecutableOutputPath", () => {
+        const platformMock = mockGlobalValue(process, "platform");
+        const buildArgumentsConfig = mockGlobalValue(configuration, "buildArguments");
+        let mockedLogger: MockedObject<Pick<WorkspaceContext["logger"], "warn">>;
+
+        function createTestFolderContext(
+            swiftVersion: Version,
+            binPath: string
+        ): MockedObject<FolderContext> {
+            mockedLogger = mockObject<Pick<WorkspaceContext["logger"], "warn">>({
+                warn: () => {},
+            });
+            const testBuildFlags = mockObject<BuildFlags>({
+                getBuildBinaryPath: sinon.stub().resolves(binPath),
+            });
+            const testToolchain = mockObject<SwiftToolchain>({
+                buildFlags: instance(testBuildFlags),
+                swiftVersion: swiftVersion,
+                unversionedTriple: undefined,
+            });
+            const testSwiftPackage = mockObject<SwiftPackage>({
+                getTargets: sinon.stub().resolves([{ name: "PackageTests" }]),
+                name: Promise.resolve("MyPackage"),
+            });
+            return mockObject<FolderContext>({
+                toolchain: instance(testToolchain),
+                swiftPackage: instance(testSwiftPackage),
+                workspaceFolder: {
+                    uri: { fsPath: "/test/workspace" },
+                    name: "TestWorkspace",
+                } as any,
+                workspaceContext: { logger: instance(mockedLogger) } as any,
+                folder: { fsPath: "/test/workspace" } as any,
+                swiftVersion: swiftVersion,
+                relativePath: "",
+                linuxMain: { exists: true } as any as LinuxMain,
+            });
+        }
+
+        setup(() => {
+            additionalTestArgumentsConfig.setValue(() => createMockFolderConfig([]));
+            buildArgumentsConfig.setValue([]);
+        });
+
+        suite("with native build system (Swift < 6.4)", () => {
+            const swiftVersion = new Version(6, 3, 0);
+
+            test("uses .xctest on linux with targetName", async () => {
+                platformMock.setValue("linux" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests\.xctest$/);
+            });
+
+            test("uses .xctest on windows with targetName", async () => {
+                platformMock.setValue("win32" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests\.xctest$/);
+            });
+
+            test("uses .xctest on darwin with targetName", async () => {
+                platformMock.setValue("darwin" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests\.xctest$/);
+            });
+        });
+
+        suite("with swiftbuild build system (Swift >= 6.4)", () => {
+            const swiftVersion = new Version(6, 4, 0);
+
+            test("uses -test-runner on linux with targetName", async () => {
+                platformMock.setValue("linux" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests-test-runner$/);
+            });
+
+            test("uses -test-runner.exe on windows with targetName", async () => {
+                platformMock.setValue("win32" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests-test-runner\.exe$/);
+            });
+
+            test("uses .xctest on darwin with targetName", async () => {
+                platformMock.setValue("darwin" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests\.xctest$/);
+            });
+
+            test("uses -test-runner on linux without targetName", async () => {
+                platformMock.setValue("linux" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest
+                );
+
+                expect(result).to.match(/MyPackagePackageTests-test-runner$/);
+            });
+
+            test("uses -test-runner on linux for swift-testing", async () => {
+                platformMock.setValue("linux" as NodeJS.Platform);
+                const ctx = createTestFolderContext(swiftVersion, "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.swiftTesting,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests-test-runner$/);
+            });
+        });
+
+        suite("with explicit --build-system override", () => {
+            test("uses -test-runner when --build-system swiftbuild on old Swift", async () => {
+                platformMock.setValue("linux" as NodeJS.Platform);
+                buildArgumentsConfig.setValue(["--build-system", "swiftbuild"]);
+                const ctx = createTestFolderContext(new Version(6, 3, 0), "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests-test-runner$/);
+            });
+
+            test("uses .xctest when --build-system native on new Swift", async () => {
+                platformMock.setValue("linux" as NodeJS.Platform);
+                buildArgumentsConfig.setValue(["--build-system", "native"]);
+                const ctx = createTestFolderContext(new Version(6, 4, 0), "/build/debug");
+
+                const result = await TestingConfigurationFactory.testExecutableOutputPath(
+                    instance(ctx),
+                    TestKind.debug,
+                    TestLibrary.xctest,
+                    "PackageTests"
+                );
+
+                expect(result).to.match(/PackageTests\.xctest$/);
+            });
         });
     });
 });

--- a/test/unit-tests/toolchain/BuildFlags.test.ts
+++ b/test/unit-tests/toolchain/BuildFlags.test.ts
@@ -704,4 +704,92 @@ suite("BuildFlags Test Suite", () => {
             expect(execSwiftSpy).to.have.been.calledThrice;
         });
     });
+
+    suite("lastFlagValue", () => {
+        test("returns undefined for empty args", () => {
+            expect(BuildFlags.lastFlagValue([], "--build-system")).to.be.undefined;
+        });
+
+        test("returns undefined when flag is not present", () => {
+            expect(BuildFlags.lastFlagValue(["--other-flag", "value"], "--build-system")).to.be
+                .undefined;
+        });
+
+        test("finds value in --flag value format", () => {
+            expect(
+                BuildFlags.lastFlagValue(["--build-system", "native"], "--build-system")
+            ).to.equal("native");
+        });
+
+        test("finds value in --flag=value format", () => {
+            expect(BuildFlags.lastFlagValue(["--build-system=native"], "--build-system")).to.equal(
+                "native"
+            );
+        });
+
+        test("returns last occurrence when flag appears multiple times (--flag value)", () => {
+            expect(
+                BuildFlags.lastFlagValue(
+                    ["--build-system", "xcode", "--build-system", "native"],
+                    "--build-system"
+                )
+            ).to.equal("native");
+        });
+
+        test("returns last occurrence when flag appears multiple times (--flag=value)", () => {
+            expect(
+                BuildFlags.lastFlagValue(
+                    ["--build-system=xcode", "--build-system=native"],
+                    "--build-system"
+                )
+            ).to.equal("native");
+        });
+
+        test("returns last valid occurrence when validate skips invalid values", () => {
+            const isNative = (v: string): v is "native" => v === "native";
+            expect(
+                BuildFlags.lastFlagValue(
+                    ["--build-system", "native", "--build-system", "unknown"],
+                    "--build-system",
+                    isNative
+                )
+            ).to.equal("native");
+        });
+
+        test("returns undefined when all occurrences fail validation", () => {
+            const isNative = (v: string): v is "native" => v === "native";
+            expect(
+                BuildFlags.lastFlagValue(["--build-system", "xcode"], "--build-system", isNative)
+            ).to.be.undefined;
+        });
+
+        test("validate skips invalid --flag=value occurrences and returns last valid", () => {
+            const isNative = (v: string): v is "native" => v === "native";
+            expect(
+                BuildFlags.lastFlagValue(
+                    ["--build-system=native", "--build-system=xcode"],
+                    "--build-system",
+                    isNative
+                )
+            ).to.equal("native");
+        });
+
+        test("returns undefined when flag is last argument with no following value", () => {
+            expect(BuildFlags.lastFlagValue(["--build-system"], "--build-system")).to.be.undefined;
+        });
+
+        test("handles mixed --flag value and --flag=value formats, returns last", () => {
+            expect(
+                BuildFlags.lastFlagValue(
+                    ["--build-system=xcode", "--build-system", "native"],
+                    "--build-system"
+                )
+            ).to.equal("native");
+        });
+
+        test("does not match flags that share a prefix", () => {
+            expect(BuildFlags.lastFlagValue(["--build-system-extra", "value"], "--build-system")).to
+                .be.undefined;
+        });
+    });
 });


### PR DESCRIPTION
## Description
Swift 6.4.0+ defaults to the 'swiftbuild' build system, which produces one test binary per test target instead of one per package. Modify debugSession to create per-target debug configurations when using the swiftbuild build system.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
