### PR TITLE
Clean up CI workflows

### DIFF
--- a/.github/workflows/nightly-insiders.yml
+++ b/.github/workflows/nightly-insiders.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       needs_token: true
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "5.8"}, {"swift_version": "5.9"}, {"swift_version": "5.10"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-6.2"}, {"swift_version": "nightly-6.3"}, {"swift_version": "nightly-main"}]'
+      linux_swift_versions: '["nightly-6.3", "nightly-main"]'
       linux_env_vars: |
         NODE_VERSION=${{ needs.package.outputs.node-version }}
         NODE_PATH=${{ needs.package.outputs.node-path }}
@@ -64,7 +64,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "5.9"}, {"swift_version": "6.0"}, {"swift_version": "6.1"}, {"swift_version": "nightly-6.1"}, {"swift_version": "nightly-6.2"}, {"swift_version": "nightly-6.3"}, {"swift_version": "nightly"}, {"swift_version": "nightly-main"}]'
+      windows_swift_versions: '["nightly-6.3", "nightly-main"]'
       windows_env_vars: |
         CI=1
         VSCODE_VERSION=insiders

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,7 +63,7 @@ jobs:
     with:
       needs_token: true
       # Linux
-      linux_exclude_swift_versions: '[{"swift_version": "nightly-6.1"}]'
+      # Run against all of the swift versions from https://github.com/swiftlang/github-workflows/blob/main/.github/workflows/swift_package_test.yml#L44
       linux_env_vars: |
         NODE_VERSION=${{ needs.package.outputs.node-version }}
         NODE_PATH=${{ needs.package.outputs.node-path }}
@@ -74,7 +74,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: '[{"swift_version": "nightly-6.1"}, {"swift_version": "nightly"}, {"swift_version": "6.2"}]'  # Missing https://github.com/swiftlang/swift/pull/80144
+      # Run against all of the swift versions from https://github.com/swiftlang/github-workflows/blob/main/.github/workflows/swift_package_test.yml#L85
       windows_env_vars: |
         CI=1
         VSCODE_SWIFT_VSIX_ID=${{needs.package.outputs.artifact-id}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,7 +51,7 @@ jobs:
     with:
       needs_token: true
       # Linux
-      linux_exclude_swift_versions: "${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '[{\"swift_version\": \"nightly-6.1\"}]' || '[{\"swift_version\": \"nightly-6.1\"},{\"swift_version\": \"nightly-6.2\"},{\"swift_version\": \"nightly-6.3\"},{\"swift_version\": \"nightly-main\"}]' }}"
+      linux_exclude_swift_versions: "${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '[]' || '[{\"swift_version\": \"nightly-6.3\"}, {\"swift_version\": \"nightly-main\"}]' }}"
       linux_env_vars: |
         NODE_VERSION=${{ needs.package.outputs.node-version }}
         NODE_PATH=${{ needs.package.outputs.node-path }}
@@ -63,7 +63,7 @@ jobs:
       linux_pre_build_command: . .github/workflows/scripts/setup-linux.sh
       linux_build_command: ./scripts/test.sh
       # Windows
-      windows_exclude_swift_versions: "${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '[{\"swift_version\": \"nightly-6.1\"},{\"swift_version\": \"nightly-main\"}]' || '[{\"swift_version\": \"nightly-6.1\"},{\"swift_version\": \"nightly-6.2\"},{\"swift_version\": \"nightly-6.3\"},{\"swift_version\": \"nightly-main\"}]' }}"
+      windows_exclude_swift_versions: "${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '[]' || '[{\"swift_version\": \"nightly-6.3\"}, {\"swift_version\": \"nightly-main\"}]' }}"
       windows_env_vars: |
         CI=1
         FAST_TEST_RUN=${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && '0' || '1'}}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,7 +45,7 @@ jobs:
             vscode-swift-sha.txt
 
   tests:
-    name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Test'}}
+    name: ${{ contains(github.event.pull_request.labels.*.name, 'full-test-run') && 'Full Test Run' || 'Fast Test Run'}}
     needs: package
     uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,8 @@
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.9.1",
+        "@xterm/addon-serialize": "^0.14.0",
+        "@xterm/headless": "^6.0.0",
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
         "chai-subset": "^1.6.0",
@@ -4281,6 +4283,23 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -16408,6 +16427,18 @@
       "version": "0.8.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
       "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
+    },
+    "@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "dev": true
+    },
+    "@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -2140,6 +2140,8 @@
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.9.1",
+    "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/headless": "^6.0.0",
     "chai": "^4.5.0",
     "chai-as-promised": "^7.1.2",
     "chai-subset": "^1.6.0",

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -18,11 +18,10 @@ import * as vscode from "vscode";
 import { WorkspaceContext } from "./WorkspaceContext";
 import configuration from "./configuration";
 import { SwiftExecution } from "./tasks/SwiftExecution";
+import { TerminalEmulator } from "./terminal/TerminalEmulator";
 import { Disposable } from "./utilities/Disposable";
 import { validFileTypes } from "./utilities/filesystem";
-import { checkIfBuildComplete, lineBreakRegex } from "./utilities/tasks";
-
-import stripAnsi = require("strip-ansi");
+import { checkIfBuildComplete } from "./utilities/tasks";
 
 interface ParsedDiagnostic {
     uri: string;
@@ -303,43 +302,37 @@ export class DiagnosticsManager implements Disposable {
                 disposables.forEach(d => d.dispose());
                 res(diagnostics);
             };
-            let remainingData: string | undefined;
             let lastDiagnostic: vscode.Diagnostic | undefined;
             let lastDiagnosticNeedsSaving = false;
+            const terminalEmulator = new TerminalEmulator(swiftExecution);
             disposables.push(
-                swiftExecution.onDidWrite(data => {
-                    const sanitizedData = (remainingData || "") + stripAnsi(data);
-                    const lines = sanitizedData.split(lineBreakRegex);
-                    // If ends with \n then will be "" and there's no affect.
-                    // Otherwise want to keep remaining data to pre-pend next write
-                    remainingData = lines.pop();
-                    for (const line of lines) {
-                        if (checkIfBuildComplete(line)) {
-                            done();
-                            return;
-                        }
-                        const result = this.parseDiagnostic(line);
-                        if (!result) {
-                            continue;
-                        }
-                        if (result instanceof vscode.DiagnosticRelatedInformation) {
-                            lastDiagnosticNeedsSaving = this.handleRelatedInformation(
-                                result,
-                                lastDiagnostic,
-                                lastDiagnosticNeedsSaving,
-                                diagnostics
-                            );
-                            continue;
-                        }
-                        const parsed = this.handleParsedDiagnostic(
-                            result as ParsedDiagnostic,
+                terminalEmulator,
+                terminalEmulator.onDidReceiveLineData(line => {
+                    if (checkIfBuildComplete(line)) {
+                        done();
+                        return;
+                    }
+                    const result = this.parseDiagnostic(line);
+                    if (!result) {
+                        return;
+                    }
+                    if (result instanceof vscode.DiagnosticRelatedInformation) {
+                        lastDiagnosticNeedsSaving = this.handleRelatedInformation(
+                            result,
+                            lastDiagnostic,
+                            lastDiagnosticNeedsSaving,
                             diagnostics
                         );
-                        lastDiagnostic = parsed.lastDiagnostic;
-                        lastDiagnosticNeedsSaving = parsed.needsSaving;
+                        return;
                     }
+                    const parsed = this.handleParsedDiagnostic(
+                        result as ParsedDiagnostic,
+                        diagnostics
+                    );
+                    lastDiagnostic = parsed.lastDiagnostic;
+                    lastDiagnosticNeedsSaving = parsed.needsSaving;
                 }),
-                swiftExecution.onDidClose(done)
+                terminalEmulator.onDidClose(done)
             );
         });
     }

--- a/src/terminal/TerminalEmulator.ts
+++ b/src/terminal/TerminalEmulator.ts
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { IBuffer, Terminal } from "@xterm/headless";
+import * as vscode from "vscode";
+
+import { Disposable } from "../utilities/Disposable";
+
+interface TerminalProcess {
+    onDidWrite: vscode.Event<string>;
+    onDidClose: vscode.Event<unknown>;
+}
+
+/**
+ * Uses a headless xterm.js to properly handle terminal escape sequences coming from a PTY process.
+ */
+export class TerminalEmulator implements Disposable {
+    private readonly terminal: Terminal;
+    private readonly subscriptions: Disposable;
+    private readonly inFlightWrites: Promise<void>[] = [];
+
+    private lineDataEmitter = new vscode.EventEmitter<string>();
+    public onDidReceiveLineData = this.lineDataEmitter.event;
+
+    private closeEmitter = new vscode.EventEmitter<void>();
+    public onDidClose = this.closeEmitter.event;
+
+    constructor(process: TerminalProcess) {
+        this.terminal = new Terminal({ allowProposedApi: true });
+        this.subscriptions = Disposable.from(
+            this.terminal.onLineFeed(() => {
+                const buffer = this.terminal.buffer;
+                const newLine = buffer.active.getLine(buffer.active.baseY + buffer.active.cursorY);
+                if (newLine && !newLine.isWrapped) {
+                    this.sendLineData(
+                        buffer.active,
+                        buffer.active.baseY + buffer.active.cursorY - 1
+                    );
+                }
+            }),
+            process.onDidWrite(data => {
+                this.inFlightWrites.push(
+                    new Promise<void>(resolve => {
+                        this.terminal.write(data, resolve);
+                    })
+                );
+            }),
+            process.onDidClose(() => {
+                void Promise.all(this.inFlightWrites).then(() => {
+                    this.sendLineData(
+                        this.terminal.buffer.active,
+                        this.terminal.buffer.active.baseY + this.terminal.buffer.active.cursorY
+                    );
+                    this.closeEmitter.fire();
+                });
+            })
+        );
+    }
+
+    private sendLineData(buffer: IBuffer, lineIndex: number): void {
+        let line = buffer.getLine(lineIndex);
+        if (!line) {
+            return;
+        }
+        let lineData = line.translateToString(true);
+        while (lineIndex > 0 && line.isWrapped) {
+            lineIndex = lineIndex - 1;
+            line = buffer.getLine(lineIndex);
+            if (!line) {
+                break;
+            }
+            lineData = line.translateToString(false) + lineData;
+        }
+        this.lineDataEmitter.fire(lineData);
+    }
+
+    public dispose(): void {
+        this.terminal.dispose();
+        this.subscriptions.dispose();
+        this.lineDataEmitter.dispose();
+        this.closeEmitter.dispose();
+    }
+}

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -147,7 +147,8 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
 
                         resetSettings = await updateSettings({
                             "swift.diagnosticsStyle": style,
-                            "swift.buildArguments": ["-Xswiftc", `-DDIAGNOSTIC_STYLE=${style}`],
+                            // Force the re-computing of diagnostics by adding a define to the build arguments
+                            "swift.buildArguments": ["-Xswiftc", `-DDIAGNOSTIC_STYLE__${style}`],
                         });
 
                         // Clean up any lingering diagnostics
@@ -164,7 +165,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
 
                     test("succeeds", async function () {
                         await executeTaskAndWaitForDiagnostics(
-                            createBuildAllTask(folderContext),
+                            createBuildAllTask(folderContext, true),
                             createExpectedDiagnostics()
                         );
                     });
@@ -175,28 +176,19 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
 
             runTestDiagnosticStyle(
                 "default",
-                () => {
-                    const swiftVersion = folderContext.toolchain.swiftVersion;
-                    const is64OrLater = swiftVersion.isGreaterThanOrEqual(new Version(6, 4, 0));
-                    return {
-                        [mainUri.fsPath]: [
-                            // expectedMacroDiagnostic still checks "warning" is parsed
-                            ...(is64OrLater ? [] : [expectedWarningDiagnostic]),
-                            expectedMainErrorDiagnostic,
-                            expectedMainDictErrorDiagnostic,
-                            ...(workspaceContext.globalToolchainSwiftVersion.isGreaterThanOrEqual(
-                                new Version(6, 0, 0)
-                            )
-                                ? [expectedMacroDiagnostic]
-                                : []),
-                        ], // Should have parsed correct severity
-                        ...(is64OrLater
-                            ? {}
-                            : {
-                                  [funcUri.fsPath]: [expectedFuncErrorDiagnostic],
-                              }), // Check parsed for other file
-                    };
-                },
+                () => ({
+                    [mainUri.fsPath]: [
+                        expectedWarningDiagnostic,
+                        expectedMainErrorDiagnostic,
+                        expectedMainDictErrorDiagnostic,
+                        ...(workspaceContext.globalToolchainSwiftVersion.isGreaterThanOrEqual(
+                            new Version(6, 0, 0)
+                        )
+                            ? [expectedMacroDiagnostic]
+                            : []),
+                    ], // Should have parsed correct severity
+                    [funcUri.fsPath]: [expectedFuncErrorDiagnostic], // Check parsed for other file
+                }),
                 () => {
                     test("Parses related information", async function () {
                         if (
@@ -227,23 +219,14 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 }
             );
 
-            runTestDiagnosticStyle("swift", () => {
-                const is64OrLater = folderContext.toolchain.swiftVersion.isGreaterThanOrEqual(
-                    new Version(6, 4, 0)
-                );
-                return {
-                    [mainUri.fsPath]: [
-                        ...(is64OrLater ? [] : [expectedWarningDiagnostic]),
-                        expectedMainErrorDiagnostic,
-                        expectedMainDictErrorDiagnostic,
-                    ], // Should have parsed correct severity
-                    ...(is64OrLater
-                        ? {}
-                        : {
-                              [funcUri.fsPath]: [expectedFuncErrorDiagnostic],
-                          }), // Check parsed for other file
-                };
-            });
+            runTestDiagnosticStyle("swift", () => ({
+                [mainUri.fsPath]: [
+                    expectedWarningDiagnostic,
+                    expectedMainErrorDiagnostic,
+                    expectedMainDictErrorDiagnostic,
+                ], // Should have parsed correct severity
+                [funcUri.fsPath]: [expectedFuncErrorDiagnostic], // Check parsed for other file
+            }));
 
             runTestDiagnosticStyle(
                 "llvm",
@@ -300,9 +283,12 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                         );
                         expectedDiagnostic2.source = "swiftc";
 
-                        await executeTaskAndWaitForDiagnostics(createBuildAllTask(cFolderContext), {
-                            [cUri.fsPath]: [expectedDiagnostic1, expectedDiagnostic2],
-                        });
+                        await executeTaskAndWaitForDiagnostics(
+                            createBuildAllTask(cFolderContext, true),
+                            {
+                                [cUri.fsPath]: [expectedDiagnostic1, expectedDiagnostic2],
+                            }
+                        );
                     });
 
                     test("Parses C++ diagnostics", async function () {
@@ -342,7 +328,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                                 new Version(6, 4, 0)
                             );
                         await executeTaskAndWaitForDiagnostics(
-                            createBuildAllTask(cppFolderContext),
+                            createBuildAllTask(cppFolderContext, true),
                             {
                                 [cppUri.fsPath]: [
                                     expectedDiagnostic1,

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -21,53 +21,24 @@ import { WorkspaceContext } from "@src/WorkspaceContext";
 import { DiagnosticStyle } from "@src/configuration";
 import { createBuildAllTask, resetBuildAllTaskCache } from "@src/tasks/SwiftTaskProvider";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
-import { Disposable } from "@src/utilities/Disposable";
 import { Version } from "@src/utilities/version";
 
 import { testAssetUri, testSwiftTask } from "../fixtures";
 import { tag } from "../tags";
 import {
-    executeTaskAndWaitForResult,
-    waitForNoRunningTasks,
-    waitForStartTaskProcess,
-} from "../utilities/tasks";
+    ExpectedDiagnostics,
+    assertHasDiagnostic,
+    assertWithoutDiagnostic,
+    diagnosticMatcher,
+    executeTaskAndWaitForDiagnostics,
+    waitForDiagnosticsCleared,
+} from "../utilities/diagnostics";
+import { waitForNoRunningTasks, waitForStartTaskProcess } from "../utilities/tasks";
 import {
     activateExtensionForSuite,
     folderInRootWorkspace,
     updateSettings,
 } from "./utilities/testutilities";
-
-const isEqual = (d1: vscode.Diagnostic, d2: vscode.Diagnostic) => {
-    return (
-        d1.severity === d2.severity &&
-        d1.source === d2.source &&
-        d1.message === d2.message &&
-        d1.range.isEqual(d2.range)
-    );
-};
-
-const findDiagnostic = (expected: vscode.Diagnostic) => (d: vscode.Diagnostic) =>
-    isEqual(d, expected);
-
-function assertHasDiagnostic(uri: vscode.Uri, expected: vscode.Diagnostic): vscode.Diagnostic {
-    const diagnostics = vscode.languages.getDiagnostics(uri);
-    const diagnostic = diagnostics.find(findDiagnostic(expected));
-    assert.notEqual(
-        diagnostic,
-        undefined,
-        `Could not find diagnostic matching:\n${JSON.stringify(expected)}\nDiagnostics found:\n${JSON.stringify(diagnostics)}`
-    );
-    return diagnostic!;
-}
-
-function assertWithoutDiagnostic(uri: vscode.Uri, expected: vscode.Diagnostic) {
-    const diagnostics = vscode.languages.getDiagnostics(uri);
-    assert.equal(
-        diagnostics.find(findDiagnostic(expected)),
-        undefined,
-        `Unexpected diagnostic matching:\n${JSON.stringify(expected)}\nDiagnostics:\n${JSON.stringify(diagnostics)}`
-    );
-}
 
 tag("medium").suite("DiagnosticsManager Test Suite", function () {
     let workspaceContext: WorkspaceContext;
@@ -81,67 +52,6 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
     let cUri: vscode.Uri;
     let cppUri: vscode.Uri;
     let cppHeaderUri: vscode.Uri;
-    let diagnosticWaiterDisposable: Disposable | undefined;
-    let remainingExpectedDiagnostics: {
-        [uri: string]: vscode.Diagnostic[];
-    };
-
-    // Wait for all the expected diagnostics to be recieved. This may happen over several `onChangeDiagnostics` events.
-    type ExpectedDiagnostics = { [uri: string]: vscode.Diagnostic[] };
-
-    function filterRemainingDiagnostics(
-        expectedDiagnostics: ExpectedDiagnostics,
-        changedUris: readonly vscode.Uri[]
-    ) {
-        const matchingPaths = Object.keys(expectedDiagnostics).filter(uri =>
-            changedUris.some(u => u.fsPath === uri)
-        );
-        for (const uri of matchingPaths) {
-            const actualDiagnostics = vscode.languages.getDiagnostics(vscode.Uri.file(uri));
-            for (const actualDiagnostic of actualDiagnostics) {
-                remainingExpectedDiagnostics[uri] = remainingExpectedDiagnostics[uri].filter(
-                    expectedDiagnostic => !isEqual(actualDiagnostic, expectedDiagnostic)
-                );
-            }
-        }
-    }
-
-    function allDiagnosticsFulfilled(): boolean {
-        return Object.values(remainingExpectedDiagnostics).every(
-            diagnostics => diagnostics.length === 0
-        );
-    }
-
-    function waitForDiagnosticsCleared(uri: vscode.Uri): Promise<void> {
-        return new Promise<void>(resolve => {
-            const diagnosticDisposable = vscode.languages.onDidChangeDiagnostics(() => {
-                if (vscode.languages.getDiagnostics(uri).length === 0) {
-                    diagnosticDisposable?.dispose();
-                    resolve();
-                }
-            });
-        });
-    }
-
-    const waitForDiagnostics = (expectedDiagnostics: ExpectedDiagnostics) => {
-        return new Promise<void>(resolve => {
-            if (diagnosticWaiterDisposable) {
-                console.warn(
-                    "Wait for diagnostics was called before the previous wait was resolved. Only one waitForDiagnostics should run per test."
-                );
-                diagnosticWaiterDisposable?.dispose();
-            }
-            remainingExpectedDiagnostics = { ...expectedDiagnostics };
-            diagnosticWaiterDisposable = vscode.languages.onDidChangeDiagnostics(e => {
-                filterRemainingDiagnostics(expectedDiagnostics, e.uris);
-                if (allDiagnosticsFulfilled()) {
-                    diagnosticWaiterDisposable?.dispose();
-                    diagnosticWaiterDisposable = undefined;
-                    resolve();
-                }
-            });
-        });
-    };
 
     activateExtensionForSuite({
         async setup(ctx) {
@@ -156,21 +66,6 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
             cppUri = testAssetUri("diagnosticsCpp/Sources/MyPoint/MyPoint.cpp");
             cppHeaderUri = testAssetUri("diagnosticsCpp/Sources/MyPoint/include/MyPoint.h");
         },
-    });
-
-    teardown(function () {
-        diagnosticWaiterDisposable?.dispose();
-        diagnosticWaiterDisposable = undefined;
-        if (remainingExpectedDiagnostics && !allDiagnosticsFulfilled()) {
-            const title = this.currentTest?.fullTitle() ?? "<unknown test>";
-            const remainingDiagnostics = Object.entries(remainingExpectedDiagnostics ?? {}).filter(
-                ([_uri, diagnostics]) => diagnostics.length > 0
-            );
-            console.error(
-                `${title} - Not all diagnostics were fulfilled. Remaining:`,
-                JSON.stringify(remainingDiagnostics, undefined, " ")
-            );
-        }
     });
 
     suite("Parse diagnostics", function () {
@@ -222,7 +117,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
 
             function runTestDiagnosticStyle(
                 style: DiagnosticStyle,
-                expected: () => ExpectedDiagnostics,
+                createExpectedDiagnostics: () => ExpectedDiagnostics,
                 callback?: () => void
             ) {
                 suite(`${style} diagnosticsStyle`, function () {
@@ -268,12 +163,10 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                     });
 
                     test("succeeds", async function () {
-                        await Promise.all([
-                            waitForDiagnostics(expected()),
-                            createBuildAllTask(folderContext).then(task =>
-                                executeTaskAndWaitForResult(task)
-                            ),
-                        ]);
+                        await executeTaskAndWaitForDiagnostics(
+                            createBuildAllTask(folderContext),
+                            createExpectedDiagnostics()
+                        );
                     });
 
                     callback && callback();
@@ -407,15 +300,9 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                         );
                         expectedDiagnostic2.source = "swiftc";
 
-                        await Promise.all([
-                            waitForDiagnostics({
-                                [cUri.fsPath]: [expectedDiagnostic1, expectedDiagnostic2],
-                            }),
-                            createBuildAllTask(cFolderContext).then(task =>
-                                executeTaskAndWaitForResult(task)
-                            ),
-                        ]);
-                        await waitForNoRunningTasks();
+                        await executeTaskAndWaitForDiagnostics(createBuildAllTask(cFolderContext), {
+                            [cUri.fsPath]: [expectedDiagnostic1, expectedDiagnostic2],
+                        });
                     });
 
                     test("Parses C++ diagnostics", async function () {
@@ -454,19 +341,16 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                             folderContext.toolchain.swiftVersion.isGreaterThanOrEqual(
                                 new Version(6, 4, 0)
                             );
-                        await Promise.all([
-                            waitForDiagnostics({
+                        await executeTaskAndWaitForDiagnostics(
+                            createBuildAllTask(cppFolderContext),
+                            {
                                 [cppUri.fsPath]: [
                                     expectedDiagnostic1,
                                     expectedDiagnostic2,
                                     ...(is64OrLater ? [] : [expectedDiagnostic3]),
                                 ],
-                            }),
-                            createBuildAllTask(cppFolderContext).then(task =>
-                                executeTaskAndWaitForResult(task)
-                            ),
-                        ]);
-                        await waitForNoRunningTasks();
+                            }
+                        );
 
                         const diagnostic = assertHasDiagnostic(cppUri, expectedDiagnostic2);
                         assert.equal(
@@ -671,7 +555,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 assertHasDiagnostic(mainUri, diagnostic);
 
                 const diagnostics = vscode.languages.getDiagnostics(mainUri);
-                const matchingDiagnostic = diagnostics.find(findDiagnostic(diagnostic));
+                const matchingDiagnostic = diagnostics.find(diagnosticMatcher(diagnostic));
 
                 expect(matchingDiagnostic).to.have.property("code", "string");
             });
@@ -690,7 +574,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 assertHasDiagnostic(mainUri, diagnostic);
 
                 const diagnostics = vscode.languages.getDiagnostics(mainUri);
-                const matchingDiagnostic = diagnostics.find(findDiagnostic(diagnostic));
+                const matchingDiagnostic = diagnostics.find(diagnosticMatcher(diagnostic));
 
                 expect(matchingDiagnostic).to.have.property("code", 1);
             });
@@ -713,7 +597,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 assertHasDiagnostic(mainUri, diagnostic);
 
                 const diagnostics = vscode.languages.getDiagnostics(mainUri);
-                const matchingDiagnostic = diagnostics.find(findDiagnostic(diagnostic));
+                const matchingDiagnostic = diagnostics.find(diagnosticMatcher(diagnostic));
 
                 expect(matchingDiagnostic).to.have.property("code", diagnostic.code);
             });
@@ -732,7 +616,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 );
 
                 const diagnostics = vscode.languages.getDiagnostics(mainUri);
-                const matchingDiagnostic = diagnostics.find(findDiagnostic(diagnostic));
+                const matchingDiagnostic = diagnostics.find(diagnosticMatcher(diagnostic));
 
                 expect(matchingDiagnostic).to.have.property("code");
                 expect(matchingDiagnostic?.code).to.have.property("value", "More Information...");
@@ -770,7 +654,7 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 );
 
                 const diagnostics = vscode.languages.getDiagnostics(mainUri);
-                const matchingDiagnostic = diagnostics.find(findDiagnostic(diagnostic));
+                const matchingDiagnostic = diagnostics.find(diagnosticMatcher(diagnostic));
 
                 expect(matchingDiagnostic).to.have.property("code");
                 expect(matchingDiagnostic?.code).to.have.property("value", "More Information...");

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -157,7 +157,7 @@ tag("large").suite("Test Explorer Suite", function () {
                 //
                 // GitHub Issue: https://github.com/swiftlang/vscode-swift/issues/1986
                 if (
-                    workspaceContext.globalToolchain.swiftVersion.dev &&
+                    process.platform === "win32" &&
                     workspaceContext.globalToolchain.swiftVersion.isGreaterThanOrEqual({
                         major: 6,
                         minor: 3,

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -664,7 +664,7 @@ tag("large").suite("Test Explorer Suite", function () {
         [TestKind.standard, TestKind.parallel, TestKind.coverage].forEach(runProfile => {
             let xcTestFailureMessage: string;
 
-            beforeEach(() => {
+            beforeEach(function () {
                 // From 5.7 to 5.10 running with the --parallel option dumps the test results out
                 // to the console with no newlines, so it isn't possible to distinguish where errors
                 // begin and end. Consequently we can't record them, and so we manually mark them
@@ -677,6 +677,22 @@ tag("large").suite("Test Explorer Suite", function () {
             });
 
             suite(runProfile, () => {
+                suiteSetup(function () {
+                    // Code coverage is currently not working in Windows with the latest nightly-main toolchain
+                    // See https://github.com/swiftlang/swift/issues/88607
+                    if (
+                        runProfile === TestKind.coverage &&
+                        process.platform === "win32" &&
+                        workspaceContext.globalToolchain.swiftVersion.isGreaterThanOrEqual({
+                            major: 6,
+                            minor: 4,
+                            patch: 0,
+                        })
+                    ) {
+                        this.skip();
+                    }
+                });
+
                 suite(`swift-testing (${runProfile})`, function () {
                     suiteSetup(function () {
                         if (

--- a/test/reporters/GitHubActionsSummaryReporter.ts
+++ b/test/reporters/GitHubActionsSummaryReporter.ts
@@ -15,6 +15,7 @@ import { diffLines } from "diff";
 import * as fs from "fs";
 import * as mocha from "mocha";
 
+const EOL = "\r\n";
 const SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
 
 interface AssertionError extends Error {
@@ -73,7 +74,7 @@ module.exports = class GitHubActionsSummaryReporter extends mocha.reporters.Base
 
 function fullTitle(test: Mocha.Test | Mocha.Suite): string {
     if (test.parent && test.parent.title) {
-        return fullTitle(test.parent) + " | " + test.title;
+        return fullTitle(test.parent) + " → " + test.title;
     }
     return test.title;
 }
@@ -82,23 +83,38 @@ function generateErrorMessage(failure: Mocha.Test): string {
     if (!failure.err) {
         return "The test did not report what the error was.";
     }
+    return convertErrorToString(failure.err);
+}
 
+function convertErrorToString(error: Error): string {
     const stackTraceFilter = mocha.utils.stackTraceFilter();
-    if (isAssertionError(failure.err) && failure.err.showDiff) {
-        const { message, stack } = splitStackTrace(failure.err);
-        return (
+    let result: string;
+    if (isAssertionError(error) && error.showDiff) {
+        const stackTraceFilter = mocha.utils.stackTraceFilter();
+        const { message, stack } = splitStackTrace(error);
+        result =
             message +
-            eol() +
-            generateDiff(failure.err.actual, failure.err.expected) +
-            eol() +
-            eol() +
-            stackTraceFilter(stack)
-        );
+            EOL +
+            generateDiff(error.actual, error.expected) +
+            EOL +
+            EOL +
+            stackTraceFilter(stack);
+    } else if (error.stack) {
+        result = stackTraceFilter(error.stack);
+    } else {
+        result = mocha.utils.stringify(error);
     }
-    if (failure.err.stack) {
-        return stackTraceFilter(failure.err.stack);
+
+    if (!error.cause) {
+        return result;
     }
-    return mocha.utils.stringify(failure.err);
+    let causedByString = "Caused By: ";
+    if (error.cause instanceof Error) {
+        causedByString += convertErrorToString(error.cause);
+    } else {
+        causedByString += mocha.utils.stringify(error.cause);
+    }
+    return result + EOL + causedByString;
 }
 
 function splitStackTrace(error: Error): { message: string; stack: string } {
@@ -116,7 +132,7 @@ function splitStackTrace(error: Error): { message: string; stack: string } {
 
 function generateDiff(actual: string, expected: string) {
     return [
-        "🟩 expected 🟥 actual\n\n",
+        "🟩 expected 🟥 actual" + EOL + EOL,
         ...diffLines(expected, actual).map(part => {
             if (part.added) {
                 return "🟩" + part.value;
@@ -138,43 +154,44 @@ function details(summary: string, open: boolean, content: string): string {
     return tag(
         "details",
         open ? ["open"] : [],
-        eol() + tag("summary", [], summary) + eol() + content + eol()
+        EOL + tag("summary", [], summary) + EOL + content + EOL
     );
 }
 
 function list(lines: string[]): string {
-    return tag("ul", [], eol() + lines.map(line => tag("li", [], line)).join(eol()) + eol());
+    return tag("ul", [], EOL + lines.map(line => tag("li", [], line)).join(EOL) + EOL);
 }
 
-function eol(): string {
-    if (process.platform === "win32") {
-        return "\r\n";
-    }
-    return "\n";
+function fixLineEndings(str: string): string {
+    return str.replace(/\r?\n/g, EOL);
 }
 
 function createMarkdownSummary(title: string, stats: Mocha.Stats, failures: Mocha.Test[]): string {
     const isFailedRun = stats.failures > 0;
-    let summary = tag("h3", [], "Summary") + eol();
+    let summary = tag("h3", [], "Summary");
+    summary += EOL;
     summary += list([
         ...(stats.passes > 0 ? [`✅ ${stats.passes} passing test(s)`] : []),
         ...(stats.failures > 0 ? [`❌ ${stats.failures} failing test(s)`] : []),
         ...(stats.pending > 0 ? [`⚠️ ${stats.pending} pending test(s)`] : []),
     ]);
+    summary += EOL;
     if (isFailedRun) {
         summary += tag("h3", [], "Test Failures");
+        summary += EOL;
         summary += list(
             failures.map(failure => {
                 const errorMessage = generateErrorMessage(failure);
                 return (
-                    eol() +
+                    EOL +
                     tag("h5", [], fullTitle(failure)) +
-                    eol() +
-                    tag("pre", [], eol() + errorMessage + eol()) +
-                    eol()
+                    EOL +
+                    tag("pre", [], fixLineEndings(errorMessage)) +
+                    EOL
                 );
             })
         );
+        summary += EOL;
     }
-    return details(`${isFailedRun ? "❌" : "✅"} ${title}`, isFailedRun, summary) + eol();
+    return details(`${isFailedRun ? "❌" : "✅"} ${title}`, isFailedRun, summary) + EOL;
 }

--- a/test/utilities/diagnostics.ts
+++ b/test/utilities/diagnostics.ts
@@ -1,0 +1,177 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+import { SwiftTask } from "@src/tasks/SwiftTaskProvider";
+import { Disposable } from "@src/utilities/Disposable";
+
+import { executeTaskAndWaitForResult } from "./tasks";
+import { withTimeout } from "./withTimeout";
+
+import stripAnsi = require("strip-ansi");
+
+function severityToString(severity: vscode.DiagnosticSeverity): string {
+    switch (severity) {
+        case vscode.DiagnosticSeverity.Error:
+            return "Error";
+        case vscode.DiagnosticSeverity.Warning:
+            return "Warning";
+        case vscode.DiagnosticSeverity.Information:
+            return "Information";
+        case vscode.DiagnosticSeverity.Hint:
+            return "Hint";
+    }
+}
+
+function rangeToString(r: vscode.Range): string {
+    return `[start: [${r.start.line}:${r.start.character}], end: [${r.end.line}:${r.end.character}]]`;
+}
+
+function diagnosticToString(d: vscode.Diagnostic): string {
+    return `[${severityToString(d.severity)}] ${rangeToString(d.range)} ${d.message}`;
+}
+
+function diagnosticMapToString(map: Map<vscode.Uri, vscode.Diagnostic[]>): string {
+    const mapArray = Array.from(map.entries())
+        .map<[string, vscode.Diagnostic[]]>(([uri, diagnostics]) => [uri.fsPath, diagnostics])
+        .sort(([pathA], [pathB]) => pathA.localeCompare(pathB));
+    const mapObject: { [key: string]: string[] } = {};
+    for (const [filePath, diagnostics] of mapArray) {
+        mapObject[filePath] = diagnostics.map(diagnosticToString);
+    }
+    return JSON.stringify(mapObject, undefined, 2);
+}
+
+function isEqual(d1: vscode.Diagnostic, d2: vscode.Diagnostic): boolean {
+    return (
+        d1.severity === d2.severity &&
+        d1.source === d2.source &&
+        d1.message === d2.message &&
+        d1.range.isEqual(d2.range)
+    );
+}
+
+export function diagnosticMatcher(expected: vscode.Diagnostic): (d: vscode.Diagnostic) => boolean {
+    return d => isEqual(d, expected);
+}
+
+export function assertHasDiagnostic(
+    uri: vscode.Uri,
+    expected: vscode.Diagnostic
+): vscode.Diagnostic {
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    const diagnostic = diagnostics.find(diagnosticMatcher(expected));
+    assert.notEqual(
+        diagnostic,
+        undefined,
+        `Could not find diagnostic matching:\n${JSON.stringify(expected)}\nDiagnostics found:\n${JSON.stringify(diagnostics)}`
+    );
+    return diagnostic!;
+}
+
+export function assertWithoutDiagnostic(uri: vscode.Uri, expected: vscode.Diagnostic) {
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    assert.equal(
+        diagnostics.find(diagnosticMatcher(expected)),
+        undefined,
+        `Unexpected diagnostic matching:\n${JSON.stringify(expected)}\nDiagnostics:\n${JSON.stringify(diagnostics)}`
+    );
+}
+
+export type ExpectedDiagnostics = { [uri: string]: vscode.Diagnostic[] };
+
+export function waitForDiagnosticsCleared(uri: vscode.Uri): Promise<void> {
+    return new Promise<void>(resolve => {
+        const diagnosticDisposable = vscode.languages.onDidChangeDiagnostics(() => {
+            if (vscode.languages.getDiagnostics(uri).length === 0) {
+                diagnosticDisposable?.dispose();
+                resolve();
+            }
+        });
+    });
+}
+
+function filterDiagnosticsFromVSCode(
+    expectedDiagnostics: Map<vscode.Uri, vscode.Diagnostic[]>
+): Map<vscode.Uri, vscode.Diagnostic[]> {
+    const allRemainingDiagnostics = new Map<vscode.Uri, vscode.Diagnostic[]>();
+    for (const [fileUri, expectedFileDiagnostics] of expectedDiagnostics.entries()) {
+        const fileDiagnostics = vscode.languages.getDiagnostics(fileUri);
+        const remainingFileDiagnostics = expectedFileDiagnostics.filter(
+            d => fileDiagnostics.findIndex(diagnosticMatcher(d)) < 0
+        );
+        if (remainingFileDiagnostics.length > 0) {
+            allRemainingDiagnostics.set(fileUri, remainingFileDiagnostics);
+        }
+    }
+    return allRemainingDiagnostics;
+}
+
+/**
+ * Waits for the provided diagnostics to be reported by VS Code.
+ *
+ * If the diagnostics do not appear after a short timeout then the promise will be rejected. The error
+ * message contains information about which diagnostics were not found.
+ *
+ * @param expectedDiagnostics The diagnostics that should be present.
+ */
+export function waitForDiagnostics(expectedDiagnostics: ExpectedDiagnostics): Promise<void> {
+    let remainingDiagnostics = new Map<vscode.Uri, vscode.Diagnostic[]>();
+    Object.keys(expectedDiagnostics).forEach(filePath => {
+        remainingDiagnostics.set(vscode.Uri.file(filePath), expectedDiagnostics[filePath]);
+    });
+    remainingDiagnostics = filterDiagnosticsFromVSCode(remainingDiagnostics);
+    if (remainingDiagnostics.size === 0) {
+        return Promise.resolve();
+    }
+
+    // If there are outsanding diagnostics then we need to wait for them to arrive
+    const subscriptions: Disposable[] = [];
+    return withTimeout<void>(
+        token =>
+            new Promise<void>(resolve => {
+                subscriptions.push(
+                    token.onCancellationRequested(resolve),
+                    vscode.languages.onDidChangeDiagnostics(() => {
+                        remainingDiagnostics = filterDiagnosticsFromVSCode(remainingDiagnostics);
+                        if (remainingDiagnostics.size === 0) {
+                            resolve();
+                        }
+                    })
+                );
+            }),
+        10_000
+    )
+        .catch(error => {
+            throw Error(
+                `The following diagnostics were not found: ${diagnosticMapToString(remainingDiagnostics)}`,
+                { cause: error }
+            );
+        })
+        .finally(() => subscriptions.forEach(s => s.dispose()));
+}
+
+export async function executeTaskAndWaitForDiagnostics(
+    task: SwiftTask | Promise<SwiftTask>,
+    expectedDiagnostics: ExpectedDiagnostics
+): Promise<void> {
+    const { output: taskOutput } = await executeTaskAndWaitForResult(await task);
+    return waitForDiagnostics(expectedDiagnostics).catch(error => {
+        throw Error(
+            `Failed to get diagnostics after running the task. Task output:\n\n${stripAnsi(taskOutput)}`,
+            { cause: error }
+        );
+    });
+}

--- a/test/utilities/diagnostics.ts
+++ b/test/utilities/diagnostics.ts
@@ -18,9 +18,8 @@ import { SwiftTask } from "@src/tasks/SwiftTaskProvider";
 import { Disposable } from "@src/utilities/Disposable";
 
 import { executeTaskAndWaitForResult } from "./tasks";
+import { fixProcessOutput } from "./terminal";
 import { withTimeout } from "./withTimeout";
-
-import stripAnsi = require("strip-ansi");
 
 function severityToString(severity: vscode.DiagnosticSeverity): string {
     switch (severity) {
@@ -168,9 +167,9 @@ export async function executeTaskAndWaitForDiagnostics(
     expectedDiagnostics: ExpectedDiagnostics
 ): Promise<void> {
     const { output: taskOutput } = await executeTaskAndWaitForResult(await task);
-    return waitForDiagnostics(expectedDiagnostics).catch(error => {
+    return waitForDiagnostics(expectedDiagnostics).catch(async error => {
         throw Error(
-            `Failed to get diagnostics after running the task. Task output:\n\n${stripAnsi(taskOutput)}`,
+            `Failed to get diagnostics after running the task. Task output:\n\n${await fixProcessOutput(taskOutput)}`,
             { cause: error }
         );
     });

--- a/test/utilities/terminal.ts
+++ b/test/utilities/terminal.ts
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { Terminal } from "@xterm/headless";
+
+import stripAnsi = require("strip-ansi");
+
+/**
+ * Takes the output from a terminal process and returns the final state of the terminal
+ * buffer as seen by the end user.
+ *
+ * @param output The output from the terminal process.
+ * @returns A string that contains the final state of the terminal buffer at process exit.
+ */
+export function fixProcessOutput(output: string): Promise<string> {
+    const terminal = new Terminal({ allowProposedApi: true });
+    const serializeAddon = new SerializeAddon();
+    terminal.loadAddon(serializeAddon);
+    return new Promise<string>((resolve, reject) => {
+        try {
+            terminal.write(output, () => {
+                try {
+                    resolve(stripAnsi(serializeAddon.serialize()));
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        } catch (error) {
+            reject(error);
+        }
+    }).finally(() => {
+        terminal.dispose();
+        serializeAddon.dispose();
+    });
+}

--- a/test/utilities/withTimeout.ts
+++ b/test/utilities/withTimeout.ts
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import * as vscode from "vscode";
+
+export type TimeoutTask<T> = (token: vscode.CancellationToken) => Promise<T>;
+
+/**
+ * Executes the provided task. The promise will be rejected if the time spent exceeds the provided timeout.
+ *
+ * @param task The task to execute.
+ * @param timeout The timeout in milliseconds.
+ */
+export function withTimeout<T>(task: TimeoutTask<T>, timeout: number): Promise<T> {
+    const cancellation = new vscode.CancellationTokenSource();
+    return Promise.race([
+        task(cancellation.token),
+        new Promise<never>((_resolve, reject) =>
+            setTimeout(() => {
+                reject(new Error(`Operation timed out after ${timeout}ms`));
+                setImmediate(() => cancellation.cancel());
+            }, timeout)
+        ),
+    ]);
+}


### PR DESCRIPTION
## Description
Clean up various aspects of our CI workflows:
- Remove outdated swift versions
  - `Nightly` will now run tests against all active Swift versions
  - `Nightly - VS Code Insiders` will now run tests against only `nightly-6.3` and `nightly-main` Swift toolchains
- Rename the `tests` job to be more consistent between workflows
- Include the build output when DiagnosticsManager's tests fail
- Print the cause(s) of an error in the job summary if a test fails

The DiagnosticsManager test suite has been failing against nightly-main. This was tracked down to two issues:
1.  Debug builds are now bailing early when encountering errors. Run release builds for the test suite to force the build system to do a monolithic build that will report more errors.
2. There was a legitimate issue in the DiagnosticsManager where terminal output would be mangled because we weren't properly handling terminal control sequences, resulting in diagnostics being missed. We will now use a headless Xterm in order to get the true process output as seen by the end user in the terminal.

I've also disabled the tests involving code coverage on Windows with Swift nightly-main because they are currently failing due to swiftlang/swift-build#1353.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
