### PR TITLE
Throw when debugging no tests

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -567,6 +567,9 @@ export class TestingConfigurationFactory {
         if (args.length === 0) {
             return args;
         }
+        if (this.testList.length === 0) {
+            throw new Error("There were no tests found to launch.");
+        }
         return ["-XCTest", this.testList.join(","), ...args];
     }
 


### PR DESCRIPTION
When the user hits "debug all" when there are no tests we still try and create/perform a test run. When crafting the arguments for XCTest we would create an empty `-XCTest` argument, which would throw a large and not very helpful error in the context of a VS Code test run.

Throw an error when there are no tests given to `-XCTest`, which should make it more clear what happened.
