### PR TITLE
Fix swift-testing timeout when doing a Run All tests w/ multiple test targets with swift-build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## {{releaseVersion}} - {{releaseDate}}
 
+### Fixed
+
+- Fix swift-testing timeout when doing a Run All tests w/ multiple test targets when using swift-build ([#2207](https://github.com/swiftlang/vscode-swift/pull/2207))
+
 ## 2.16.4 - 2026-04-21
 
 ### Added

--- a/assets/test/defaultPackage/Package.swift
+++ b/assets/test/defaultPackage/Package.swift
@@ -28,5 +28,8 @@ let package = Package(
         .testTarget(
             name: "PackageTests",
             dependencies: ["PackageLib"]),
+        .testTarget(
+            name: "PackageTests2",
+            dependencies: ["PackageLib"]),
     ]
 )

--- a/assets/test/defaultPackage/Package@swift-6.0.swift
+++ b/assets/test/defaultPackage/Package@swift-6.0.swift
@@ -32,5 +32,9 @@ let package = Package(
             name: "PackageTests",
             dependencies: ["PackageLib"]
         ),
+        .testTarget(
+            name: "PackageTests2",
+            dependencies: ["PackageLib"]
+        ),
     ]
 )

--- a/assets/test/defaultPackage/Tests/PackageTests2/PackageTests2.swift
+++ b/assets/test/defaultPackage/Tests/PackageTests2/PackageTests2.swift
@@ -1,0 +1,13 @@
+#if swift(>=6.0)
+import Testing
+
+@Test func secondTargetTestPassing() {
+  #expect(1 == 1)
+}
+
+@Suite
+struct SecondTargetSuite {
+  @Test
+  func testPassing() throws {}
+}
+#endif

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -11,11 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-import { exec } from "child_process";
 import * as readline from "readline";
 import { Readable } from "stream";
 import * as vscode from "vscode";
 
+import { SwiftLogger } from "../../logging/SwiftLogger";
 import { lineBreakRegex } from "../../utilities/tasks";
 import { colorize, sourceLocationToVSCodeLocation } from "../../utilities/utilities";
 import { TestClass } from "../TestDiscovery";
@@ -197,11 +197,12 @@ export type SourceLocation = {
 export class SwiftTestingOutputParser {
     private completionMap = new Map<number, boolean>();
     private testCaseMap = new Map<string, Map<string, TestCase>>();
-    private path?: string;
+    private reader?: INamedPipeReader;
 
     constructor(
         public addParameterizedTestCases: (testClasses: TestClass[], parentIndex: number) => void,
-        public onAttachment: (testIndex: number, path: string) => void
+        public onAttachment: (testIndex: number, path: string) => void,
+        private logger?: SwiftLogger
     ) {}
 
     /**
@@ -213,10 +214,8 @@ export class SwiftTestingOutputParser {
         runState: ITestRunState,
         pipeReader?: INamedPipeReader
     ): Promise<void> {
-        this.path = path;
-
         // Creates a reader based on the platform unless being provided in a test context.
-        const reader = pipeReader ?? this.createReader(path);
+        this.reader = pipeReader ?? this.createReader(path);
         const readlinePipe = new Readable({
             read() {},
         });
@@ -228,26 +227,33 @@ export class SwiftTestingOutputParser {
             crlfDelay: Infinity,
         });
 
-        rl.on("line", line => this.parse(JSON.parse(line), runState));
+        // A thrown `SyntaxError` here would escalate to `uncaughtException` on
+        // the extension host because readline dispatches the listener
+        // synchronously. Swallow the bad line and carry on so one malformed
+        // payload can't bring the extension down.
+        rl.on("line", line => {
+            try {
+                this.parse(JSON.parse(line), runState);
+            } catch (error) {
+                this.logger?.error(
+                    `Failed to parse swift-testing event: ${error instanceof Error ? error.message : String(error)} line=${line}`
+                );
+            }
+        });
 
-        void reader.start(readlinePipe);
+        void this.reader.start(readlinePipe);
     }
 
     /**
-     * Closes the FIFO pipe after a test run. This must be called at the
-     * end of a run regardless of the run's success or failure.
+     * Stops the FIFO reader after a test run. This must be called at the
+     * end of a run regardless of the run's success or failure, because the
+     * reader holds the FIFO open (O_RDWR on Unix, a listening server on
+     * Windows) and would otherwise block EOF from ever reaching the parser.
      */
     public async close() {
-        if (!this.path) {
-            return;
-        }
-
-        await new Promise<void>(resolve => {
-            // eslint-disable-next-line sonarjs/os-command
-            exec(`echo '{}' > ${this.path}`, () => {
-                resolve();
-            });
-        });
+        const reader = this.reader;
+        this.reader = undefined;
+        await reader?.stop();
     }
 
     /**
@@ -265,8 +271,8 @@ export class SwiftTestingOutputParser {
 
     private createReader(path: string): INamedPipeReader {
         return process.platform === "win32"
-            ? new WindowsNamedPipeReader(path)
-            : new UnixNamedPipeReader(path);
+            ? new WindowsNamedPipeReader(path, this.logger)
+            : new UnixNamedPipeReader(path, this.logger);
     }
 
     private parse(item: SwiftTestEvent, runState: ITestRunState) {

--- a/src/TestExplorer/TestParsers/TestEventStreamReader.ts
+++ b/src/TestExplorer/TestParsers/TestEventStreamReader.ts
@@ -14,9 +14,15 @@
 import * as fs from "fs";
 import * as net from "net";
 import { Readable } from "stream";
+import { promisify } from "util";
+
+import { SwiftLogger } from "../../logging/SwiftLogger";
+
+const openAsync = promisify(fs.open);
 
 export interface INamedPipeReader {
     start(readable: Readable): Promise<void>;
+    stop(): Promise<void>;
 }
 
 /**
@@ -24,25 +30,45 @@ export interface INamedPipeReader {
  * Note that the path must be in the Windows named pipe format of `\\.\pipe\pipename`.
  */
 export class WindowsNamedPipeReader implements INamedPipeReader {
-    constructor(private path: string) {}
+    private server?: net.Server;
+    private readable?: Readable;
+
+    constructor(
+        private path: string,
+        private logger?: SwiftLogger
+    ) {}
 
     public async start(readable: Readable) {
+        this.readable = readable;
         return new Promise<void>((resolve, reject) => {
             try {
-                const server = net.createServer(function (stream) {
+                // `swift test` w/ swift-testing tests launches one test target subprocess at a time.
+                // Each one opens a fresh connection to the named pipe, writes its events, and
+                // closes. The server must keep listening across connections so that
+                // every target's events reach the parser.
+                const server = net.createServer(stream => {
                     stream.on("data", data => readable.push(data));
-                    stream.on("error", () => server.close());
-                    stream.on("end", function () {
-                        readable.push(null);
-                        server.close();
+                    stream.on("error", err => {
+                        this.logger?.warn(`swift-testing pipe connection error: ${err.message}`);
                     });
                 });
-
+                this.server = server;
                 server.listen(this.path, () => resolve());
             } catch (error) {
                 reject(error);
             }
         });
+    }
+
+    public async stop(): Promise<void> {
+        const server = this.server;
+        const readable = this.readable;
+        this.server = undefined;
+        this.readable = undefined;
+        if (server) {
+            await new Promise<void>(resolve => server.close(() => resolve()));
+        }
+        readable?.push(null);
     }
 }
 
@@ -52,38 +78,78 @@ export class WindowsNamedPipeReader implements INamedPipeReader {
  * before calling `start()`.
  */
 export class UnixNamedPipeReader implements INamedPipeReader {
-    constructor(private path: string) {}
+    private guardFd?: number;
+    private pipe?: fs.ReadStream;
+
+    constructor(
+        private path: string,
+        private logger?: SwiftLogger
+    ) {}
 
     public async start(readable: Readable) {
-        return new Promise<void>((resolve, reject) => {
-            fs.open(this.path, fs.constants.O_RDONLY, (err, fd) => {
-                if (err) {
-                    return reject(err);
+        const guardFd = await openAsync(this.path, fs.constants.O_RDWR);
+        this.guardFd = guardFd;
+
+        // With the guard writer held open, the dedicated read fd can be
+        // opened without blocking and will receive EOF only when we
+        // explicitly close the guard in `stop()`.
+        let readFd: number;
+        try {
+            readFd = await openAsync(this.path, fs.constants.O_RDONLY);
+        } catch (error) {
+            fs.close(guardFd, () => {});
+            this.guardFd = undefined;
+            throw error;
+        }
+
+        // Using a net.Socket to read the pipe has an 8kb internal buffer,
+        // meaning we couldn't read from writes that were > 8kb.
+        const pipe = fs.createReadStream("", { fd: readFd, autoClose: true });
+        this.pipe = pipe;
+        pipe.on("data", data => {
+            if (!readable.push(data)) {
+                pipe.pause();
+            }
+        });
+        readable.on("drain", () => pipe.resume());
+        pipe.on("error", err => {
+            this.logger?.warn(`swift-testing pipe read error: ${err.message}`);
+        });
+        pipe.on("end", () => {
+            readable.push(null);
+        });
+    }
+
+    public async stop(): Promise<void> {
+        const guardFd = this.guardFd;
+        const pipe = this.pipe;
+        this.guardFd = undefined;
+        this.pipe = undefined;
+        if (guardFd === undefined) {
+            return;
+        }
+
+        // Dropping the guard writer lets the kernel deliver EOF to the read
+        // fd, which triggers the stream's "end" handler above and closes the
+        // read fd via autoClose. We wait for both the guard close and the
+        // read stream to fully drain so callers can rely on all buffered
+        // events having reached the parser before the FIFO is unlinked.
+        const pipeDrained =
+            pipe && !pipe.closed
+                ? new Promise<void>(resolve => pipe.once("close", () => resolve()))
+                : Promise.resolve();
+
+        const guardClosed = new Promise<void>(resolve => {
+            fs.close(guardFd, closeErr => {
+                if (closeErr) {
+                    this.logger?.warn(
+                        `Failed to close swift-testing FIFO guard fd: ${closeErr.message}`
+                    );
                 }
-                try {
-                    // Create our own readable stream that handles backpressure.
-                    // Using a net.Socket to read the pipe has an 8kb internal buffer,
-                    // meaning we couldn't read from writes that were > 8kb.
-                    const pipe = fs.createReadStream("", { fd });
-
-                    pipe.on("data", data => {
-                        if (!readable.push(data)) {
-                            pipe.pause();
-                        }
-                    });
-
-                    readable.on("drain", () => pipe.resume());
-                    pipe.on("error", () => pipe.close());
-                    pipe.on("end", () => {
-                        readable.push(null);
-                        fs.close(fd);
-                    });
-
-                    resolve();
-                } catch (error) {
-                    fs.close(fd, () => reject(error));
-                }
+                resolve();
             });
         });
+
+        await Promise.all([guardClosed, pipeDrained]);
     }
 }

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -105,7 +105,8 @@ export class TestRunner {
                 : new XCTestOutputParser();
         this.swiftTestOutputParser = new SwiftTestingOutputParser(
             this.testRun.addParameterizedTestCases.bind(this.testRun),
-            this.testRun.addAttachment.bind(this.testRun)
+            this.testRun.addAttachment.bind(this.testRun),
+            this.folderContext.workspaceContext.logger
         );
         this.onDebugSessionTerminated = this.debugSessionTerminatedEmitter.event;
     }
@@ -119,7 +120,8 @@ export class TestRunner {
         // The SwiftTestingOutputParser holds state and needs to be reset between iterations.
         this.swiftTestOutputParser = new SwiftTestingOutputParser(
             this.testRun.addParameterizedTestCases,
-            this.testRun.addAttachment
+            this.testRun.addAttachment,
+            this.folderContext.workspaceContext.logger
         );
         this.testRun.setIteration(iteration);
     }
@@ -446,13 +448,22 @@ export class TestRunner {
 
                 this.testRun.testRunStarted();
 
-                await this.launchTests(
-                    runState,
-                    this.testKind === TestKind.parallel ? TestKind.standard : this.testKind,
-                    outputStream,
-                    testBuildConfig,
-                    TestLibrary.swiftTesting
-                );
+                try {
+                    await this.launchTests(
+                        runState,
+                        this.testKind === TestKind.parallel ? TestKind.standard : this.testKind,
+                        outputStream,
+                        testBuildConfig,
+                        TestLibrary.swiftTesting
+                    );
+                } finally {
+                    // The reader holds the FIFO open (O_RDWR on Unix, a listening
+                    // server on Windows) so that sequential writers from each test
+                    // target can all reach the parser. Now that `swift test` has
+                    // exited we must stop the reader to release the fd before the
+                    // FIFO is unlinked below.
+                    await this.swiftTestOutputParser.close();
+                }
 
                 await SwiftTestingConfigurationSetup.cleanupAttachmentFolder(
                     this.folderContext,
@@ -520,8 +531,6 @@ export class TestRunner {
                 // `testRunStarted()` to flush the buffer of test result output, the build error will be silently
                 // discarded. If the test run has already started this is a no-op so its safe to call it multiple times.
                 this.testRun.testRunStarted();
-
-                void this.swiftTestOutputParser.close();
             }
 
             // If there is a compilation error the tests slated to be run are marked as 'skipped' and not 'failed'.

--- a/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -38,6 +38,8 @@ class TestEventStream {
         });
         readable.push(null);
     }
+
+    async stop() {}
 }
 
 suite("SwiftTestingOutputParser Suite", () => {

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -221,6 +221,8 @@ tag("large").suite("Test Explorer Suite", function () {
                 // 6.0 uses the LSP which returns tests in the order they're declared.
                 // Includes swift-testing tests.
                 assertTestControllerHierarchy(testExplorer.controller, [
+                    "PackageTests2",
+                    ["secondTargetTestPassing()", "SecondTargetSuite", ["testPassing()"]],
                     "PackageTests",
                     [
                         "PassingXCTestSuite",
@@ -254,6 +256,8 @@ tag("large").suite("Test Explorer Suite", function () {
                 // 5.10 uses `swift test list` which returns test alphabetically, without the round brackets.
                 // Does not include swift-testing tests.
                 assertTestControllerHierarchy(testExplorer.controller, [
+                    "PackageTests2",
+                    ["secondTargetTestPassing()", "SecondTargetSuite", ["testPassing()"]],
                     "PackageTests",
                     [
                         "CrashingXCTests",
@@ -456,6 +460,22 @@ tag("large").suite("Test Explorer Suite", function () {
                             test: "PackageTests.testRelease()",
                             issues: [issueText],
                         },
+                    ],
+                });
+            });
+
+            test("runs tests across multiple targets in one invocation", async () => {
+                const testRun = await runTest(
+                    testExplorer,
+                    TestKind.standard,
+                    "PackageTests.topLevelTestPassing()",
+                    "PackageTests2.secondTargetTestPassing()"
+                );
+
+                assertTestResults(testRun, {
+                    passed: [
+                        "PackageTests.topLevelTestPassing()",
+                        "PackageTests2.secondTargetTestPassing()",
                     ],
                 });
             });
@@ -1005,6 +1025,16 @@ tag("large").suite("Test Explorer Suite", function () {
 
         type TestHierarchy = string | TestHierarchy[];
 
+        function packageTestsChildren(testItems: TestHierarchy): TestHierarchy[] {
+            if (!Array.isArray(testItems)) {
+                return [];
+            }
+            const index = testItems.indexOf("PackageTests");
+            return index >= 0 && Array.isArray(testItems[index + 1])
+                ? (testItems[index + 1] as TestHierarchy[])
+                : [];
+        }
+
         // Because we're at the whim of how often VS Code/the LSP provide document symbols
         // we can't assume that changes to test items will be reflected in the next onTestItemsDidChange
         // so poll until the condition is met.
@@ -1030,14 +1060,14 @@ tag("large").suite("Test Explorer Suite", function () {
                 appendSource(newTest),
             ]);
 
-            await validate(testItems => testItems[1].includes(testName));
+            await validate(testItems => packageTestsChildren(testItems).includes(testName));
 
             await Promise.all([
                 eventPromise(testExplorer.onTestItemsDidChange),
                 setSource(originalSource),
             ]);
 
-            await validate(testItems => !testItems[1].includes(testName));
+            await validate(testItems => !packageTestsChildren(testItems).includes(testName));
         });
 
         test("Test explorer updates when a suite is added and removed", async () => {
@@ -1047,13 +1077,13 @@ tag("large").suite("Test Explorer Suite", function () {
                 eventPromise(testExplorer.onTestItemsDidChange),
                 appendSource(newSuite),
             ]);
-            await validate(testItems => testItems[1].includes(suiteName));
+            await validate(testItems => packageTestsChildren(testItems).includes(suiteName));
 
             await Promise.all([
                 eventPromise(testExplorer.onTestItemsDidChange),
                 setSource(originalSource),
             ]);
-            await validate(testItems => !testItems[1].includes(suiteName));
+            await validate(testItems => !packageTestsChildren(testItems).includes(suiteName));
         });
 
         afterEach(async () => {

--- a/test/unit-tests/testexplorer/TestEventStreamReader.test.ts
+++ b/test/unit-tests/testexplorer/TestEventStreamReader.test.ts
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import * as assert from "assert";
+import { execFile } from "child_process";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import { afterEach, beforeEach } from "mocha";
+import * as os from "os";
+import * as path from "path";
+import { Readable } from "stream";
+import { promisify } from "util";
+
+import { UnixNamedPipeReader } from "@src/TestExplorer/TestParsers/TestEventStreamReader";
+
+const execFileAsync = promisify(execFile);
+
+suite("UnixNamedPipeReader Suite", () => {
+    let fifoPath: string;
+
+    beforeEach(async function () {
+        if (process.platform === "win32") {
+            this.skip();
+            return;
+        }
+        fifoPath = path.join(
+            os.tmpdir(),
+            `vscode-swift-test-fifo-${Date.now()}-${crypto.randomBytes(6).toString("hex")}`
+        );
+        await execFileAsync("mkfifo", [fifoPath]);
+    });
+
+    afterEach(() => {
+        if (fifoPath && fs.existsSync(fifoPath)) {
+            fs.unlinkSync(fifoPath);
+        }
+    });
+
+    function collectData(readable: Readable): Promise<string> {
+        return new Promise(resolve => {
+            let out = "";
+            readable.on("data", chunk => {
+                out += chunk.toString();
+            });
+            readable.on("end", () => resolve(out));
+        });
+    }
+
+    async function writeAndClose(filePath: string, data: string): Promise<void> {
+        await fs.promises.writeFile(filePath, data);
+    }
+
+    test("delivers data from a single writer", async () => {
+        const reader = new UnixNamedPipeReader(fifoPath);
+        const readable = new Readable({ read() {} });
+        const collected = collectData(readable);
+
+        await reader.start(readable);
+        await writeAndClose(fifoPath, "hello\n");
+        await reader.stop();
+
+        const result = await collected;
+        assert.strictEqual(result, "hello\n");
+    });
+
+    test("delivers data from multiple sequential writers without blocking", async () => {
+        // Regression test for the "first suite runs, then hangs" bug.
+        // `swift test` spawns one subprocess per test target, each opens/writes/closes
+        // the shared FIFO in sequence. Without a persistent writer reference on the
+        // reader's side the first writer's EOF tears the reader down, and the second
+        // writer blocks forever on open().
+        const reader = new UnixNamedPipeReader(fifoPath);
+        const readable = new Readable({ read() {} });
+        const collected = collectData(readable);
+
+        await reader.start(readable);
+
+        await writeAndClose(fifoPath, "suite-1\n");
+        await writeAndClose(fifoPath, "suite-2\n");
+        await writeAndClose(fifoPath, "suite-3\n");
+
+        await reader.stop();
+
+        const result = await collected;
+        assert.strictEqual(result, "suite-1\nsuite-2\nsuite-3\n");
+    });
+
+    test("stop() terminates the readable with EOF", async () => {
+        const reader = new UnixNamedPipeReader(fifoPath);
+        const readable = new Readable({ read() {} });
+
+        await reader.start(readable);
+
+        const endPromise = new Promise<void>(resolve => readable.on("end", () => resolve()));
+        readable.on("data", () => {});
+        await reader.stop();
+
+        await endPromise;
+    });
+
+    test("stop() resolves only after buffered data has drained", async () => {
+        const reader = new UnixNamedPipeReader(fifoPath);
+        const readable = new Readable({ read() {} });
+        const collected = collectData(readable);
+
+        await reader.start(readable);
+        await writeAndClose(fifoPath, "trailing\n");
+
+        // stop() must not resolve until the kernel has delivered EOF and the
+        // read stream has drained. After it resolves, all data should be visible.
+        await reader.stop();
+
+        const result = await collected;
+        assert.strictEqual(result, "trailing\n");
+    });
+});


### PR DESCRIPTION
## Description
Running a swift-testing Test Run Request that spans more than one test target sequentially launches one test-binary subprocess per target. As SwiftPM iterates these test binaries the JSON event stream is written to, however at the end of the first binary's tests an EOF was sent to the reader by the extension. The pipe was town down and the second subprocess then blocked forever on `open(fifo, O_WRONLY)` with no reader present.

`UnixNamedPipeReader` now holds a guard fd open with `O_RDWR` for the duration of the run so the kernel never delivers EOF between external writers. A second `O_RDONLY` fd feeds the `ReadStream`. `stop()` closes the guard, which lets EOF propagate naturally, cleanly ending the stream. `WindowsNamedPipeReader` keeps its server listening across connections and closes it in `stop()`. The parser's `close()` now tears the reader down instead of writing an `echo '{}'` sentinel, and `TestRunner.runSession()` calls it unconditionally after `launchTests`.

The regression escaped integration tests because `defaultPackage` had only one test target, so the multi-filter path was never exercised.

Add a second swift-testing target (`PackageTests2`) and a new test that runs tests across both targets in one invocation. Also added `UnixNamedPipeReader` unit tests covering single-writer, sequential multi-writer, and `stop()` teardown.

Also improved the logging for failure cases when parsing JSONL entries.

## Tasks
- [X] Required tests have been written
- [X] ~Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
