### PR TITLE
Re-enable nightly code coverage tests

### DIFF
--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -695,22 +695,6 @@ tag("large").suite("Test Explorer Suite", function () {
             });
 
             suite(runProfile, () => {
-                suiteSetup(function () {
-                    // Code coverage is currently not working in Windows with the latest nightly-main toolchain
-                    // See https://github.com/swiftlang/swift/issues/88607
-                    if (
-                        runProfile === TestKind.coverage &&
-                        process.platform === "win32" &&
-                        workspaceContext.globalToolchain.swiftVersion.isGreaterThanOrEqual({
-                            major: 6,
-                            minor: 4,
-                            patch: 0,
-                        })
-                    ) {
-                        this.skip();
-                    }
-                });
-
                 suite(`swift-testing (${runProfile})`, function () {
                     suiteSetup(function () {
                         if (


### PR DESCRIPTION
## Description
The upstream issue preventing our code coverage tests from running should be fixed. Re-enable the tests that were skipped.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
