### PR TITLE
Fix swiftly toolchain invocations

### DIFF
--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -448,15 +448,10 @@ export class TestingConfigurationFactory {
             args = [...args, "--disable-xctest"];
         }
 
-        const inv = this.ctx.toolchain.getToolchainInvocation(
-            "swift",
-            this.addBuildOptionsToArgs(this.addTestsToArgs(args))
-        );
-
         return {
             ...baseConfig,
-            program: inv.command,
-            args: inv.args,
+            program: "swift",
+            args: this.addBuildOptionsToArgs(this.addTestsToArgs(args)),
             env: {
                 ...this.testEnv,
                 ...this.sanitizerRuntimeEnvironment,
@@ -512,15 +507,10 @@ export class TestingConfigurationFactory {
             xcTestArgs = [...xcTestArgs, "--parallel"];
         }
 
-        const inv = this.ctx.toolchain.getToolchainInvocation(
-            "swift",
-            this.addBuildOptionsToArgs(this.addTestsToArgs(xcTestArgs))
-        );
-
         return {
             ...baseConfig,
-            program: inv.command,
-            args: inv.args,
+            program: "swift",
+            args: this.addBuildOptionsToArgs(this.addTestsToArgs(xcTestArgs)),
             env: {
                 ...this.testEnv,
                 ...this.sanitizerRuntimeEnvironment,

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -20,6 +20,7 @@ import { SwiftLogger } from "../logging/SwiftLogger";
 import { SwiftToolchain } from "../toolchain/toolchain";
 import { Disposable } from "../utilities/Disposable";
 import { fileExists } from "../utilities/filesystem";
+import { findBinaryInPath } from "../utilities/shell";
 import { getErrorDescription, swiftRuntimeEnv } from "../utilities/utilities";
 import { DebugAdapter, LaunchConfigType, SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 import { getTargetBinaryPath, swiftPrelaunchBuildTaskArguments } from "./launch";
@@ -317,6 +318,10 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
         }
 
         const inv = toolchain.getToolchainInvocation("lldb-dap", []);
+        // lldb-dap requires that the debugAdapterExecutable always be an absolute path.
+        if (!path.isAbsolute(inv.command)) {
+            inv.command = await findBinaryInPath(inv.command);
+        }
         launchConfig.debugAdapterExecutable = inv.command;
         launchConfig.debugAdapterArgs = inv.args;
         return true;

--- a/test/integration-tests/commands/runPlayground.test.ts
+++ b/test/integration-tests/commands/runPlayground.test.ts
@@ -93,7 +93,10 @@ suite("Run Playground Command", function () {
             expect(mockTaskManager.executeTaskAndWait).to.have.been.calledOnce;
 
             const task = mockTaskManager.executeTaskAndWait.args[0][0] as SwiftTask;
-            expect(task.execution.args).to.deep.equal(["play", "PackageLib/PackageLib.swift:3"]);
+            expect(task.execution.args).to.include.members([
+                "play",
+                "PackageLib/PackageLib.swift:3",
+            ]);
             expect(task.execution.options.cwd).to.equal(folderContext.folder.fsPath);
         });
 
@@ -106,7 +109,10 @@ suite("Run Playground Command", function () {
             expect(mockTaskManager.executeTaskAndWait).to.have.been.calledOnce;
 
             const task = mockTaskManager.executeTaskAndWait.args[0][0] as SwiftTask;
-            expect(task.execution.args).to.deep.equal(["play", "PackageLib/Package Lib.swift:3"]);
+            expect(task.execution.args).to.include.members([
+                "play",
+                "PackageLib/Package Lib.swift:3",
+            ]);
             expect(task.execution.options.cwd).to.equal(folderContext.folder.fsPath);
         });
 
@@ -120,7 +126,7 @@ suite("Run Playground Command", function () {
             expect(mockTaskManager.executeTaskAndWait).to.have.been.calledOnce;
 
             const task = mockTaskManager.executeTaskAndWait.args[0][0] as SwiftTask;
-            expect(task.execution.args).to.deep.equal(["play", "bar"]);
+            expect(task.execution.args).to.include.members(["play", "bar"]);
             expect(task.execution.options.cwd).to.equal(folderContext.folder.fsPath);
         });
     });

--- a/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -194,8 +194,7 @@ tag("medium").suite("SwiftPluginTaskProvider Test Suite", function () {
 
                 const swiftExecution = task?.execution as SwiftExecution;
                 expect(swiftExecution).to.not.be.undefined;
-                assert.deepEqual(
-                    swiftExecution.args,
+                expect(swiftExecution.args).to.include.members(
                     workspaceContext.globalToolchain.buildFlags.withAdditionalFlags([
                         "package",
                         ...expected,
@@ -257,7 +256,7 @@ tag("medium").suite("SwiftPluginTaskProvider Test Suite", function () {
                 });
 
                 test("provides", () => {
-                    expect(task?.execution.args).to.deep.equal(
+                    expect(task?.execution.args).to.include.members(
                         folderContext.toolchain.buildFlags.withAdditionalFlags([
                             "package",
                             "command_plugin",
@@ -288,7 +287,7 @@ tag("medium").suite("SwiftPluginTaskProvider Test Suite", function () {
                 });
 
                 test("provides", () => {
-                    expect(task?.execution.args).to.deep.equal(
+                    expect(task?.execution.args).to.include.members(
                         folderContext.toolchain.buildFlags.withAdditionalFlags([
                             "package",
                             "--disable-sandbox",

--- a/test/unit-tests/debugger/debugAdapterFactory.test.ts
+++ b/test/unit-tests/debugger/debugAdapterFactory.test.ts
@@ -25,6 +25,7 @@ import { SwiftLogger } from "@src/logging/SwiftLogger";
 import { BuildFlags } from "@src/toolchain/BuildFlags";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
 import { Result } from "@src/utilities/result";
+import * as shell from "@src/utilities/shell";
 import { Version } from "@src/utilities/version";
 
 import {
@@ -44,10 +45,15 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
     let mockToolchain: MockedObject<SwiftToolchain>;
     let mockBuildFlags: MockedObject<BuildFlags>;
     let mockLogger: MockedObject<SwiftLogger>;
+    const mockShellUtil = mockGlobalModule(shell);
     const mockDebugAdapter = mockGlobalObject(debugAdapter, "DebugAdapter");
     const mockWindow = mockGlobalObject(vscode, "window");
 
     setup(() => {
+        mockShellUtil.findBinaryInPath.rejects(
+            Error("findBinaryInPath() was not correctly mocked for this test.")
+        );
+        mockShellUtil.findBinaryInPath.withArgs("swiftly").resolves("/path/to/swiftly");
         mockBuildFlags = mockObject<BuildFlags>({ getBuildBinaryPath: mockFn() });
         mockToolchain = mockObject<SwiftToolchain>({
             swiftVersion: new Version(6, 0, 0),
@@ -637,7 +643,7 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
                 });
             expect(launchConfig).to.containSubset({
                 type: LaunchConfigType.LLDB_DAP,
-                debugAdapterExecutable: "swiftly",
+                debugAdapterExecutable: "/path/to/swiftly",
                 debugAdapterArgs: ["run", "lldb-dap"],
             });
         });
@@ -657,7 +663,7 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
                     program: "/home/user/myproject/.build/debug/MyApp",
                 });
             expect(launchConfig).to.containSubset({
-                debugAdapterExecutable: "swiftly",
+                debugAdapterExecutable: "/path/to/swiftly",
                 debugAdapterArgs: ["run", "lldb-dap"],
             });
             expect(mockWindow.showErrorMessage).to.not.have.been.called;

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -349,7 +349,6 @@ suite("LanguageClientManager Suite", () => {
 
     test("launches SourceKit-LSP via swiftly run for swiftly-managed toolchains", async () => {
         mockedToolchain.manager = "swiftly";
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (mockedToolchain as any).getToolchainInvocation = mockFn(s =>
             s
                 .withArgs("sourcekit-lsp", match.any)

--- a/test/unit-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/unit-tests/tasks/SwiftTaskProvider.test.ts
@@ -190,7 +190,6 @@ suite("SwiftTaskProvider Unit Test Suite", () => {
         });
 
         test("swiftly toolchain uses swiftly run swift invocation", () => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (toolchain as any).getToolchainInvocation = mockFn(s =>
                 s.withArgs("swift", match.any).callsFake((_exe: string, args: string[]) => ({
                     command: "swiftly",


### PR DESCRIPTION
## Description
The recent changes to how the extension invokes toolchains via swiftly broke a couple things:
- Launched tests were adding duplicate `swift run` args causing the command to fail.
- The `debugAdapterExecutable` was being set to `swiftly` which caused the LLDB DAP extension's check for the existence of that path to fail. It expects that the `debugAdapterExecutable` will be an absolute path.

This PR fixes the two issues above as well as several tests that were doing deep equality checks on the arguments array coming from Swift tasks. I'll be opening a follow up PR to run our nightly CI against a swiftly downloaded toolchain so that we can catch issues like this before they're merged.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
