### PR TITLE
Revert back to plist@3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-plugin-mocha"
         update-types: ["version-update:semver-major"]
+      # Next major version of plist is broken on Windows.
+      - dependency-name: "plist"
+        update-types: ["version-update:semver-major"]
       # Newer versions of fantasticon are broken on Windows.
       # https://github.com/tancredi/fantasticon/issues/470
       - dependency-name: "fantasticon"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "archiver": "^7.0.1",
         "fast-glob": "^3.3.3",
         "lcov-parse": "^1.0.0",
-        "plist": "^4.0.0",
+        "plist": "^3.1.0",
         "tar": "^7.5.13",
         "vscode-languageclient": "^9.0.1",
         "xml2js": "^0.6.2",
@@ -3904,11 +3904,12 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14.6"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xterm/addon-serialize": {
@@ -9912,15 +9913,17 @@
       }
     },
     "node_modules/plist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-4.0.0.tgz",
-      "integrity": "sha512-4dOqNo0Y2NpfSf9q4+zr4bh7pzNWeckIam34Z0KYJhg8qtNNfh59VbD+Yna5SjwcxawVvLKx5w5FtuCijpEF4Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=10.4.0"
       }
     },
     "node_modules/plist/node_modules/xmlbuilder": {
@@ -15868,9 +15871,9 @@
       "optional": true
     },
     "@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="
     },
     "@xterm/addon-serialize": {
       "version": "0.14.0",
@@ -20122,11 +20125,12 @@
       }
     },
     "plist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-4.0.0.tgz",
-      "integrity": "sha512-4dOqNo0Y2NpfSf9q4+zr4bh7pzNWeckIam34Z0KYJhg8qtNNfh59VbD+Yna5SjwcxawVvLKx5w5FtuCijpEF4Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
       "requires": {
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2184,7 +2184,7 @@
     "archiver": "^7.0.1",
     "fast-glob": "^3.3.3",
     "lcov-parse": "^1.0.0",
-    "plist": "^4.0.0",
+    "plist": "^3.1.0",
     "tar": "^7.5.13",
     "vscode-languageclient": "^9.0.1",
     "xml2js": "^0.6.2",

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -768,7 +768,12 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
         try {
             infoPlist = plist.parse(data) as unknown as InfoPlist;
         } catch (error) {
-            void vscode.window.showWarningMessage(`Unable to parse ${platformManifest}: ${error}`);
+            const parsingError = Error(
+                `Unable to parse ${platformManifest}. Tests explorer won't work as expected.`,
+                { cause: error }
+            );
+            logger?.error(parsingError);
+            void vscode.window.showWarningMessage(parsingError.message);
             return undefined;
         }
         const plistKey = type === "XCTest" ? "XCTEST_VERSION" : "SWIFT_TESTING_VERSION";


### PR DESCRIPTION
## Description
Parsing the platform manifest on Windows is failing after upgrading to the latest version of plist (v4.0.0). This is causing the Test Explorer to be unable to debug XCTest tests. Revert back to 3.1.0 for now until we can figure out what exactly is going wrong.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
