### PR TITLE
Clean up SwiftTaskProvider test suite

### DIFF
--- a/test/common.ts
+++ b/test/common.ts
@@ -59,3 +59,22 @@ chai.use(chaiPathPlugin);
 chai.use(chaiAsPromised);
 
 installTagSupport();
+
+// Add missing type definitions for chai-as-promised
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Chai {
+        interface Eventually {
+            includes: Chai.PromisedInclude;
+            contains: Chai.PromisedInclude;
+        }
+
+        interface PromisedNested {
+            includes: Chai.PromisedInclude;
+        }
+
+        interface PromisedDeep {
+            includes: Chai.PromisedInclude;
+        }
+    }
+}

--- a/test/integration-tests/tasks/SwiftTaskProvider.test.ts
+++ b/test/integration-tests/tasks/SwiftTaskProvider.test.ts
@@ -22,7 +22,12 @@ import { Version } from "@src/utilities/version";
 
 import { mockGlobalObject } from "../../MockUtils";
 import { tag } from "../../tags";
-import { executeTaskAndWaitForResult, waitForEndTaskProcess } from "../../utilities/tasks";
+import {
+    executeTaskAndWaitForResult,
+    waitForEndTask,
+    waitForEndTaskProcess,
+    waitForNoRunningTasks,
+} from "../../utilities/tasks";
 import {
     activateExtensionForSuite,
     folderInRootWorkspace,
@@ -31,11 +36,35 @@ import {
 
 import assert = require("assert");
 
-suite("SwiftTaskProvider Test Suite", () => {
+tag("medium").suite("SwiftTaskProvider Test Suite", () => {
     let workspaceContext: WorkspaceContext;
     let toolchain: SwiftToolchain;
     let workspaceFolder: vscode.WorkspaceFolder;
     let folderContext: FolderContext;
+    let resetSettings: (() => Promise<void>) | undefined;
+
+    async function fetchAllSwiftTasks(): Promise<vscode.Task[]> {
+        // Before Swift 6.0, tasks are disabled when another build task is running.
+        if (workspaceContext.globalToolchain.swiftVersion.isLessThan(new Version(6, 0, 0))) {
+            await waitForNoRunningTasks();
+        }
+        return vscode.tasks.fetchTasks({ type: "swift" });
+    }
+
+    async function findBuildAllTask(): Promise<vscode.Task | undefined> {
+        const tasks = await fetchAllSwiftTasks();
+        return tasks.find(t => t.name === "Build All (defaultPackage)");
+    }
+
+    async function findBuildAllTaskFromTasksJSON(): Promise<vscode.Task | undefined> {
+        const tasks = await fetchAllSwiftTasks();
+        return tasks.find(
+            t =>
+                t.name ===
+                "swift: Build All from " +
+                    (vscode.workspace.workspaceFile ? "code workspace" : "tasks.json")
+        );
+    }
 
     activateExtensionForSuite({
         async setup(ctx) {
@@ -43,36 +72,129 @@ suite("SwiftTaskProvider Test Suite", () => {
             expect(workspaceContext.folders).to.not.have.lengthOf(0);
             workspaceFolder = workspaceContext.folders[0].workspaceFolder;
 
-            // Make sure have another folder
+            // Make sure to add another folder
             folderContext = await folderInRootWorkspace("diagnostics", workspaceContext);
             toolchain = folderContext.toolchain;
         },
     });
 
-    suite("createSwiftTask", () => {
-        test("Exit code on success", async () => {
+    teardown(async () => {
+        if (resetSettings) {
+            await resetSettings();
+        }
+    });
+
+    test("provides build all task", async () => {
+        await expect(findBuildAllTask())
+            .to.eventually.have.property("detail")
+            .that.includes("swift build --build-tests");
+    });
+
+    test("can execute the build all task", async () => {
+        const task = await findBuildAllTask();
+        assert(task);
+        await vscode.tasks.executeTask(task);
+        await Promise.all([
+            expect(waitForEndTaskProcess(task)).to.eventually.equal(0),
+            waitForEndTask(task),
+        ]);
+    });
+
+    test("provides build all task from tasks.json", async () => {
+        await expect(findBuildAllTaskFromTasksJSON())
+            .to.eventually.have.property("detail")
+            .that.includes("swift build --show-bin-path");
+    });
+
+    test("can execute the build all task from tasks.json", async () => {
+        const task = await findBuildAllTaskFromTasksJSON();
+        assert(task);
+        await vscode.tasks.executeTask(task);
+        await Promise.all([
+            expect(waitForEndTaskProcess(task)).to.eventually.equal(0),
+            waitForEndTask(task),
+        ]);
+    });
+
+    test("provides product debug task", async () => {
+        const tasks = await fetchAllSwiftTasks();
+        expect(tasks.map(t => t.name)).to.include("Build Debug PackageExe (defaultPackage)");
+        expect(tasks.find(t => t.name === "Build Debug PackageExe (defaultPackage)"))
+            .to.have.property("detail")
+            .that.includes("swift build --product PackageExe");
+    });
+
+    test("provides library build tasks when enabled in settings", async () => {
+        let tasks = await fetchAllSwiftTasks();
+        let taskNames = tasks.map(t => t.name);
+        expect(taskNames).to.not.include("Build Debug PackageLib2 (defaultPackage)");
+        expect(taskNames).to.not.include("Build Release PackageLib2 (defaultPackage)");
+
+        resetSettings = await updateSettings({
+            "swift.createTasksForLibraryProducts": true,
+        });
+
+        tasks = await fetchAllSwiftTasks();
+        taskNames = tasks.map(t => t.name);
+        expect(taskNames).to.include("Build Debug PackageLib2 (defaultPackage)");
+        expect(tasks.find(t => t.name === "Build Debug PackageLib2 (defaultPackage)"))
+            .to.have.property("detail")
+            .that.includes("swift build --product PackageLib2");
+        expect(taskNames).to.include("Build Release PackageLib2 (defaultPackage)");
+        expect(tasks.find(t => t.name === "Build Release PackageLib2 (defaultPackage)"))
+            .to.have.property("detail")
+            .that.includes("swift build -c release --product PackageLib2");
+
+        // Don't include automatic products
+        expect(taskNames).to.not.include("Build Debug PackageLib (defaultPackage)");
+        expect(taskNames).to.not.include("Build Release PackageLib (defaultPackage)");
+    });
+
+    test("provides product release task", async () => {
+        const tasks = await fetchAllSwiftTasks();
+        expect(tasks.map(t => t.name)).to.include("Build Release PackageExe (defaultPackage)");
+        expect(tasks.find(t => t.name === "Build Release PackageExe (defaultPackage)"))
+            .to.have.property("detail")
+            .that.includes("swift build -c release --product PackageExe");
+    });
+
+    test("provides tasks for sub-folders with a Package.swift", async () => {
+        const diagnosticTasks = (await fetchAllSwiftTasks())
+            .map(t => t.name)
+            .filter(name => name.endsWith("(diagnostics)"));
+        expect(diagnosticTasks).to.have.members([
+            "Build All (diagnostics)",
+            "Build Debug diagnostics (diagnostics)",
+            "Build Release diagnostics (diagnostics)",
+        ]);
+    });
+
+    suite("createSwiftTask()", () => {
+        test("returns an exit code of 0 when the process completes successfully", async () => {
             const task = createSwiftTask(
                 ["--help"],
                 "help",
                 { cwd: workspaceFolder.uri, scope: vscode.TaskScope.Workspace },
                 toolchain
             );
-            const { exitCode } = await executeTaskAndWaitForResult(task);
-            expect(exitCode).to.equal(0);
+            await expect(executeTaskAndWaitForResult(task))
+                .to.eventually.have.property("exitCode")
+                .that.equals(0);
         });
 
-        test("Exit code on failure", async () => {
+        test("returns a non-zero exit code when the process fails", async () => {
             const task = createSwiftTask(
                 ["invalid_swift_command"],
                 "invalid",
                 { cwd: workspaceFolder.uri, scope: vscode.TaskScope.Workspace },
                 toolchain
             );
-            const { exitCode } = await executeTaskAndWaitForResult(task);
-            expect(exitCode).to.not.equal(0);
+            await expect(executeTaskAndWaitForResult(task))
+                .to.eventually.have.property("exitCode")
+                .that.does.not.equal(0);
         });
 
-        test("Exit code on failure to launch", async () => {
+        test("returns a non-zero exit code if the swift binary could not be found", async () => {
             const task = createSwiftTask(
                 ["--help"],
                 "help",
@@ -90,148 +212,27 @@ suite("SwiftTaskProvider Test Suite", () => {
                     new Version(1, 2, 3)
                 )
             );
-            const { exitCode } = await executeTaskAndWaitForResult(task);
-            expect(exitCode).to.not.equal(0);
+            await expect(executeTaskAndWaitForResult(task))
+                .to.eventually.have.property("exitCode")
+                .that.does.not.equal(0);
         });
     });
 
-    suite("provideTasks", () => {
-        let resetSettings: (() => Promise<void>) | undefined;
-        teardown(async () => {
-            if (resetSettings) {
-                await resetSettings();
-            }
-        });
-
-        suite("includes build all task from extension", () => {
-            async function getBuildAllTask(): Promise<vscode.Task | undefined> {
-                const tasks = await vscode.tasks.fetchTasks({ type: "swift" });
-                return tasks.find(t => t.name === "Build All (defaultPackage)");
-            }
-
-            test("provided", async () => {
-                const task = await getBuildAllTask();
-                expect(task?.detail).to.include("swift build --build-tests");
-            });
-
-            tag("medium").test("executes", async () => {
-                const task = await getBuildAllTask();
-                assert(task);
-                const exitPromise = waitForEndTaskProcess(task);
-                await vscode.tasks.executeTask(task);
-                const exitCode = await exitPromise;
-                expect(exitCode).to.equal(0);
-            });
-        });
-
-        suite("includes build all task from tasks.json", () => {
-            async function getBuildAllTask(): Promise<vscode.Task | undefined> {
-                const tasks = await vscode.tasks.fetchTasks({ type: "swift" });
-                return tasks.find(
-                    t =>
-                        t.name ===
-                        "swift: Build All from " +
-                            (vscode.workspace.workspaceFile ? "code workspace" : "tasks.json")
-                );
-            }
-
-            test("provided", async () => {
-                const task = await getBuildAllTask();
-                expect(task?.detail).to.include("swift build --show-bin-path");
-            });
-
-            tag("medium").test("executes", async () => {
-                const task = await getBuildAllTask();
-                assert(task);
-                const exitPromise = waitForEndTaskProcess(task);
-                await vscode.tasks.executeTask(task);
-                const exitCode = await exitPromise;
-                expect(exitCode).to.equal(0);
-            });
-        });
-
-        test("includes product debug task", async () => {
-            const tasks = await vscode.tasks.fetchTasks({ type: "swift" });
-            const task = tasks.find(t => t.name === "Build Debug PackageExe (defaultPackage)");
-            expect(
-                task,
-                'expected to find a task named "Build Debug PackageExe (defaultPackage)", instead found ' +
-                    tasks.map(t => t.name)
-            ).to.not.be.undefined;
-            expect(task?.detail).to.include("swift build --product PackageExe");
-        });
-
-        test("includes library build tasks task", async () => {
-            const taskProvider = workspaceContext.taskProvider;
-            let tasks = await taskProvider.provideTasks(new vscode.CancellationTokenSource().token);
-            let task = tasks.find(t => t.name === "Build Debug PackageLib2 (defaultPackage)");
-            expect(task).to.be.undefined;
-            task = tasks.find(t => t.name === "Build Release PackageLib2 (defaultPackage)");
-            expect(task).to.be.undefined;
-
-            resetSettings = await updateSettings({
-                "swift.createTasksForLibraryProducts": true,
-            });
-
-            tasks = await taskProvider.provideTasks(new vscode.CancellationTokenSource().token);
-            task = tasks.find(t => t.name === "Build Debug PackageLib2 (defaultPackage)");
-            expect(
-                task,
-                'expected to find a task named "Build Debug PackageLib2 (defaultPackage)", instead found ' +
-                    tasks.map(t => t.name)
-            ).to.not.be.undefined;
-            expect(task?.detail).to.include("swift build --product PackageLib2");
-            task = tasks.find(t => t.name === "Build Release PackageLib2 (defaultPackage)");
-            expect(
-                task,
-                'expected to find a task named "Build Release PackageLib2 (defaultPackage)", instead found ' +
-                    tasks.map(t => t.name)
-            ).to.not.be.undefined;
-            expect(task?.detail).to.include("swift build -c release --product PackageLib2");
-
-            // Don't include automatic products
-            task = tasks.find(t => t.name === "Build Debug PackageLib (defaultPackage)");
-            expect(task).to.be.undefined;
-            task = tasks.find(t => t.name === "Build Release PackageLib (defaultPackage)");
-            expect(task).to.be.undefined;
-        });
-
-        test("includes product release task", async () => {
-            const taskProvider = workspaceContext.taskProvider;
-            const tasks = await taskProvider.provideTasks(
-                new vscode.CancellationTokenSource().token
-            );
-            const task = tasks.find(t => t.name === "Build Release PackageExe (defaultPackage)");
-            expect(
-                task,
-                'expected to find a task named "Build Release PackageExe (defaultPackage)", instead found ' +
-                    tasks.map(t => t.name)
-            ).to.not.be.undefined;
-            expect(task?.detail).to.include("swift build -c release --product PackageExe");
-        });
-
-        test("includes additional folders", async () => {
-            const tasks = await vscode.tasks.fetchTasks({ type: "swift" });
-            const diagnosticTasks = tasks.filter(t => t.name.endsWith("(diagnostics)"));
-            expect(diagnosticTasks).to.have.lengthOf(3);
-        });
-    });
-
-    suite("createBuildAllTask", () => {
-        test("should return same task instance", async () => {
+    suite("createBuildAllTask()", () => {
+        test("returns the same task instance when called multiple times", async () => {
             expect(await createBuildAllTask(folderContext)).to.equal(
                 await createBuildAllTask(folderContext)
             );
         });
 
-        test("different task returned for release mode", async () => {
+        test("returns a different task when release mode is enabled", async () => {
             expect(await createBuildAllTask(folderContext)).to.not.equal(
                 await createBuildAllTask(folderContext, true)
             );
         });
     });
 
-    suite("getBuildAllTask", () => {
+    suite("getBuildAllTask()", () => {
         const tasksMock = mockGlobalObject(vscode, "tasks");
 
         test("creates build all task when it cannot find one", async () => {

--- a/test/reporters/GitHubActionsSummaryReporter.ts
+++ b/test/reporters/GitHubActionsSummaryReporter.ts
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import * as chai from "chai";
 import { diffLines } from "diff";
 import * as fs from "fs";
 import * as mocha from "mocha";
@@ -20,12 +21,12 @@ const SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
 
 interface AssertionError extends Error {
     showDiff?: boolean;
-    actual: string;
-    expected: string;
+    actual: unknown;
+    expected: unknown;
 }
 
 function isAssertionError(err: Error): err is AssertionError {
-    return typeof (err as any).actual === "string" && typeof (err as any).expected === "string";
+    return Object.hasOwn(err, "actual") && Object.hasOwn(err, "expected");
 }
 
 module.exports = class GitHubActionsSummaryReporter extends mocha.reporters.Base {
@@ -88,33 +89,20 @@ function generateErrorMessage(failure: Mocha.Test): string {
 
 function convertErrorToString(error: Error): string {
     const stackTraceFilter = mocha.utils.stackTraceFilter();
-    let result: string;
-    if (isAssertionError(error) && error.showDiff) {
-        const stackTraceFilter = mocha.utils.stackTraceFilter();
-        const { message, stack } = splitStackTrace(error);
-        result =
-            message +
-            EOL +
-            generateDiff(error.actual, error.expected) +
-            EOL +
-            EOL +
-            stackTraceFilter(stack);
-    } else if (error.stack) {
-        result = stackTraceFilter(error.stack);
-    } else {
-        result = mocha.utils.stringify(error);
+    const { message, stack } = splitStackTrace(error);
+    let result = message;
+    if (isAssertionError(error)) {
+        if (error.showDiff) {
+            result += EOL + generateDiff(error);
+        } else if (prettyPrint(error.actual).length > chai.config.truncateThreshold) {
+            result += EOL + "The full actual value was:" + EOL + prettyPrint(error.actual);
+        }
     }
-
-    if (!error.cause) {
-        return result;
-    }
-    let causedByString = "Caused By: ";
+    result += EOL + stackTraceFilter(stack);
     if (error.cause instanceof Error) {
-        causedByString += convertErrorToString(error.cause);
-    } else {
-        causedByString += mocha.utils.stringify(error.cause);
+        result += EOL + "Caused By: " + EOL + convertErrorToString(error.cause);
     }
-    return result + EOL + causedByString;
+    return result.replaceAll(/\r?\n/g, EOL);
 }
 
 function splitStackTrace(error: Error): { message: string; stack: string } {
@@ -130,7 +118,21 @@ function splitStackTrace(error: Error): { message: string; stack: string } {
     };
 }
 
-function generateDiff(actual: string, expected: string) {
+function prettyPrint(obj: unknown): string {
+    if (obj === undefined) {
+        return "undefined";
+    }
+
+    if (obj === null) {
+        return "null";
+    }
+
+    return JSON.stringify(obj, undefined, 2).replaceAll(/\r?\n/g, EOL);
+}
+
+function generateDiff(error: AssertionError) {
+    const actual = prettyPrint(error.actual);
+    const expected = prettyPrint(error.expected);
     return [
         "🟩 expected 🟥 actual" + EOL + EOL,
         ...diffLines(expected, actual).map(part => {

--- a/test/utilities/tasks.ts
+++ b/test/utilities/tasks.ts
@@ -174,6 +174,26 @@ export async function withTaskWatcher(
 }
 
 /**
+ * Creates a Promise that resolves when the provided Task ends.
+ *
+ * @param task A {@link vscode.Task}
+ * @returns A Promise
+ */
+export function waitForEndTask(task: vscode.Task): Promise<void> {
+    const subscriptions: Disposable[] = [];
+    return new Promise<void>(resolve => {
+        subscriptions.push(
+            vscode.tasks.onDidEndTask(event => {
+                if (task.detail !== event.execution.task.detail) {
+                    return;
+                }
+                resolve();
+            })
+        );
+    }).finally(() => subscriptions.forEach(s => s.dispose()));
+}
+
+/**
  * Ideally we would want to use {@link executeTaskAndWaitForResult} but that
  * requires the tests creating the task through some means. If the
  * {@link vscode.Task Task}, was provided by the extension under test, the


### PR DESCRIPTION
## Description
Clean up a few aspects of the SwiftTaskProvider test suite:
- Improve the expectations so that they include more info on failure
- Improve the naming of the tests to make it clear what behaviour they're testing

The actual contents of the tests have not changed.

Issue: #2225

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
