### PR TITLE
Pin the version of plist to 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,9 +36,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "eslint-plugin-mocha"
         update-types: ["version-update:semver-major"]
-      # Next major version of plist is broken on Windows.
+      # Versions of plist after 3.1.0 are broken on Windows.
       - dependency-name: "plist"
-        update-types: ["version-update:semver-major"]
       # Newer versions of fantasticon are broken on Windows.
       # https://github.com/tancredi/fantasticon/issues/470
       - dependency-name: "fantasticon"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "archiver": "^7.0.1",
         "fast-glob": "^3.3.3",
         "lcov-parse": "^1.0.0",
-        "plist": "^3.1.0",
+        "plist": "=3.1.0",
         "tar": "^7.5.13",
         "vscode-languageclient": "^9.0.1",
         "xml2js": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -2184,7 +2184,7 @@
     "archiver": "^7.0.1",
     "fast-glob": "^3.3.3",
     "lcov-parse": "^1.0.0",
-    "plist": "^3.1.0",
+    "plist": "=3.1.0",
     "tar": "^7.5.13",
     "vscode-languageclient": "^9.0.1",
     "xml2js": "^0.6.2",


### PR DESCRIPTION
## Description
I originally told dependabot not to update to the next major version, but 3.1.1 was just released and it has the same issue as 4.0.0. Pin specifically to 3.1.0 until we can figure out why it's broken.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
