### PR TITLE
Re-enable "Debugs specified XCTest test" test on Windows

### DIFF
--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -49,7 +49,7 @@ export function registerDebugger(workspaceContext: WorkspaceContext): Disposable
     });
 
     function register() {
-        subscriptions.push(registerLoggingDebugAdapterTracker());
+        subscriptions.push(registerLoggingDebugAdapterTracker(workspaceContext));
         subscriptions.push(registerLLDBDebugAdapter(workspaceContext));
     }
 

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -13,18 +13,41 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
+import { WorkspaceContext } from "../WorkspaceContext";
 import { SwiftLogger } from "../logging/SwiftLogger";
 import { Disposable } from "../utilities/Disposable";
+import { Version } from "../utilities/version";
 import { LaunchConfigType } from "./debugAdapter";
 
 /**
  * Factory class for building LoggingDebugAdapterTracker
  */
 class LoggingDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactory {
+    constructor(private workspaceContext: WorkspaceContext) {}
+
     createDebugAdapterTracker(
         session: vscode.DebugSession
     ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
-        return new LoggingDebugAdapterTracker(session.id);
+        const trackerOptions: LoggingDebugAdapterTrackerOptions = { ignoreConsoleOutput: true };
+        if (session.type === LaunchConfigType.LLDB_DAP && process.platform === "win32") {
+            // Normally, we ignore the console output category since it's reserved for messages from the
+            // debugger. However, in Swift 6.3 lldb-dap cannot properly distinguish between lldb's and the
+            // debuggee's output and will instead output everything under "console". Therefore, we need to
+            // include the "console" category with this configuration.
+            //
+            // This issue was fixed in Swift 6.4, but the change cannot be easily cherry picked back to 6.3.
+            const swiftVersion = this.workspaceContext.folders.find(
+                f => f.workspaceFolder.uri.fsPath === session.workspaceFolder?.uri.fsPath
+            )?.swiftVersion;
+            if (
+                swiftVersion &&
+                swiftVersion.isGreaterThanOrEqual(new Version(6, 3, 0)) &&
+                swiftVersion.isLessThan(new Version(6, 4, 0))
+            ) {
+                trackerOptions.ignoreConsoleOutput = false;
+            }
+        }
+        return new LoggingDebugAdapterTracker(session.id, trackerOptions);
     }
 }
 
@@ -45,10 +68,10 @@ interface DebugMessage {
  * Register the LoggingDebugAdapterTrackerFactory with the VS Code debug adapter tracker
  * @returns A disposable to be disposed when the extension is deactivated
  */
-export function registerLoggingDebugAdapterTracker(): Disposable {
+export function registerLoggingDebugAdapterTracker(workspaceContext: WorkspaceContext): Disposable {
     // Register the factory for both lldb-dap and CodeLLDB since either could be used when
     // resolving a Swift launch configuration.
-    const trackerFactory = new LoggingDebugAdapterTrackerFactory();
+    const trackerFactory = new LoggingDebugAdapterTrackerFactory(workspaceContext);
     const subscriptions: Disposable[] = [
         vscode.debug.registerDebugAdapterTrackerFactory(LaunchConfigType.CODE_LLDB, trackerFactory),
         vscode.debug.registerDebugAdapterTrackerFactory(LaunchConfigType.LLDB_DAP, trackerFactory),
@@ -56,6 +79,10 @@ export function registerLoggingDebugAdapterTracker(): Disposable {
 
     // Return a disposable that cleans everything up.
     return Disposable.from(...subscriptions);
+}
+
+interface LoggingDebugAdapterTrackerOptions {
+    ignoreConsoleOutput: boolean;
 }
 
 /**
@@ -69,9 +96,14 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
     private exitHandler?: (exitCode: number) => void;
     private output: string[] = [];
     private exitCode: number | undefined;
+    private ignoreConsoleOutput: boolean;
 
-    constructor(public id: string) {
+    constructor(
+        public id: string,
+        options: LoggingDebugAdapterTrackerOptions = { ignoreConsoleOutput: true }
+    ) {
         LoggingDebugAdapterTracker.debugSessionIdMap[id] = this;
+        this.ignoreConsoleOutput = options.ignoreConsoleOutput;
     }
 
     static setDebugSessionCallback(
@@ -114,17 +146,8 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
         if (debugMessage.event === "exited" && debugMessage.body.exitCode) {
             this.exitCode = debugMessage.body.exitCode;
             this.exitHandler?.(debugMessage.body.exitCode);
-        } else if (
-            debugMessage.type === "event" &&
-            debugMessage.event === "output" &&
-            debugMessage.body.category !== "console"
-        ) {
-            const output = debugMessage.body.output;
-            if (this.cb) {
-                this.cb(output);
-            } else {
-                this.output.push(output);
-            }
+        } else if (debugMessage.type === "event" && debugMessage.event === "output") {
+            this.handleProcessOutput(debugMessage);
         }
     }
 
@@ -134,5 +157,17 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
      */
     onWillStopSession(): void {
         delete LoggingDebugAdapterTracker.debugSessionIdMap[this.id];
+    }
+
+    private handleProcessOutput(message: DebugMessage): void {
+        if (this.ignoreConsoleOutput && message.body.category === "console") {
+            return;
+        }
+        const output = message.body.output;
+        if (this.cb) {
+            this.cb(output);
+        } else {
+            this.output.push(output);
+        }
     }
 }

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -150,24 +150,7 @@ tag("large").suite("Test Explorer Suite", function () {
                 }
             });
 
-            test("Debugs specified XCTest test", async function () {
-                // This test is failing consistently on Windows with Swift 6.3 and nightly-main.
-                // The issue has been tracked down to lldb-dap setting the wrong category when
-                // reporting debugee stdout/stderr over the DAP.
-                //
-                // GitHub Issue: https://github.com/swiftlang/vscode-swift/issues/1986
-                if (
-                    process.platform === "win32" &&
-                    workspaceContext.globalToolchain.swiftVersion.isGreaterThanOrEqual({
-                        major: 6,
-                        minor: 3,
-                        patch: 0,
-                    })
-                ) {
-                    this.skip();
-                }
-                await runXCTest.call(this);
-            });
+            test("Debugs specified XCTest test", runXCTest);
 
             test("Debugs specified swift-testing test", async function () {
                 await runSwiftTesting.call(this);


### PR DESCRIPTION
## Description
A change was made in Swift 6.3 that correctly puts `lldb-dap`'s own process output under the `console` category. However, on Windows it cannot distinguish between its own output and the debuggee's. So, both of them will end up under `console` which the Swift extension ends up ignoring. This was fixed in Swift 6.4 by having `lldb-dap` use ConPTY to launch the debuggee.

This PR re-enables the failing tests and adds a workaround for Swift 6.3 that will include output from the `console` category as process output.

Issue: #1986 

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
