### PR TITLE
Report `vscode-swift/no-exclusive-tests` on the `only` identifier

### DIFF
--- a/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
+++ b/eslint-plugin-vscode-swift/no-exclusive-tests.mjs
@@ -31,10 +31,13 @@ export default createRule({
                     return;
                 }
 
+                const reportNode =
+                    node.callee.type === "MemberExpression" ? node.callee.property : node.callee;
+
                 if (type.symbol.name === "ExclusiveSuiteFunction") {
                     context.report({
                         messageId: "noExclusiveSuites",
-                        node: node.callee,
+                        node: reportNode,
                     });
                     return;
                 }
@@ -42,7 +45,7 @@ export default createRule({
                 if (type.symbol.name === "ExclusiveTestFunction") {
                     context.report({
                         messageId: "noExclusiveTests",
-                        node: node.callee,
+                        node: reportNode,
                     });
                 }
             },


### PR DESCRIPTION
## Description
In VS Code, the `vscode-swift/no-exclusive-tests` linting problem highlights the full member expression (e.g. `test.only` or `suite.only`). This PR modifies the rule so that it only highlights the `only` identifier, making it easier to see exactly which portion of the expression to remove.


## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
