### PR TITLE
Fix `swift.buildPath` being ignored by `swift package plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix swift-testing timeout when doing a Run All tests w/ multiple test targets when using swift-build ([#2207](https://github.com/swiftlang/vscode-swift/pull/2207))
 - Run toolchain executables via `swiftly run <tool>` when the active toolchain is managed by swiftly ([#2177](https://github.com/swiftlang/vscode-swift/pull/2177))
+- Fix swift.buildPath being ignored by swift package plugin tasks ([#2235](https://github.com/swiftlang/vscode-swift/pull/2235))
 
 ## 2.16.4 - 2026-04-21
 

--- a/src/toolchain/BuildFlags.ts
+++ b/src/toolchain/BuildFlags.ts
@@ -43,24 +43,24 @@ export class BuildFlags {
     private withSwiftSDKFlags(args: string[]): string[] {
         switch (args[0]) {
             case "package": {
-                if (args[1] === "plugin") {
-                    // Don't append build path flags for `swift package plugin` commands
-                    return args;
-                }
-                const subcommand = args.splice(0, 2).concat(this.buildPathFlags());
-                switch (subcommand[1]) {
+                // Build-path and destination control flags belong on the parent
+                // `package` command, before any subcommand. Otherwise SwiftPM's
+                // argument parser rejects them when the subcommand has further
+                // subcommands or positional args (e.g. `swift package plugin --list`).
+                const command = args.splice(0, 1).concat(this.buildPathFlags());
+                const subcommand: string | undefined = args[0];
+                switch (subcommand) {
                     case "dump-symbol-graph":
                     case "diagnose-api-breaking-changes":
-                    case "resolve": {
+                    case "resolve":
                         // These two tools require building the package, so SDK
                         // flags are needed. Destination control flags are
                         // required to be placed before subcommand options.
-                        return [...subcommand, ...this.swiftpmSDKFlags(), ...args];
-                    }
+                        return [...command, ...this.swiftpmSDKFlags(), ...args];
                     default:
                         // Other swift-package subcommands operate on the host,
-                        // so it doesn't need to know about the destination.
-                        return subcommand.concat(args);
+                        // so they don't need to know about the destination.
+                        return command.concat(args);
                 }
             }
             case "build":
@@ -259,7 +259,7 @@ export class BuildFlags {
         const disableSandboxFlags = ["--disable-sandbox", "-Xswiftc", "-disable-sandbox"];
         switch (args[0]) {
             case "package": {
-                if (args[1] === "plugin") {
+                if (BuildFlags.packageSubcommand(args) === "plugin") {
                     return args;
                 }
                 return [args[0], ...disableSandboxFlags, ...args.slice(1)];
@@ -273,6 +273,23 @@ export class BuildFlags {
                 // Do nothing for other commands
                 return args;
         }
+    }
+
+    /**
+     * Find the `swift package` subcommand in an argument list, skipping any
+     * leading global options (e.g. `--scratch-path PATH`, `--sdk PATH`,
+     * `--swift-sdk SDK`) that may have been inserted before it.
+     */
+    private static packageSubcommand(args: string[]): string | undefined {
+        let i = 1;
+        while (i < args.length) {
+            const arg = args[i];
+            if (!arg.startsWith("-")) {
+                return arg;
+            }
+            i += arg.includes("=") ? 1 : 2;
+        }
+        return undefined;
     }
 
     /**

--- a/test/unit-tests/toolchain/BuildFlags.test.ts
+++ b/test/unit-tests/toolchain/BuildFlags.test.ts
@@ -372,9 +372,9 @@ suite("BuildFlags Test Suite", () => {
                     buildFlags.withAdditionalFlags(["package", sub, "--disable-sandbox"])
                 ).to.deep.equal([
                     "package",
-                    sub,
                     "--sdk",
                     "/some/full/path/to/sdk",
+                    sub,
                     "--disable-sandbox",
                 ]);
             }
@@ -411,17 +411,50 @@ suite("BuildFlags Test Suite", () => {
             buildPathConfig.setValue("/some/build/path");
             expect(
                 buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin", "--verbose"])
-            ).to.deep.equal(["package", "plugin", "my-plugin", "--verbose"]);
+            ).to.deep.equal([
+                "package",
+                "--scratch-path",
+                "/some/build/path",
+                "plugin",
+                "my-plugin",
+                "--verbose",
+            ]);
 
             sdkConfig.setValue("/some/full/path/to/sdk");
             expect(
                 buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin"])
-            ).to.deep.equal(["package", "plugin", "my-plugin"]);
+            ).to.deep.equal([
+                "package",
+                "--scratch-path",
+                "/some/build/path",
+                "plugin",
+                "my-plugin",
+            ]);
 
             sandboxConfig.setValue(true);
             expect(
                 buildFlags.withAdditionalFlags(["package", "plugin", "my-plugin"])
-            ).to.deep.equal(["package", "plugin", "my-plugin"]);
+            ).to.deep.equal([
+                "package",
+                "--scratch-path",
+                "/some/build/path",
+                "plugin",
+                "my-plugin",
+            ]);
+        });
+
+        test("package plugin --list with buildPath", () => {
+            // Regression test for https://github.com/swiftlang/vscode-swift/issues/2234
+            // The build-path flag must be placed before the `plugin` subcommand,
+            // otherwise SwiftPM rejects it as an unknown plugin option.
+            buildPathConfig.setValue("/tmp/scratch");
+            expect(buildFlags.withAdditionalFlags(["package", "plugin", "--list"])).to.deep.equal([
+                "package",
+                "--scratch-path",
+                "/tmp/scratch",
+                "plugin",
+                "--list",
+            ]);
         });
 
         test("build", () => {


### PR DESCRIPTION
`BuildFlags.withSwiftSDKFlags` previously placed `--scratch-path` after the `package` subcommand, which SwiftPM's argument parser rejects when the subcommand has further subcommands or positional args (e.g. `swift package plugin --list`). PR #1996 had silenced this by skipping build-path flags entirely for `package plugin`, however arguments to `swift package` commands should still be respected.

Move build-path and SDK flags to the parent `package` command, before the subcommand, so they apply correctly across all `package` subcommands, including `plugin`

Issue: #2234

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
