### PR TITLE
Add new swift.sourcekit-lsp.includeDeclarationInFindAllReferences setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## {{releaseVersion}} - {{releaseDate}}
 
+### Added
+
+- Add `swift.sourcekit-lsp.includeDeclarationInFindAllReferences` setting to control whether the symbol declaration is included in Find All References results ([])
+
 ### Fixed
 
 - Fix swift-testing timeout when doing a Run All tests w/ multiple test targets when using swift-build ([#2207](https://github.com/swiftlang/vscode-swift/pull/2207))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `swift.sourcekit-lsp.includeDeclarationInFindAllReferences` setting to control whether the symbol declaration is included in Find All References results ([])
+- Add `swift.sourcekit-lsp.includeDeclarationInFindAllReferences` setting to control whether the symbol declaration is included in Find All References results ([#2236](https://github.com/swiftlang/vscode-swift/pull/2236))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -971,6 +971,13 @@
             "order": 6,
             "scope": "machine-overridable"
           },
+          "swift.sourcekit-lsp.includeDeclarationInFindAllReferences": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Whether the symbol declaration should be included in the results of `Find All References`. When `false`, only usage sites are returned.",
+            "order": 7,
+            "scope": "machine-overridable"
+          },
           "sourcekit-lsp.inlayHints.enabled": {
             "type": "boolean",
             "default": true,

--- a/package.json
+++ b/package.json
@@ -972,9 +972,19 @@
             "scope": "machine-overridable"
           },
           "swift.sourcekit-lsp.includeDeclarationInFindAllReferences": {
-            "type": "boolean",
-            "default": true,
-            "markdownDescription": "Whether the symbol declaration should be included in the results of `Find All References`. When `false`, only usage sites are returned.",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "always",
+              "never"
+            ],
+            "enumDescriptions": [
+              "Use the value sent by VS Code.",
+              "Always include the symbol declaration in `Find All References` results.",
+              "Never include the symbol declaration in `Find All References` results."
+            ],
+            "markdownDescription": "Controls whether the symbol declaration is included in the results of `Find All References`.",
             "order": 7,
             "scope": "machine-overridable"
           },

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -66,6 +66,8 @@ interface LSPConfiguration {
     readonly supportedLanguages: string[];
     /** Is SourceKit-LSP disabled */
     readonly disable: boolean;
+    /** Include declaration in Find All References results */
+    readonly includeDeclarationInFindAllReferences: boolean;
     /** Is the trace server enabled */
     readonly traceServer: "off" | "messages" | "verbose";
 }
@@ -193,6 +195,14 @@ const configuration = {
                         .getConfiguration("swift.sourcekit-lsp")
                         .get<boolean>("disable", false),
                     "swift.sourcekit-lsp.disable"
+                );
+            },
+            get includeDeclarationInFindAllReferences(): boolean {
+                return validateBooleanSetting(
+                    vscode.workspace
+                        .getConfiguration("swift.sourcekit-lsp")
+                        .get<boolean>("includeDeclarationInFindAllReferences", true),
+                    "swift.sourcekit-lsp.includeDeclarationInFindAllReferences"
                 );
             },
             get traceServer(): "off" | "messages" | "verbose" {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -67,7 +67,7 @@ interface LSPConfiguration {
     /** Is SourceKit-LSP disabled */
     readonly disable: boolean;
     /** Include declaration in Find All References results */
-    readonly includeDeclarationInFindAllReferences: boolean;
+    readonly includeDeclarationInFindAllReferences: "default" | "always" | "never";
     /** Is the trace server enabled */
     readonly traceServer: "off" | "messages" | "verbose";
 }
@@ -197,11 +197,11 @@ const configuration = {
                     "swift.sourcekit-lsp.disable"
                 );
             },
-            get includeDeclarationInFindAllReferences(): boolean {
-                return validateBooleanSetting(
+            get includeDeclarationInFindAllReferences(): "default" | "always" | "never" {
+                return validateStringSetting<"default" | "always" | "never">(
                     vscode.workspace
                         .getConfiguration("swift.sourcekit-lsp")
-                        .get<boolean>("includeDeclarationInFindAllReferences", true),
+                        .get<string>("includeDeclarationInFindAllReferences", "default"),
                     "swift.sourcekit-lsp.includeDeclarationInFindAllReferences"
                 );
             },

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -287,6 +287,17 @@ export function lspClientOptions(
                 }
                 return result;
             },
+            provideReferences: async (document, position, options, token, next) => {
+                return next(
+                    document,
+                    position,
+                    {
+                        ...options,
+                        includeDeclaration: configuration.lsp.includeDeclarationInFindAllReferences,
+                    },
+                    token
+                );
+            },
             // temporarily remove text edit from Inlay hints while SourceKit-LSP
             // returns invalid replacement text
             provideInlayHints: async (document, position, token, next) => {

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -288,15 +288,12 @@ export function lspClientOptions(
                 return result;
             },
             provideReferences: async (document, position, options, token, next) => {
-                return next(
-                    document,
-                    position,
-                    {
-                        ...options,
-                        includeDeclaration: configuration.lsp.includeDeclarationInFindAllReferences,
-                    },
-                    token
-                );
+                const setting = configuration.lsp.includeDeclarationInFindAllReferences;
+                const referenceOptions =
+                    setting === "default"
+                        ? options
+                        : { ...options, includeDeclaration: setting === "always" };
+                return next(document, position, referenceOptions, token);
             },
             // temporarily remove text edit from Inlay hints while SourceKit-LSP
             // returns invalid replacement text

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -289,11 +289,15 @@ export function lspClientOptions(
             },
             provideReferences: async (document, position, options, token, next) => {
                 const setting = configuration.lsp.includeDeclarationInFindAllReferences;
-                const referenceOptions =
-                    setting === "default"
-                        ? options
-                        : { ...options, includeDeclaration: setting === "always" };
-                return next(document, position, referenceOptions, token);
+                if (setting === "default") {
+                    return next(document, position, options, token);
+                }
+                return next(
+                    document,
+                    position,
+                    { ...options, includeDeclaration: setting === "always" },
+                    token
+                );
             },
             // temporarily remove text edit from Inlay hints while SourceKit-LSP
             // returns invalid replacement text

--- a/test/integration-tests/language/LanguageClientIntegration.test.ts
+++ b/test/integration-tests/language/LanguageClientIntegration.test.ts
@@ -122,5 +122,36 @@ tag("large").suite("Language Client Integration Suite", function () {
                 expect(referenceUris).to.contain(uri);
             }
         });
+        test("Find All References excludes declaration when setting is false", async function () {
+            const config = vscode.workspace.getConfiguration("swift.sourcekit-lsp");
+            await config.update(
+                "includeDeclarationInFindAllReferences",
+                false,
+                vscode.ConfigurationTarget.Workspace
+            );
+            try {
+                const editor = await vscode.window.showTextDocument(uri);
+                const document = editor.document;
+
+                const referenceLocations = await vscode.commands.executeCommand<vscode.Location[]>(
+                    "vscode.executeReferenceProvider",
+                    document.uri,
+                    position
+                );
+
+                // We expect the declaration in `PackageLib.swift` to be excluded,
+                // usages in `main.swift` and `hello.swift` remain.
+                const referenceUris = referenceLocations.map(ref => ref.uri.toString());
+                expect(referenceUris).to.not.contain(expectedDefinitionUri.toString());
+                expect(referenceUris).to.contain(uri.toString());
+                expect(referenceUris).to.contain(snippetUri.toString());
+            } finally {
+                await config.update(
+                    "includeDeclarationInFindAllReferences",
+                    undefined,
+                    vscode.ConfigurationTarget.Workspace
+                );
+            }
+        });
     });
 });

--- a/test/integration-tests/language/LanguageClientIntegration.test.ts
+++ b/test/integration-tests/language/LanguageClientIntegration.test.ts
@@ -122,11 +122,11 @@ tag("large").suite("Language Client Integration Suite", function () {
                 expect(referenceUris).to.contain(uri);
             }
         });
-        test("Find All References excludes declaration when setting is false", async function () {
+        test("Find All References excludes declaration when setting is never", async function () {
             const config = vscode.workspace.getConfiguration("swift.sourcekit-lsp");
             await config.update(
                 "includeDeclarationInFindAllReferences",
-                false,
+                "never",
                 vscode.ConfigurationTarget.Workspace
             );
             try {


### PR DESCRIPTION
## Description

This PR adds a new `swift.sourcekit-lsp.includeDeclarationInFindAllReferences` setting, defaulting to `true`, that controls whether the symbol declaration is included in `Find All References` results.

When the setting is `false`, the extension sends `includeDeclaration: false` to SourceKit-LSP through a new `provideReferences` middleware, allowing users to opt out of including declarations in reference results.

The default value is `true` to preserve the existing behavior and stay consistent with other VS Code language extensions.

Issue: [https://github.com/swiftlang/vscode-swift/issues/2231](https://github.com/swiftlang/vscode-swift/issues/2231)

### Changes

- `package.json`: Add the new `swift.sourcekit-lsp.includeDeclarationInFindAllReferences` setting under `contributes.configuration`
- `src/configuration.ts`: Add the corresponding `LSPConfiguration` field and getter, validated via `validateBooleanSetting`
- `src/sourcekit-lsp/LanguageClientConfiguration.ts`: Add a `provideReferences` middleware that applies the setting to the outgoing references request
- `test/integration-tests/language/LanguageClientIntegration.test.ts`: Add an integration test case for the new behavior
- `CHANGELOG.md`: Add an entry under the unreleased `### Added` section

### Verification

I verified the behavior locally in the Extension Development Host against the `defaultPackage` test asset.

#### 1. New setting in VS Code Settings UI - `true`

The new `Swift › Sourcekit-lsp: Include Declaration In Find All References` setting appears in the Settings UI with the `markdownDescription` rendered correctly.

<img width="1431" height="889" alt="스크린샷 2026-05-16 오전 12 53 31" src="https://github.com/user-attachments/assets/596c0d6b-f875-4d3e-9cb4-09589fee1e9a" />

#### 2. Setting toggled to `false`

When the user disables the setting, the extension forwards `includeDeclaration: false` to SourceKit-LSP via the new `provideReferences` middleware.

<img width="1420" height="883" alt="스크린샷 2026-05-16 오전 12 57 46" src="https://github.com/user-attachments/assets/9045b356-1ed3-49da-837f-b3de31f2acaa" />

#### 3. Default behavior — setting `true`

`Find All References` returns 3 results: the declaration in `PackageLib.swift` (`public let a = "B"`) and the usages in `main.swift` and `hello.swift`.

<img width="1416" height="891" alt="스크린샷 2026-05-16 오전 12 56 13" src="https://github.com/user-attachments/assets/37dbc6b5-f1ff-4fe1-b5e7-519afd220c60" />

#### 4. Opt-out behavior — setting `false`

With the setting disabled, the declaration is excluded and only the 2 usages remain.

<img width="1417" height="885" alt="스크린샷 2026-05-16 오전 12 57 17" src="https://github.com/user-attachments/assets/4a48e283-6f86-4b79-ad43-8f037c3b0579" />

## Tasks

- [x] Required tests have been written
- [ ] Documentation has been updated
- [x] Added an entry to `CHANGELOG.md` if applicable