### PR TITLE
Restore original LSP diagnostic message before forwarding to server

### DIFF
--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -47,6 +47,27 @@ const isSourceKit: DiagnosticPredicate = diagnostic =>
     isSource(diagnostic, DiagnosticsManager.isSourcekit);
 
 /**
+ * Symbol-like key used to stash the original LSP message on a `vscode.Diagnostic`
+ * before `DiagnosticsManager` mutates it for display (capitalize, strip
+ * `(fix available)`, etc.). Read back in the `provideCodeActions` middleware
+ * so we forward the un-mutated message to the server.
+ *
+ * This matters because clangd looks up cached fix-its by `(range, message)`
+ * ([ClangdLSPServer.h] `struct DiagKey`); if the message differs from what it
+ * published, the lookup misses and the user sees no quickfix.
+ */
+const ORIGINAL_LSP_MESSAGE = "__vscodeSwiftOriginalLSPMessage";
+
+export function getOriginalLSPMessage(diagnostic: vscode.Diagnostic): string | undefined {
+    const raw = (diagnostic as unknown as Record<string, unknown>)[ORIGINAL_LSP_MESSAGE];
+    return typeof raw === "string" ? raw : undefined;
+}
+
+function setOriginalLSPMessage(diagnostic: vscode.Diagnostic, message: string): void {
+    (diagnostic as unknown as Record<string, unknown>)[ORIGINAL_LSP_MESSAGE] = message;
+}
+
+/**
  * Handles the collection and deduplication of diagnostics from
  * various {@link vscode.Diagnostic.source | Diagnostic sources}.
  *
@@ -462,15 +483,19 @@ export class DiagnosticsManager implements Disposable {
     }
 
     private capitalizeMessage = (diagnostic: vscode.Diagnostic): vscode.Diagnostic => {
+        const original = getOriginalLSPMessage(diagnostic) ?? diagnostic.message;
         const message = diagnostic.message;
         diagnostic = { ...diagnostic };
         diagnostic.message = this.capitalize(message);
+        setOriginalLSPMessage(diagnostic, original);
         return diagnostic;
     };
 
     private cleanMessage = (diagnostic: vscode.Diagnostic) => {
+        const original = getOriginalLSPMessage(diagnostic) ?? diagnostic.message;
         diagnostic = { ...diagnostic };
         diagnostic.message = diagnostic.message.replace("(fix available)", "").trim();
+        setOriginalLSPMessage(diagnostic, original);
         return diagnostic;
     };
 

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -20,7 +20,7 @@ import {
     vsdiag,
 } from "vscode-languageclient";
 
-import { DiagnosticsManager } from "../DiagnosticsManager";
+import { DiagnosticsManager, getOriginalLSPMessage } from "../DiagnosticsManager";
 import { WorkspaceContext } from "../WorkspaceContext";
 import { promptForDiagnostics } from "../commands/captureDiagnostics";
 import configuration from "../configuration";
@@ -317,6 +317,39 @@ export function lspClientOptions(
                     DiagnosticsManager.isSourcekit,
                     diagnostics
                 );
+            },
+            // `DiagnosticsManager` mutates messages for display (capitalize, strip
+            // `(fix available)`, etc.). Some language services on the server side
+            // — notably clangd — match diagnostics in `context.diagnostics` to
+            // cached fix-its by `(range, message)`, so a mutated message produces
+            // a cache miss and no quickfix is returned. Restore the original
+            // message before forwarding.
+            provideCodeActions: async (document, range, context, token, next) => {
+                let restoredDiagnostics: readonly vscode.Diagnostic[] | undefined;
+                for (let i = 0; i < context.diagnostics.length; i++) {
+                    const d = context.diagnostics[i];
+                    const original = getOriginalLSPMessage(d);
+                    if (original !== undefined && original !== d.message) {
+                        if (restoredDiagnostics === undefined) {
+                            restoredDiagnostics = context.diagnostics.slice();
+                        }
+                        const restored = new vscode.Diagnostic(d.range, original, d.severity);
+                        restored.code = d.code;
+                        restored.source = d.source;
+                        restored.tags = d.tags;
+                        restored.relatedInformation = d.relatedInformation;
+                        (restoredDiagnostics as vscode.Diagnostic[])[i] = restored;
+                    }
+                }
+                if (restoredDiagnostics !== undefined) {
+                    const restoredContext: vscode.CodeActionContext = {
+                        diagnostics: restoredDiagnostics,
+                        only: context.only,
+                        triggerKind: context.triggerKind,
+                    };
+                    return next(document, range, restoredContext, token);
+                }
+                return next(document, range, context, token);
             },
             handleWorkDoneProgress: (() => {
                 let lastPrompted = new Date(0).getTime();

--- a/test/unit-tests/DiagnosticsManager.test.ts
+++ b/test/unit-tests/DiagnosticsManager.test.ts
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+import * as vscode from "vscode";
+
+import { DiagnosticsManager, getOriginalLSPMessage } from "@src/DiagnosticsManager";
+
+import { mockObject } from "../MockUtils";
+
+suite("DiagnosticsManager preserves the original LSP message", () => {
+    // The mutation that breaks clangd lookups: stripping "(fix available)" from
+    // diagnostic messages so the Problems panel reads cleaner.
+    //
+    // clangd matches diagnostics in `context.diagnostics` against its fix-it
+    // cache using (range, message) — see ClangdLSPServer.h `struct DiagKey`.
+    // If we hand back a mutated message, the lookup misses and no quickfix is
+    // returned. The fix is to stash the original message on the diagnostic so
+    // a `provideCodeActions` middleware can restore it before forwarding.
+    test("stashes the original message before mutating it for display", () => {
+        const workspaceContext = mockObject<{ logger: { error: (msg: string) => void } }>({
+            logger: mockObject({ error: () => undefined }),
+        });
+        const manager = new DiagnosticsManager(workspaceContext as never);
+
+        const uri = vscode.Uri.parse("file:///tmp/Foo.m");
+        const diag = new vscode.Diagnostic(
+            new vscode.Range(2, 16, 2, 19),
+            "method definition for 'bravo:' not found (fix available)",
+            vscode.DiagnosticSeverity.Warning
+        );
+        diag.source = "clang";
+        diag.code = "-Wincomplete-implementation";
+
+        manager.handleDiagnostics(uri, DiagnosticsManager.isSourcekit, [diag]);
+
+        const stored = (manager.allDiagnostics.get(uri.fsPath) ?? [])[0];
+        expect(stored, "diagnostic should be stored").to.not.be.undefined;
+        // Display message is mutated as before.
+        expect(stored.message).to.equal("Method definition for 'bravo:' not found");
+        // But we kept the original for the LSP round-trip.
+        expect(getOriginalLSPMessage(stored)).to.equal(
+            "method definition for 'bravo:' not found (fix available)"
+        );
+
+        manager.dispose();
+    });
+
+    test("leaves the stash undefined when nothing is mutated", () => {
+        const workspaceContext = mockObject<{ logger: { error: (msg: string) => void } }>({
+            logger: mockObject({ error: () => undefined }),
+        });
+        const manager = new DiagnosticsManager(workspaceContext as never);
+
+        const uri = vscode.Uri.parse("file:///tmp/Foo.swift");
+        // An already-capitalized message with no "(fix available)" suffix —
+        // capitalize and clean are both no-ops but stash should still resolve
+        // to the original (== current) message.
+        const diag = new vscode.Diagnostic(
+            new vscode.Range(0, 0, 0, 1),
+            "Type 'A' has no member 'b'",
+            vscode.DiagnosticSeverity.Error
+        );
+        diag.source = "sourcekitd";
+
+        manager.handleDiagnostics(uri, DiagnosticsManager.isSourcekit, [diag]);
+
+        const stored = (manager.allDiagnostics.get(uri.fsPath) ?? [])[0];
+        expect(stored.message).to.equal("Type 'A' has no member 'b'");
+        expect(getOriginalLSPMessage(stored)).to.equal("Type 'A' has no member 'b'");
+
+        manager.dispose();
+    });
+});


### PR DESCRIPTION
## Summary
- `DiagnosticsManager` capitalizes and strips `(fix available)` from incoming LSP diagnostic messages for display. That mutated message is stored in the `DiagnosticCollection` and is the one VS Code subsequently puts into `context.diagnostics` on `textDocument/codeAction` requests.
- clangd matches diagnostics in `context.diagnostics` against its fix-it cache by `(range, message)` ([`ClangdLSPServer.h` — `struct DiagKey`](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clangd/ClangdLSPServer.h#L251-L260)). A mutated message means the lookup misses and no quickfix comes back.
- Stash the pre-mutation message on each diagnostic and add a `provideCodeActions` middleware that restores it before forwarding. Display-side behavior is unchanged.

This is the user-visible symptom in swiftlang/sourcekit-lsp#2186 (no "Add method implementation" quickfix for `-Wincomplete-implementation` warnings on Objective-C files). With this patch, the existing clangd fix-it round-trips through vscode-swift end-to-end.

## Repro before this PR
Project with an `@interface` declaring methods and an `@implementation` that doesn't define all of them:
- `Foo.h`: declares `-bravo:` and `+charlie`
- `Foo.m`: `@implementation Foo` (alpha only)

clangd publishes two `-Wincomplete-implementation` warnings. Cursor on `Foo` in `@implementation Foo`, hit Cmd+. → no code actions appear. With the fix, the menu shows:
- "Apply fix: insert `- (void)bravo:(NSString *)s {…`"
- "Apply fix: insert `+ (NSInteger)charlie {…`"

The clangd FIXME at `ClangdLSPServer.h:246-249` notes that long-term clangd should switch to using `Diagnostic.data`. That's being addressed separately; this PR is the immediate fix on the client side.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `npm run compile` clean
- [ ] CI runs the new `DiagnosticsManager.test.ts` (stashes original, no-op when nothing was mutated)
- [ ] Manual repro in VS Code with an iOS/Obj-C project that has missing method implementations

---

Yes, I authored this with my $200 Claude plan, I hope that's okay — it is the only way I can find the time to contribute features and bug fixes to the projects I love