### PR TITLE
GitHub actions test summary improvements

### DIFF
--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -29,6 +29,7 @@ import { fileExists } from "@src/utilities/filesystem";
 import { Version } from "@src/utilities/version";
 
 import { testAssetPath, testAssetUri } from "../../fixtures";
+import { attachCapturedLogs } from "../../reporters/utilities";
 import { closeAllEditors } from "../../utilities/commands";
 import { waitForNoRunningTasks } from "../../utilities/tasks";
 
@@ -38,19 +39,7 @@ export function getRootWorkspaceFolder(): vscode.WorkspaceFolder {
     return result;
 }
 
-interface Loggable {
-    get logs(): string[];
-}
-
-function printLogs(logger: Loggable, message: string) {
-    console.error(`${message}, captured logs are:`);
-    logger.logs.forEach(log => console.log(log));
-    console.log("======== END OF LOGS ========\n");
-}
-
-// Until the logger on the WorkspaceContext is available we capture logs here.
-// Once it becomes available (via setLogger) we forward logs to that logger to maintain ordering.
-class ExtensionActivationLogger implements Loggable {
+class ExtensionActivationLogger {
     private logger: SwiftLogger | undefined;
     private _logs: string[] = [];
 
@@ -106,11 +95,15 @@ class ExtensionActivationLogger implements Loggable {
 // Mocha doesn't give us a hook to run code when a before block times out.
 // This utility method can be used to dump logs right before the before block times out.
 // Ensure you pass in a timeout that is slightly less than mocha's `before` timeout.
-function configureLogDumpOnTimeout(timeout: number, logger: ExtensionActivationLogger) {
+function configureLogDumpOnTimeout(
+    timeout: number,
+    logger: ExtensionActivationLogger,
+    test: Mocha.Runnable | undefined
+): NodeJS.Timeout {
     return setTimeout(
         () => {
             logger.info(`Activating extension timed out!`);
-            printLogs(logger, "Activating extension exceeded the timeout");
+            attachCapturedLogs(test, logger.logs);
         },
         Math.max(0, timeout - 300)
     );
@@ -151,7 +144,7 @@ const extensionBootstrapper = (() => {
 
             // Mocha doesn't give us a hook to run code when a before block times out, so
             // we set a timeout to just before mocha's so we have time to print the logs.
-            const timer = configureLogDumpOnTimeout(SETUP_TIMEOUT_MS, activationLogger);
+            const timer = configureLogDumpOnTimeout(SETUP_TIMEOUT_MS, activationLogger, this.test);
 
             activationLogger.info(`Begin activating extension`);
 
@@ -231,7 +224,7 @@ const extensionBootstrapper = (() => {
             } catch (error: any) {
                 // Mocha will throw an error to break out of a test if `.skip` is used.
                 if (error.message?.indexOf("sync skip;") === -1) {
-                    printLogs(activationLogger, "Error during test/suite setup");
+                    attachCapturedLogs(this.test, activationLogger.logs);
                 }
                 throw error;
             } finally {
@@ -248,7 +241,7 @@ const extensionBootstrapper = (() => {
 
         mocha.afterEach(async function () {
             if (this.currentTest && activatedAPI && this.currentTest.isFailed()) {
-                printLogs(activationLogger, `Test failed: ${testTitle(this.currentTest)}`);
+                attachCapturedLogs(this.currentTest, activationLogger.logs);
             }
             if (vscode.debug.activeDebugSession) {
                 await vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
@@ -259,7 +252,11 @@ const extensionBootstrapper = (() => {
             // Allow enough time for the extension to deactivate
             this.timeout(TEARDOWN_TIMEOUT_MS);
 
-            const timer = configureLogDumpOnTimeout(TEARDOWN_TIMEOUT_MS, activationLogger);
+            const timer = configureLogDumpOnTimeout(
+                TEARDOWN_TIMEOUT_MS,
+                activationLogger,
+                this.test
+            );
 
             activationLogger.info("Deactivating extension...");
 
@@ -279,7 +276,7 @@ const extensionBootstrapper = (() => {
                 }
             } catch (error) {
                 if (workspaceContext) {
-                    printLogs(activationLogger, "Error during test/suite teardown");
+                    attachCapturedLogs(this.test, activationLogger.logs);
                 }
                 // We always want to restore settings and deactivate the extension even if the
                 // user supplied teardown fails. That way we have the best chance at not causing
@@ -360,10 +357,7 @@ const extensionBootstrapper = (() => {
             }
 
             if (!workspaceContext) {
-                printLogs(
-                    activationLogger,
-                    "Error during test/suite setup, workspace context could not be created"
-                );
+                attachCapturedLogs(currentTest, activationLogger.logs);
                 throw new Error("Extension did not activate. Workspace context is not available.");
             }
 

--- a/test/reporters/GitHubActionsSummaryReporter.ts
+++ b/test/reporters/GitHubActionsSummaryReporter.ts
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import * as chai from "chai";
 import { diffLines } from "diff";
 import * as fs from "fs";
 import * as mocha from "mocha";
@@ -22,12 +23,12 @@ const SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
 
 interface AssertionError extends Error {
     showDiff?: boolean;
-    actual: string;
-    expected: string;
+    actual: unknown;
+    expected: unknown;
 }
 
 function isAssertionError(err: Error): err is AssertionError {
-    return typeof (err as any).actual === "string" && typeof (err as any).expected === "string";
+    return Object.hasOwn(err, "actual") && Object.hasOwn(err, "expected");
 }
 
 module.exports = class GitHubActionsSummaryReporter extends mocha.reporters.Base {
@@ -90,33 +91,22 @@ function generateErrorMessage(failure: Mocha.Test): string {
 
 function convertErrorToString(error: Error): string {
     const stackTraceFilter = mocha.utils.stackTraceFilter();
-    let result: string;
-    if (isAssertionError(error) && error.showDiff) {
-        const stackTraceFilter = mocha.utils.stackTraceFilter();
-        const { message, stack } = splitStackTrace(error);
-        result =
-            message +
-            EOL +
-            generateDiff(error.actual, error.expected) +
-            EOL +
-            EOL +
-            stackTraceFilter(stack);
-    } else if (error.stack) {
-        result = stackTraceFilter(error.stack);
-    } else {
-        result = mocha.utils.stringify(error);
+    const { message, stack } = splitStackTrace(error);
+    let result = message;
+    if (isAssertionError(error)) {
+        const oneLineActualValue = prettyPrint(error.actual, { multiline: false });
+        const actualValueWasTruncated = oneLineActualValue.length > chai.config.truncateThreshold;
+        if (error.showDiff) {
+            result += EOL + generateDiff(error);
+        } else if (actualValueWasTruncated) {
+            result += EOL + "The full actual value was:" + EOL + prettyPrint(error.actual);
+        }
     }
-
-    if (!error.cause) {
-        return result;
-    }
-    let causedByString = "Caused By: ";
+    result += EOL + stackTraceFilter(stack);
     if (error.cause instanceof Error) {
-        causedByString += convertErrorToString(error.cause);
-    } else {
-        causedByString += mocha.utils.stringify(error.cause);
+        result += EOL + "Caused By: " + EOL + convertErrorToString(error.cause);
     }
-    return result + EOL + causedByString;
+    return result.replaceAll(/\r?\n/g, EOL);
 }
 
 function splitStackTrace(error: Error): { message: string; stack: string } {
@@ -132,7 +122,22 @@ function splitStackTrace(error: Error): { message: string; stack: string } {
     };
 }
 
-function generateDiff(actual: string, expected: string) {
+function prettyPrint(obj: unknown, options: { multiline: boolean } = { multiline: true }): string {
+    if (obj === undefined) {
+        return "undefined";
+    }
+
+    if (obj === null) {
+        return "null";
+    }
+
+    const spaces = options.multiline ? 2 : undefined;
+    return JSON.stringify(obj, undefined, spaces).replaceAll(/\r?\n/g, EOL);
+}
+
+function generateDiff(error: AssertionError) {
+    const actual = prettyPrint(error.actual);
+    const expected = prettyPrint(error.expected);
     return [
         "🟩 expected 🟥 actual" + EOL + EOL,
         ...diffLines(expected, actual).map(part => {

--- a/test/reporters/GitHubActionsSummaryReporter.ts
+++ b/test/reporters/GitHubActionsSummaryReporter.ts
@@ -15,6 +15,8 @@ import { diffLines } from "diff";
 import * as fs from "fs";
 import * as mocha from "mocha";
 
+import { getCapturedLogs } from "./utilities";
+
 const EOL = "\r\n";
 const SUMMARY_ENV_VAR = "GITHUB_STEP_SUMMARY";
 
@@ -182,13 +184,22 @@ function createMarkdownSummary(title: string, stats: Mocha.Stats, failures: Moch
         summary += list(
             failures.map(failure => {
                 const errorMessage = generateErrorMessage(failure);
-                return (
+                let content =
                     EOL +
                     tag("h5", [], fullTitle(failure)) +
                     EOL +
                     tag("pre", [], fixLineEndings(errorMessage)) +
-                    EOL
-                );
+                    EOL;
+                const logs = getCapturedLogs(failure);
+                if (logs && logs.length > 0) {
+                    content +=
+                        details(
+                            "Captured Extension Logs",
+                            false,
+                            tag("pre", [], fixLineEndings(logs.join("\n")))
+                        ) + EOL;
+                }
+                return content;
             })
         );
         summary += EOL;

--- a/test/reporters/utilities.ts
+++ b/test/reporters/utilities.ts
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2025 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * Attaches the provided array of log messages to a test so they can be
+ * retrieved later by a reporter (e.g. to include in a failure summary).
+ */
+export function attachCapturedLogs(test: Mocha.Runnable | undefined, logs: string[]): void {
+    if (!test) {
+        return;
+    }
+    (test as any).__VSCode_Swift_capturedLogs = [...logs];
+}
+
+/**
+ * Retrieves the array of log messages previously attached to a test via
+ * {@link attachCapturedLogs}, or `undefined` if none were set.
+ */
+export function getCapturedLogs(test: Mocha.Runnable): string[] | undefined {
+    return (test as any).__VSCode_Swift_capturedLogs;
+}


### PR DESCRIPTION
## Description
A couple improvements to the `GitHubActionsSummaryReporter` in CI:
- Add extension logs from integration tests to the failure summary
- Log the full actual value of an `AssertionError` if it has been truncated by `chai`

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
