### PR TITLE
Support swift-testing warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `swift.sourcekit-lsp.includeDeclarationInFindAllReferences` setting to control whether the symbol declaration is included in Find All References results ([#2236](https://github.com/swiftlang/vscode-swift/pull/2236))
+- Add support for [swift-testing warnings](https://github.com/swiftlang/swift-evolution/blob/main/proposals/testing/0013-issue-severity-warning.md) ([#2244](https://github.com/swiftlang/vscode-swift/pull/2244))
 
 ### Fixed
 

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -391,7 +391,18 @@ export class SwiftTestingOutputParser {
             .map(message => MessageRenderer.render(message))
             .join("\n");
 
-        if (payload.issue.isFailure === false && !payload.issue.isKnown) {
+        const isWarning =
+            payload.issue.severity === "warning" ||
+            (payload.issue.isFailure === false && !payload.issue.isKnown);
+
+        if (isWarning) {
+            issues.forEach(message => {
+                const text =
+                    additionalDetails.length > 0
+                        ? `${MessageRenderer.render(message)}: ${additionalDetails}`
+                        : MessageRenderer.render(message);
+                runState.recordWarning(testIndex, text, location);
+            });
             return;
         }
 

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -57,6 +57,10 @@ export interface ITestRunState {
         diff?: TestIssueDiff
     ): void;
 
+    // record a non-failing warning against a test. Warnings are surfaced via the
+    // test run output panel and as editor diagnostics, but do not mark the test as failed.
+    recordWarning(index: number, message: string, location?: vscode.Location): void;
+
     // set test index to have been skipped
     skipped(index: number): void;
 

--- a/src/TestExplorer/TestParsers/XCTestOutputParser.ts
+++ b/src/TestExplorer/TestParsers/XCTestOutputParser.ts
@@ -161,6 +161,9 @@ class ParallelXCTestRunStateProxy implements ITestRunState {
     ): void {
         this.runState.recordIssue(index, message, isKnown, location);
     }
+    recordWarning(index: number, message: string, location?: Location | undefined): void {
+        this.runState.recordWarning(index, message, location);
+    }
     started(index: number, startTime?: number | undefined): void {}
     completed(index: number, timing: { duration: number } | { timestamp: number }): void {}
     skipped(index: number): void {}

--- a/src/TestExplorer/TestRunProxy.ts
+++ b/src/TestExplorer/TestRunProxy.ts
@@ -35,6 +35,10 @@ function getWarningDiagnostics(): vscode.DiagnosticCollection {
     return warningDiagnostics;
 }
 
+export function clearTestWarningDiagnostics(): void {
+    warningDiagnostics?.clear();
+}
+
 /**
  * Test only structure that stores the state of test items.
  */
@@ -433,10 +437,7 @@ export class TestRunProxy implements vscode.CancellationToken {
     }
 
     private clearWarningDiagnostics() {
-        if (!warningDiagnostics) {
-            return;
-        }
-        warningDiagnostics.clear();
+        clearTestWarningDiagnostics();
         this.warningDiagnosticUris.clear();
     }
 

--- a/src/TestExplorer/TestRunProxy.ts
+++ b/src/TestExplorer/TestRunProxy.ts
@@ -26,6 +26,15 @@ import { reduceTestItemChildren } from "./TestUtils";
 
 import stripAnsi = require("strip-ansi");
 
+let warningDiagnostics: vscode.DiagnosticCollection | undefined;
+
+function getWarningDiagnostics(): vscode.DiagnosticCollection {
+    if (!warningDiagnostics) {
+        warningDiagnostics = vscode.languages.createDiagnosticCollection("swift-test-warnings");
+    }
+    return warningDiagnostics;
+}
+
 /**
  * Test only structure that stores the state of test items.
  */
@@ -58,6 +67,7 @@ export class TestRunProxy implements vscode.CancellationToken {
     private testRunCompleteEmitter = new vscode.EventEmitter<void>();
     private coverage: TestCoverage;
     private _testItems: vscode.TestItem[];
+    private warningDiagnosticUris = new Set<string>();
 
     /**
      * The list of test items for this test run
@@ -129,6 +139,7 @@ export class TestRunProxy implements vscode.CancellationToken {
 
         this.runStarted = true;
         this.resetTags(this.controller);
+        this.clearWarningDiagnostics();
 
         this.testRun = this.controller.createTestRun(this.testRunRequest);
         this.token.add(this.testRun.token);
@@ -389,6 +400,44 @@ export class TestRunProxy implements vscode.CancellationToken {
      */
     public appendOutputToTest(output: string, test: vscode.TestItem, location?: vscode.Location) {
         this.performAppendOutput(output, test, location);
+    }
+
+    /**
+     * Records a warning against a test. The warning is surfaced both in the test
+     * results output panel and as a `vscode.DiagnosticSeverity.Warning` diagnostic
+     * in the editor. The test itself is not marked as failed.
+     * @param test The test the warning is associated with.
+     * @param message The warning message.
+     * @param location Optional source location of the warning.
+     */
+    public recordWarning(test: vscode.TestItem, message: string, location?: vscode.Location) {
+        const symbol = SymbolRenderer.eventMessageSymbol(TestSymbol.warning);
+        const colored = `${SymbolRenderer.ansiEscapeCodePrefix}33m${message}${SymbolRenderer.resetANSIEscapeCode}`;
+
+        this.testRun?.appendOutput(`${symbol} ${colored}\r\n`, location, test);
+
+        if (!location) {
+            return;
+        }
+
+        const diagnostic = new vscode.Diagnostic(
+            location.range,
+            message,
+            vscode.DiagnosticSeverity.Warning
+        );
+        diagnostic.source = "swift-testing";
+        const collection = getWarningDiagnostics();
+        const existing = collection.get(location.uri) ?? [];
+        collection.set(location.uri, [...existing, diagnostic]);
+        this.warningDiagnosticUris.add(location.uri.toString());
+    }
+
+    private clearWarningDiagnostics() {
+        if (!warningDiagnostics) {
+            return;
+        }
+        warningDiagnostics.clear();
+        this.warningDiagnosticUris.clear();
     }
 
     private enqueued(test: vscode.TestItem) {

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -1191,6 +1191,14 @@ export class TestRunnerTestRunState implements ITestRunState {
         this.issues.set(index, issueList);
     }
 
+    recordWarning(index: number, message: string, location?: vscode.Location) {
+        if (this.isUnknownTest(index)) {
+            return;
+        }
+        const test = this.testRun.testItems[index];
+        this.testRun.recordWarning(test, message, location);
+    }
+
     // set test item to have been skipped
     skipped(index: number) {
         if (this.isUnknownTest(index)) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,6 +16,7 @@ import * as vscode from "vscode";
 
 import { debugSnippet, runSnippet } from "./SwiftSnippets";
 import { TestKind } from "./TestExplorer/TestKind";
+import { clearTestWarningDiagnostics } from "./TestExplorer/TestRunProxy";
 import { WorkspaceContext } from "./WorkspaceContext";
 import { attachDebugger } from "./commands/attachDebugger";
 import { cleanBuild, debugBuild, runBuild } from "./commands/build";
@@ -295,9 +296,10 @@ export function register(ctx: WorkspaceContext): Disposable[] {
             }
         }),
         vscode.commands.registerCommand("swift.attachDebugger", attachDebugger),
-        vscode.commands.registerCommand("swift.clearDiagnosticsCollection", () =>
-            ctx.diagnostics.clear()
-        ),
+        vscode.commands.registerCommand("swift.clearDiagnosticsCollection", () => {
+            ctx.diagnostics.clear();
+            clearTestWarningDiagnostics();
+        }),
         vscode.commands.registerCommand(
             "swift.captureDiagnostics",
             async () => await captureDiagnostics(ctx)

--- a/test/integration-tests/testexplorer/MockTestRunState.ts
+++ b/test/integration-tests/testexplorer/MockTestRunState.ts
@@ -34,6 +34,10 @@ export interface TestRunTestItem {
         location?: vscode.Location;
         diff?: TestIssueDiff;
     }[];
+    warnings?: {
+        message: string;
+        location?: vscode.Location;
+    }[];
     timing?: { duration: number } | { timestamp: number };
     output: string[];
 }
@@ -122,6 +126,13 @@ export class TestRunState implements ITestRunState {
             { message, location, isKnown, diff },
         ];
         this.testItemFinder.tests[index].status = TestStatus.failed;
+    }
+
+    recordWarning(index: number, message: string, location?: vscode.Location): void {
+        this.testItemFinder.tests[index].warnings = [
+            ...(this.testItemFinder.tests[index].warnings ?? []),
+            { message, location },
+        ];
     }
 
     skipped(index: number): void {

--- a/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -55,12 +55,14 @@ suite("SwiftTestingOutputParser Suite", () => {
     });
 
     type ExtractPayload<T> = T extends { payload: infer E } ? E : never;
+    type IssueOverrides = { isFailure?: boolean; severity?: string };
     function testEvent(
         name: ExtractPayload<EventRecord>["kind"],
         testID?: string,
         messages?: EventMessage[],
         sourceLocation?: SourceLocation,
-        testCaseID?: string
+        testCaseID?: string,
+        issueOverrides?: IssueOverrides
     ): EventRecord {
         return {
             kind: "event",
@@ -70,7 +72,9 @@ suite("SwiftTestingOutputParser Suite", () => {
                 instant: { absolute: 0, since1970: 0 },
                 messages: messages ?? [],
                 ...{ testID, sourceLocation },
-                ...(messages ? { issue: { sourceLocation, isKnown: false } } : {}),
+                ...(messages
+                    ? { issue: { sourceLocation, isKnown: false, ...issueOverrides } }
+                    : {}),
                 _testCase: {
                     id: testCaseID ?? testID,
                     displayName: testCaseID ?? testID,
@@ -306,24 +310,23 @@ suite("SwiftTestingOutputParser Suite", () => {
         ]);
     });
 
-    test("Issue with isFailure: false isn't recorded", async () => {
+    test("Issue with isFailure: false is recorded as a warning", async () => {
         const issueLocation = {
             _filePath: "file:///some/file.swift",
             line: 1,
             column: 2,
         };
-        const issueEvent = testEvent(
-            "issueRecorded",
-            "MyTests.MyTests/testWarning()",
-            [{ text: "This is a warning", symbol: TestSymbol.warning }],
-            issueLocation
-        );
-        (issueEvent.payload as any).issue.isFailure = false;
-
         const events = new TestEventStream([
             testEvent("runStarted"),
             testEvent("testCaseStarted", "MyTests.MyTests/testWarning()"),
-            issueEvent,
+            testEvent(
+                "issueRecorded",
+                "MyTests.MyTests/testWarning()",
+                [{ text: "This is a warning", symbol: TestSymbol.warning }],
+                issueLocation,
+                undefined,
+                { isFailure: false }
+            ),
             testEvent("testCaseEnded", "MyTests.MyTests/testWarning()"),
             testEvent("runEnded"),
         ]);
@@ -336,7 +339,94 @@ suite("SwiftTestingOutputParser Suite", () => {
                 status: TestStatus.passed,
                 timing: { timestamp: 0 },
                 output: [],
+                warnings: [
+                    {
+                        message: "This is a warning",
+                        location: new vscode.Location(
+                            vscode.Uri.file(issueLocation._filePath),
+                            new vscode.Position(issueLocation.line - 1, issueLocation.column)
+                        ),
+                    },
+                ],
             },
         ]);
+    });
+
+    test("Issue with severity: warning is recorded as a warning and the test passes", async () => {
+        const issueLocation = {
+            _filePath: "file:///some/file.swift",
+            line: 4,
+            column: 7,
+        };
+        const events = new TestEventStream([
+            testEvent("runStarted"),
+            testEvent("testCaseStarted", "MyTests.MyTests/testWarning()"),
+            testEvent(
+                "issueRecorded",
+                "MyTests.MyTests/testWarning()",
+                [{ text: "Deprecated API used", symbol: TestSymbol.warning }],
+                issueLocation,
+                undefined,
+                { severity: "warning", isFailure: false }
+            ),
+            testEvent("testCaseEnded", "MyTests.MyTests/testWarning()"),
+            testEvent("runEnded"),
+        ]);
+
+        await outputParser.watch("file:///mock/named/pipe", testRunState, events);
+
+        assert.deepEqual(testRunState.tests, [
+            {
+                name: "MyTests.MyTests/testWarning()",
+                status: TestStatus.passed,
+                timing: { timestamp: 0 },
+                output: [],
+                warnings: [
+                    {
+                        message: "Deprecated API used",
+                        location: new vscode.Location(
+                            vscode.Uri.file(issueLocation._filePath),
+                            new vscode.Position(issueLocation.line - 1, issueLocation.column)
+                        ),
+                    },
+                ],
+            },
+        ]);
+    });
+
+    test("A test with both a warning and a failing issue still fails", async () => {
+        const issueLocation = {
+            _filePath: "file:///some/file.swift",
+            line: 1,
+            column: 2,
+        };
+        const events = new TestEventStream([
+            testEvent("runStarted"),
+            testEvent("testCaseStarted", "MyTests.MyTests/testMixed()"),
+            testEvent(
+                "issueRecorded",
+                "MyTests.MyTests/testMixed()",
+                [{ text: "A warning", symbol: TestSymbol.warning }],
+                issueLocation,
+                undefined,
+                { severity: "warning", isFailure: false }
+            ),
+            testEvent(
+                "issueRecorded",
+                "MyTests.MyTests/testMixed()",
+                [{ text: "Expectation failed: bar == foo", symbol: TestSymbol.fail }],
+                issueLocation
+            ),
+            testEvent("testCaseEnded", "MyTests.MyTests/testMixed()"),
+            testEvent("runEnded"),
+        ]);
+
+        await outputParser.watch("file:///mock/named/pipe", testRunState, events);
+
+        assert.equal(testRunState.tests.length, 1);
+        assert.equal(testRunState.tests[0].status, TestStatus.failed);
+        assert.equal(testRunState.tests[0].warnings?.length, 1);
+        assert.equal(testRunState.tests[0].warnings?.[0].message, "A warning");
+        assert.equal(testRunState.tests[0].issues?.length, 1);
     });
 });


### PR DESCRIPTION
Implement support for SE-0013 (issue severity warnings), swift-testing emits issues with severity "warning" and `isFailure: false`. These were previously dropped silently by the JSON event stream parser.

Route warning-severity issues through a new `recordWarning` path that publishes them via `TestRun.appendOutput` (with location-linked yellow text in the editor view) and as `DiagnosticSeverity.Warning` entries in a "swift-test-warnings" `DiagnosticCollection` (for editor squiggles and the Problems panel). Tests with only warnings continue to pass; tests with both a warning and a failing issue still fail.

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
