### PR TITLE
Handle empty swiftly JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix swift-testing timeout when doing a Run All tests w/ multiple test targets when using swift-build ([#2207](https://github.com/swiftlang/vscode-swift/pull/2207))
 - Run toolchain executables via `swiftly run <tool>` when the active toolchain is managed by swiftly ([#2177](https://github.com/swiftlang/vscode-swift/pull/2177))
 - Fix swift.buildPath being ignored by swift package plugin tasks ([#2235](https://github.com/swiftlang/vscode-swift/pull/2235))
+- Fix error during toolchain selection when swiftly has no active toolchain ([#2246](https://github.com/swiftlang/vscode-swift/pull/2246))
 
 ## 2.16.4 - 2026-04-21
 

--- a/src/commands/installSwiftlyToolchain.ts
+++ b/src/commands/installSwiftlyToolchain.ts
@@ -121,6 +121,7 @@ export async function promptToInstallSwiftlyToolchain(
             prompt: "Enter the branch name to list snapshot toolchains (e.g., 'main-snapshot', '6.1-snapshot')",
             placeHolder: "main-snapshot",
             value: "main-snapshot",
+            ignoreFocusOut: true,
         });
         if (!branch) {
             return; // User cancelled input

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -109,7 +109,7 @@ const SwiftlyListAvailableResult = z.object({
 });
 
 const InUseVersionResult = z.object({
-    version: z.string(),
+    version: z.optional(z.string()),
 });
 
 const SwiftlyProgressData = z.object({
@@ -565,6 +565,7 @@ export class Swiftly {
      */
     public static async inUseVersion(
         swiftlyPath: string = "swiftly",
+        logger?: SwiftLogger,
         cwd?: vscode.Uri
     ): Promise<string | undefined> {
         if (!this.isSupported()) {
@@ -578,8 +579,20 @@ export class Swiftly {
         const { stdout } = await execFile(swiftlyPath, ["use", "--format=json"], {
             cwd: cwd?.fsPath,
         });
-        const result = InUseVersionResult.parse(JSON.parse(stdout));
-        return result.version;
+        if (stdout.trim() === "") {
+            return undefined;
+        }
+        try {
+            const result = InUseVersionResult.parse(JSON.parse(stdout));
+            return result.version;
+        } catch (error) {
+            logger?.error(
+                Error(`Failed to parse swiftly JSON output: ${JSON.stringify(stdout)}`, {
+                    cause: error,
+                })
+            );
+            return undefined;
+        }
     }
 
     /**

--- a/src/ui/ToolchainSelection.ts
+++ b/src/ui/ToolchainSelection.ts
@@ -282,7 +282,7 @@ async function getQuickPickItems(
     if (activeToolchain) {
         let currentSwiftlyVersion: string | undefined = undefined;
         if (activeToolchain.manager === "swiftly") {
-            currentSwiftlyVersion = await Swiftly.inUseVersion("swiftly", cwd);
+            currentSwiftlyVersion = await Swiftly.inUseVersion("swiftly", logger, cwd);
             if (currentSwiftlyVersion === undefined) {
                 // swiftly <1.1.0 does not support JSON output and will report no active
                 // toolchain version. Fall back to using the active toolchain version as a

--- a/test/reporters/GitHubActionsSummaryReporter.ts
+++ b/test/reporters/GitHubActionsSummaryReporter.ts
@@ -132,7 +132,8 @@ function prettyPrint(obj: unknown, options: { multiline: boolean } = { multiline
     }
 
     const spaces = options.multiline ? 2 : undefined;
-    return JSON.stringify(obj, undefined, spaces).replaceAll(/\r?\n/g, EOL);
+    const prettyPrintedObj = JSON.stringify(obj, undefined, spaces) ?? "";
+    return prettyPrintedObj.replaceAll(/\r?\n/g, EOL);
 }
 
 function generateDiff(error: AssertionError) {

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -125,6 +125,59 @@ suite("Swiftly Unit Tests", () => {
         });
     });
 
+    suite("inUseVersion()", () => {
+        let mockLogger: SwiftLogger;
+
+        setup(() => {
+            mockLogger = instance(
+                mockObject<SwiftLogger>({
+                    error: mockFn(),
+                })
+            );
+            // Mock version check to return 1.1.1
+            mockUtilities.execFile.withArgs("swiftly", ["--version"]).resolves({
+                stdout: "1.1.1\n",
+                stderr: "",
+            });
+        });
+
+        test("returns the version of the active toolchain as reported by swiftly", async () => {
+            mockUtilities.execFile.withArgs("swiftly", ["use", "--format=json"]).resolves({
+                stdout: '{ "source" : { "globalDefault" : {} }, "version" : "6.3.2" }',
+                stderr: "",
+            });
+            expect(await Swiftly.inUseVersion("swiftly", mockLogger)).to.equal("6.3.2");
+            expect(mockLogger.error).to.not.have.been.called;
+        });
+
+        test("returns undefined if swiftly reports no toolchain version", async () => {
+            mockUtilities.execFile.withArgs("swiftly", ["use", "--format=json"]).resolves({
+                stdout: '{ "source" : { "globalDefault" : {} } }',
+                stderr: "",
+            });
+            expect(await Swiftly.inUseVersion("swiftly", mockLogger)).to.be.undefined;
+            expect(mockLogger.error).to.not.have.been.called;
+        });
+
+        test("returns undefined if swiftly gives empty output", async () => {
+            mockUtilities.execFile.withArgs("swiftly", ["use", "--format=json"]).resolves({
+                stdout: " ",
+                stderr: "",
+            });
+            expect(await Swiftly.inUseVersion("swiftly", mockLogger)).to.be.undefined;
+            expect(mockLogger.error).to.not.have.been.called;
+        });
+
+        test("returns undefined and logs an error if swiftly reports malformed JSON", async () => {
+            mockUtilities.execFile.withArgs("swiftly", ["use", "--format=json"]).resolves({
+                stdout: "{",
+                stderr: "",
+            });
+            expect(await Swiftly.inUseVersion("swiftly", mockLogger)).to.be.undefined;
+            expect(mockLogger.error).to.have.been.calledOnce;
+        });
+    });
+
     suite("list()", () => {
         test("should return toolchain names and locations from list command for version 1.1.0", async () => {
             // Mock version check to return 1.1.0


### PR DESCRIPTION
## Description
Swiftly version 1.1.1 outputs an empty string when doing a `swiftly use --format=json` without any installed toolchains. This causes `JSON.parse()` to throw an error and breaks toolchain selection. The extension will now properly handle this case as well as the upcoming fix that returns an empty object with no `"version"` property (swiftlang/swiftly#546).

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
