### PR TITLE
Cap the swift-testing-event-stream-version to the supported version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix swift-testing timeout when doing a Run All tests w/ multiple test targets when using swift-build ([#2207](https://github.com/swiftlang/vscode-swift/pull/2207))
 - Run toolchain executables via `swiftly run <tool>` when the active toolchain is managed by swiftly ([#2177](https://github.com/swiftlang/vscode-swift/pull/2177))
 - Fix swift.buildPath being ignored by swift package plugin tasks ([#2235](https://github.com/swiftlang/vscode-swift/pull/2235))
+- Fix nightly toolchains providing a value to `--swift-testing-event-stream-version` that swift-testing doesn't support ([#2247](https://github.com/swiftlang/vscode-swift/pull/2247))
 
 ## 2.16.4 - 2026-04-21
 

--- a/src/debugger/buildConfig.ts
+++ b/src/debugger/buildConfig.ts
@@ -52,6 +52,29 @@ export function effectiveBuildSystem(
     );
 }
 
+/**
+ * The highest swift-testing event stream version supported by this extension.
+ * Toolchains newer than this are clamped down so we don't pass a version that
+ * swift-testing in the toolchain doesn't yet understand.
+ */
+const MAX_SUPPORTED_SWIFT_TESTING_EVENT_STREAM_VERSION = new Version(6, 4, 0);
+
+/**
+ * Returns the value to pass to `--experimental-event-stream-version`.
+ * For Swift < 6.3 the version is `"0"`. For Swift >= 6.3 the version
+ * matches the toolchain `major.minor`, capped at the highest version
+ * this extension supports.
+ */
+export function swiftTestingEventStreamVersion(swiftVersion: Version): string {
+    if (swiftVersion.isLessThan(new Version(6, 3, 0))) {
+        return "0";
+    }
+    const capped = swiftVersion.isGreaterThan(MAX_SUPPORTED_SWIFT_TESTING_EVENT_STREAM_VERSION)
+        ? MAX_SUPPORTED_SWIFT_TESTING_EVENT_STREAM_VERSION
+        : swiftVersion;
+    return `${capped.major}.${capped.minor}`;
+}
+
 export function groupTestsByTarget(
     testArgs: readonly string[],
     c99ToName?: ReadonlyMap<string, string>
@@ -528,11 +551,9 @@ export class TestingConfigurationFactory {
             );
         }
 
-        // Starting in 6.3 the version string should match the toolchain version.
-        let versionString = "0";
-        if (this.ctx.toolchain.swiftVersion.isGreaterThanOrEqual(new Version(6, 3, 0))) {
-            versionString = `${this.ctx.toolchain.swiftVersion.major}.${this.ctx.toolchain.swiftVersion.minor}`;
-        }
+        // Starting in 6.3 the version string should match the toolchain version,
+        // capped at the highest version this extension supports.
+        const versionString = swiftTestingEventStreamVersion(this.ctx.toolchain.swiftVersion);
 
         const swiftTestingArgs = [
             ...this.ctx.toolchain.buildFlags.withAdditionalFlags(args),

--- a/test/unit-tests/debugger/buildConfig.test.ts
+++ b/test/unit-tests/debugger/buildConfig.test.ts
@@ -26,6 +26,7 @@ import {
     TestingConfigurationFactory,
     effectiveBuildSystem,
     groupTestsByTarget,
+    swiftTestingEventStreamVersion,
 } from "@src/debugger/buildConfig";
 import { BuildFlags } from "@src/toolchain/BuildFlags";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
@@ -350,6 +351,27 @@ suite("BuildConfig Test Suite", () => {
             expect(
                 effectiveBuildSystem(new Version(6, 4, 0), ["--build-system", "xcodebuild"])
             ).to.equal("swiftbuild");
+        });
+    });
+
+    suite("swiftTestingEventStreamVersion", () => {
+        test('returns "0" for Swift < 6.3.0', () => {
+            expect(swiftTestingEventStreamVersion(new Version(6, 2, 0))).to.equal("0");
+            expect(swiftTestingEventStreamVersion(new Version(6, 0, 0))).to.equal("0");
+            expect(swiftTestingEventStreamVersion(new Version(5, 9, 0))).to.equal("0");
+        });
+
+        test("returns toolchain major.minor for Swift 6.3.0", () => {
+            expect(swiftTestingEventStreamVersion(new Version(6, 3, 0))).to.equal("6.3");
+        });
+
+        test("returns toolchain major.minor for Swift 6.4.0", () => {
+            expect(swiftTestingEventStreamVersion(new Version(6, 4, 0))).to.equal("6.4");
+        });
+
+        test("caps at 6.4 for Swift > 6.4 (highest supported by this plugin)", () => {
+            expect(swiftTestingEventStreamVersion(new Version(6, 5, 0))).to.equal("6.4");
+            expect(swiftTestingEventStreamVersion(new Version(7, 0, 0))).to.equal("6.4");
         });
     });
 


### PR DESCRIPTION
## Description
Nightly toolchains have started reporting a Swift version of 6.5, which we blindly pass to the `--swift-testing-event-stream-version` flag. The swift testing event stream has no changes related to 6.5, and so reports it as an unknown version and fails to run tests.

We know we support up to 6.4, so cap the version that goes in to the flag. If swift-testing updates the event stream format, the PR that adds support for it to the VS Code Swift extension will need to bump this known version when it adds support. In this way we are never sending a version string higher than what we know we support.

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
