### PR TITLE
Verify plugin identity by upstream URL before auto-elevating permissions

### DIFF
--- a/src/FolderContext.ts
+++ b/src/FolderContext.ts
@@ -237,6 +237,10 @@ export class FolderContext implements ExternalFolderContext, Disposable {
             logger,
             configuration.disableSwiftPMIntegration
         );
+        // The load mutates `plugins` and `workspaceState` together (see
+        // TrustedPlugins.ts); fire both events so subscribers stay in sync.
+        await this.fireEvent(FolderOperation.pluginsUpdated);
+        await this.fireEvent(FolderOperation.workspaceStateUpdated);
     }
 
     /**

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -119,7 +119,7 @@ interface PackageResolvedPinFileV2 {
 }
 
 /** workspace-state.json file */
-interface WorkspaceState {
+export interface WorkspaceState {
     object: { dependencies: WorkspaceStateDependency[] };
     version: number;
 }
@@ -169,6 +169,7 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
     private contentsPromise: Promise<SwiftPackageState>;
     private contentsResolve: (value: SwiftPackageState | PromiseLike<SwiftPackageState>) => void;
     private tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
+    private pluginLoadQueue: Promise<void> = Promise.resolve();
 
     /**
      * SwiftPackage Constructor
@@ -376,12 +377,25 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
         logger: SwiftLogger,
         disableSwiftPMIntegration: boolean = false
     ) {
-        this.plugins = await SwiftPackage.loadPlugins(
-            this.folder,
-            toolchain,
-            logger,
-            disableSwiftPMIntegration
-        );
+        // Serialize concurrent invocations so each call observes a consistent
+        // (plugins, workspaceState) pair from the SAME SwiftPM resolve. Read
+        // workspace-state.json BEFORE assigning either field, since `swift
+        // package plugin --list` regenerates it as a side effect and trusted-plugin
+        // URL checks (see TrustedPlugins.ts) require the two fields to move
+        // together.
+        const next = this.pluginLoadQueue.then(async () => {
+            const newPlugins = await SwiftPackage.loadPlugins(
+                this.folder,
+                toolchain,
+                logger,
+                disableSwiftPMIntegration
+            );
+            const newWorkspaceState = await SwiftPackage.loadWorkspaceState(this.folder);
+            this.plugins = newPlugins;
+            this.workspaceState = newWorkspaceState;
+        });
+        this.pluginLoadQueue = next.catch(() => undefined);
+        await next;
     }
 
     /** Return if has valid contents */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -283,7 +283,6 @@ function handleFolderEvent(logger: SwiftLogger): (event: FolderEvent) => Promise
                     async () => {
                         await folder.loadSwiftPlugins(logger);
                         workspace.contextKeys.updateForPlugins(workspace.folders);
-                        await folder.fireEvent(FolderOperation.pluginsUpdated);
                     }
                 );
             }

--- a/src/tasks/SwiftPluginTaskProvider.ts
+++ b/src/tasks/SwiftPluginTaskProvider.ts
@@ -14,7 +14,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { PackagePlugin } from "../SwiftPackage";
+import { PackagePlugin, WorkspaceState } from "../SwiftPackage";
 import { WorkspaceContext } from "../WorkspaceContext";
 import configuration, {
     PluginPermissionConfiguration,
@@ -25,6 +25,13 @@ import { SwiftToolchain } from "../toolchain/toolchain";
 import { packageName, resolveTaskCwd } from "../utilities/tasks";
 import { swiftRuntimeEnv } from "../utilities/utilities";
 import { SwiftTask } from "./SwiftTaskProvider";
+import { PluginPermissions, getTrustedPluginPermissions } from "./TrustedPlugins";
+
+const NO_TRUSTED_PERMISSIONS: Required<PluginPermissions> = {
+    disableSandbox: false,
+    allowWritingToPackageDirectory: false,
+    disableTaskQueue: false,
+};
 
 // Interface class for defining task configuration
 interface TaskConfig {
@@ -32,6 +39,7 @@ interface TaskConfig {
     scope: vscode.WorkspaceFolder;
     presentationOptions?: vscode.TaskPresentationOptions;
     packageName?: string;
+    workspaceState?: WorkspaceState;
 }
 
 /**
@@ -63,6 +71,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
                             reveal: vscode.TaskRevealKind.Always,
                         },
                         packageName: packageName(folderContext),
+                        workspaceState: folderContext.swiftPackage.workspaceState,
                     })
                 );
             }
@@ -128,7 +137,7 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         // Add relative path current working directory
         const relativeCwd = path.relative(config.scope.uri.fsPath, config.cwd.fsPath);
         const taskDefinitionCwd = relativeCwd !== "" ? relativeCwd : undefined;
-        const definition = this.getTaskDefinition(plugin, taskDefinitionCwd);
+        const definition = this.getTaskDefinition(plugin, taskDefinitionCwd, config.workspaceState);
         let swiftArgs = [
             "package",
             ...this.pluginArgumentsFromConfiguration(config.scope, definition, plugin),
@@ -156,51 +165,19 @@ export class SwiftPluginTaskProvider implements vscode.TaskProvider {
         return task as SwiftTask;
     }
 
-    /**
-     * Get task definition for a command plugin
-     */
     private getTaskDefinition(
         plugin: PackagePlugin,
-        cwd: string | undefined
+        cwd: string | undefined,
+        workspaceState: WorkspaceState | undefined
     ): vscode.TaskDefinition {
-        const definition = {
+        return {
             type: "swift-plugin",
             command: plugin.command,
             args: [],
-            disableSandbox: false,
-            allowWritingToPackageDirectory: false,
             cwd,
-            disableTaskQueue: false,
+            ...NO_TRUSTED_PERMISSIONS,
+            ...getTrustedPluginPermissions(plugin, workspaceState),
         };
-        // There are common command plugins used across the package eco-system eg for docc generation
-        // Everytime these are run they need the same default setup.
-        switch (`${plugin.package}, ${plugin.command}`) {
-            case "swift-aws-lambda-runtime, archive":
-                definition.disableSandbox = true;
-                definition.disableTaskQueue = true;
-                break;
-
-            case "SwiftDocCPlugin, generate-documentation":
-                definition.allowWritingToPackageDirectory = true;
-                break;
-
-            case "SwiftDocCPlugin, preview-documentation":
-                definition.disableSandbox = true;
-                definition.allowWritingToPackageDirectory = true;
-                break;
-
-            case "SwiftFormat, swiftformat":
-                definition.allowWritingToPackageDirectory = true;
-                break;
-
-            case "swift-format, format-source-code":
-                definition.allowWritingToPackageDirectory = true;
-                break;
-
-            default:
-                break;
-        }
-        return definition;
     }
 
     /**

--- a/src/tasks/TrustedPlugins.ts
+++ b/src/tasks/TrustedPlugins.ts
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+/**
+ * Trust-policy module for SwiftPM plugin auto-elevation.
+ *
+ * The allowlist is keyed on the resolved upstream URL recorded in
+ * `.build/workspace-state.json`, not the workspace-controlled
+ * `Package(name:)` string. A workspace can claim any name it wants in its
+ * own `Package.swift`, but it cannot forge the URL SwiftPM cloned an
+ * external dependency from. That URL is the spoofing vector this module
+ * is designed to defeat.
+ */
+import { PackagePlugin, WorkspaceState } from "../SwiftPackage";
+
+export type PluginPermissions = {
+    disableSandbox?: boolean;
+    allowWritingToPackageDirectory?: boolean;
+    disableTaskQueue?: boolean;
+};
+
+type TrustedPluginEntry = {
+    urls: readonly string[];
+    command: string;
+    permissions: PluginPermissions;
+};
+
+const TRUSTED_PLUGINS: readonly TrustedPluginEntry[] = [
+    {
+        urls: [
+            "https://github.com/swiftlang/swift-docc-plugin",
+            "https://github.com/apple/swift-docc-plugin",
+        ],
+        command: "generate-documentation",
+        permissions: { allowWritingToPackageDirectory: true },
+    },
+    {
+        urls: [
+            "https://github.com/swiftlang/swift-docc-plugin",
+            "https://github.com/apple/swift-docc-plugin",
+        ],
+        command: "preview-documentation",
+        permissions: { disableSandbox: true, allowWritingToPackageDirectory: true },
+    },
+    {
+        urls: [
+            "https://github.com/swiftlang/swift-format",
+            "https://github.com/apple/swift-format",
+        ],
+        command: "format-source-code",
+        permissions: { allowWritingToPackageDirectory: true },
+    },
+    {
+        urls: ["https://github.com/nicklockwood/SwiftFormat"],
+        command: "swiftformat",
+        permissions: { allowWritingToPackageDirectory: true },
+    },
+    {
+        urls: ["https://github.com/swift-server/swift-aws-lambda-runtime"],
+        command: "archive",
+        permissions: { disableSandbox: true, disableTaskQueue: true },
+    },
+].map(entry => ({ ...entry, urls: entry.urls.map(normalizeUrl) }));
+
+/** Returns the auto-elevation permissions for `plugin` if its host package
+ * resolves from a known canonical upstream URL; otherwise returns `{}`. */
+export function getTrustedPluginPermissions(
+    plugin: PackagePlugin,
+    workspaceState: WorkspaceState | undefined
+): PluginPermissions {
+    const dep = workspaceState?.object?.dependencies?.find(
+        d => isRemoteSourceControl(d.packageRef.kind) && d.packageRef.name === plugin.package
+    );
+    if (!dep) {
+        return {};
+    }
+    const url = normalizeUrl(dep.packageRef.location);
+    const entry = TRUSTED_PLUGINS.find(e => e.command === plugin.command && e.urls.includes(url));
+    return { ...entry?.permissions };
+}
+
+// Swift 5.5 and earlier emit `"remote"`; 5.6+ emit `"remoteSourceControl"`.
+// Compare with `SwiftPackage.dependencyType`, which aliases the same way for
+// `"local"` <-> `"fileSystem"`.
+function isRemoteSourceControl(kind: string): boolean {
+    return kind === "remoteSourceControl" || kind === "remote";
+}
+
+function normalizeUrl(url: string): string {
+    let result = url.trim().toLowerCase();
+    if (result.endsWith("/")) {
+        result = result.slice(0, -1);
+    }
+    if (result.endsWith(".git")) {
+        result = result.slice(0, -4);
+    }
+    return result;
+}

--- a/test/unit-tests/SwiftPackage.test.ts
+++ b/test/unit-tests/SwiftPackage.test.ts
@@ -12,8 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 import { expect } from "chai";
+import * as fs from "fs/promises";
+import * as vscode from "vscode";
 
 import { SwiftPackage } from "@src/SwiftPackage";
+import { SwiftLogger } from "@src/logging/SwiftLogger";
+import { SwiftToolchain } from "@src/toolchain/toolchain";
+import * as utilities from "@src/utilities/utilities";
+
+import { instance, mockGlobalFunction, mockObject } from "../MockUtils";
 
 suite("SwiftPackage Suite", () => {
     suite("trimStdout", () => {
@@ -26,6 +33,186 @@ suite("SwiftPackage Suite", () => {
         test("returns empty string when output contains no JSON", () => {
             const output = "Another process is using this build folder";
             expect(SwiftPackage.trimStdout(output)).to.equal("");
+        });
+    });
+
+    suite("loadSwiftPlugins", () => {
+        // Pins the security guarantee that a pre-staged forged
+        // .build/workspace-state.json must not be authoritative once SwiftPM
+        // has been invoked. `swift package plugin --list` regenerates the
+        // file, so loadSwiftPlugins MUST refresh in-memory state from disk
+        // afterwards. See TrustedPlugins.ts for the URL-keyed allowlist that
+        // depends on this guarantee.
+        const readFileMock = mockGlobalFunction(fs, "readFile");
+        const execSwiftMock = mockGlobalFunction(utilities, "execSwift");
+
+        test("re-reads workspace-state.json after running SwiftPM", async () => {
+            // SwiftPM regenerates workspace-state.json as a side effect of
+            // `swift package plugin --list`. The post-load workspaceState
+            // must reflect the regenerated file, not whatever was on disk
+            // before. That refresh is how the forgery vector is closed. The
+            // concurrency / atomic-assignment guarantees that `plugins` and
+            // `workspaceState` come from the same resolve are pinned by the
+            // next two tests.
+            const initialWs = JSON.stringify({ version: 6, object: { dependencies: [] } });
+            const refreshedWs = JSON.stringify({
+                version: 6,
+                object: {
+                    dependencies: [
+                        {
+                            packageRef: {
+                                identity: "swift-docc-plugin",
+                                kind: "remoteSourceControl",
+                                location: "https://github.com/swiftlang/swift-docc-plugin",
+                                name: "SwiftDocCPlugin",
+                            },
+                            state: { name: "checkout" },
+                            subpath: "swift-docc-plugin",
+                        },
+                    ],
+                },
+            });
+            let workspaceStateReadCount = 0;
+            readFileMock.callsFake((async (filePath: unknown) => {
+                const p = String(filePath);
+                if (p.endsWith("Package.resolved")) {
+                    throw new Error("ENOENT");
+                }
+                workspaceStateReadCount++;
+                return workspaceStateReadCount === 1 ? initialWs : refreshedWs;
+            }) as typeof fs.readFile);
+            execSwiftMock.resolves({ stdout: "", stderr: "" });
+
+            const pkg = await SwiftPackage.create(vscode.Uri.file("/tmp/swift-package-test"));
+            expect(pkg.workspaceState).to.deep.equal(JSON.parse(initialWs));
+
+            await pkg.loadSwiftPlugins(
+                instance(mockObject<SwiftToolchain>({})),
+                instance(mockObject<SwiftLogger>({}))
+            );
+
+            expect(pkg.workspaceState).to.deep.equal(JSON.parse(refreshedWs));
+            expect(workspaceStateReadCount).to.be.greaterThanOrEqual(2);
+        });
+
+        test("serializes concurrent invocations so plugins and workspaceState always come from the same SwiftPM resolve", async () => {
+            // Without serialization, two concurrent loadSwiftPlugins calls
+            // can interleave and leave `plugins` paired with a stale
+            // `workspaceState` from a different resolve, breaking
+            // trusted-plugin URL checks.
+            readFileMock.rejects(new Error("ENOENT"));
+
+            const events: string[] = [];
+            let resolveFirstExec: () => void = () => {};
+            const firstExecBlocked = new Promise<void>(r => {
+                resolveFirstExec = r;
+            });
+            execSwiftMock.callsFake((async () => {
+                const callId = execSwiftMock.callCount;
+                events.push(`exec-${callId}-start`);
+                if (callId === 1) {
+                    await firstExecBlocked;
+                }
+                events.push(`exec-${callId}-end`);
+                return { stdout: "", stderr: "" };
+            }) as typeof utilities.execSwift);
+
+            const pkg = await SwiftPackage.create(vscode.Uri.file("/tmp/swift-package-test"));
+            const toolchain = instance(mockObject<SwiftToolchain>({}));
+            const logger = instance(mockObject<SwiftLogger>({}));
+
+            const callA = pkg.loadSwiftPlugins(toolchain, logger);
+            const callB = pkg.loadSwiftPlugins(toolchain, logger);
+
+            // Let microtasks settle. Only the first call's execSwift should
+            // be in-flight; the second must wait its turn.
+            await new Promise(r => setImmediate(r));
+            expect(events).to.deep.equal(["exec-1-start"]);
+
+            resolveFirstExec();
+            await Promise.all([callA, callB]);
+
+            expect(events).to.deep.equal([
+                "exec-1-start",
+                "exec-1-end",
+                "exec-2-start",
+                "exec-2-end",
+            ]);
+        });
+
+        test("assigns plugins and workspaceState atomically so observers never see a partial-update pair", async () => {
+            // Pins the TOCTOU fix: between `loadPlugins` and
+            // `loadWorkspaceState` an observer (e.g. provideTasks) must not
+            // see new plugins paired with a still-stale workspaceState.
+            // Trusted-plugin URL checks consult both fields together; a
+            // partial-update window would let a forged on-disk
+            // workspace-state.json grant elevation against newly-loaded
+            // plugins.
+            const initialWs = JSON.stringify({
+                version: 6,
+                object: { dependencies: [] },
+            });
+            const refreshedWs = JSON.stringify({
+                version: 6,
+                object: {
+                    dependencies: [
+                        {
+                            packageRef: {
+                                identity: "swift-docc-plugin",
+                                kind: "remoteSourceControl",
+                                location: "https://github.com/swiftlang/swift-docc-plugin",
+                                name: "SwiftDocCPlugin",
+                            },
+                            state: { name: "checkout" },
+                            subpath: "swift-docc-plugin",
+                        },
+                    ],
+                },
+            });
+
+            let resolveRefreshRead: (contents: string) => void = () => {};
+            let workspaceStateReadCount = 0;
+            readFileMock.callsFake((async (filePath: unknown) => {
+                const p = String(filePath);
+                if (p.endsWith("Package.resolved")) {
+                    throw new Error("ENOENT");
+                }
+                if (p.endsWith("workspace-state.json")) {
+                    workspaceStateReadCount++;
+                    if (workspaceStateReadCount === 1) {
+                        return initialWs;
+                    }
+                    return new Promise<string>(r => {
+                        resolveRefreshRead = r;
+                    });
+                }
+                throw new Error(`unexpected: ${p}`);
+            }) as typeof fs.readFile);
+            execSwiftMock.resolves({ stdout: "", stderr: "" });
+
+            const pkg = await SwiftPackage.create(vscode.Uri.file("/tmp/swift-package-test"));
+            const initialPlugins = pkg.plugins;
+            const initialWorkspaceState = pkg.workspaceState;
+
+            const callPromise = pkg.loadSwiftPlugins(
+                instance(mockObject<SwiftToolchain>({})),
+                instance(mockObject<SwiftLogger>({}))
+            );
+
+            // Let microtasks settle so loadPlugins has completed and we are
+            // suspended awaiting the workspace-state refresh.
+            await new Promise(r => setImmediate(r));
+            await new Promise(r => setImmediate(r));
+
+            // Critical: neither field has been updated yet. They MUST move
+            // together, never independently.
+            expect(pkg.plugins).to.equal(initialPlugins);
+            expect(pkg.workspaceState).to.equal(initialWorkspaceState);
+
+            resolveRefreshRead(refreshedWs);
+            await callPromise;
+
+            expect(pkg.workspaceState).to.deep.equal(JSON.parse(refreshedWs));
         });
     });
 });

--- a/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
+++ b/test/unit-tests/tasks/SwiftPluginTaskProvider.test.ts
@@ -18,15 +18,18 @@ import { match } from "sinon";
 import * as vscode from "vscode";
 
 import { FolderContext } from "@src/FolderContext";
+import { PackagePlugin } from "@src/SwiftPackage";
 import { WorkspaceContext } from "@src/WorkspaceContext";
 import configuration from "@src/configuration";
 import { SwiftExecution } from "@src/tasks/SwiftExecution";
 import { SwiftPluginTaskProvider } from "@src/tasks/SwiftPluginTaskProvider";
+import { SwiftTask } from "@src/tasks/SwiftTaskProvider";
 import { BuildFlags } from "@src/toolchain/BuildFlags";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
 import { Version } from "@src/utilities/version";
 
 import { MockedObject, instance, mockFn, mockGlobalValue, mockObject } from "../../MockUtils";
+import { makeWorkspaceState } from "./fixtures/pluginFixtures";
 
 suite("SwiftPluginTaskProvider Unit Test Suite", () => {
     let workspaceContext: MockedObject<WorkspaceContext>;
@@ -325,6 +328,83 @@ suite("SwiftPluginTaskProvider Unit Test Suite", () => {
             );
             const swiftExecution = resolvedTask.execution as SwiftExecution;
             assert.equal(swiftExecution.options.env?.FOO, "bar");
+        });
+    });
+
+    suite("createSwiftPluginTask trusted-plugin auto-elevation", () => {
+        // Integration-level checks that getTaskDefinition's spread correctly
+        // forwards the result of getTrustedPluginPermissions to the resolved
+        // task. The exhaustive matrix lives in TrustedPlugins.test.ts.
+        type WorkspaceStateFixture = ReturnType<typeof makeWorkspaceState>;
+
+        function buildTask(
+            plugin: PackagePlugin,
+            workspaceState?: WorkspaceStateFixture
+        ): SwiftTask {
+            const taskProvider = new SwiftPluginTaskProvider(instance(workspaceContext));
+            return taskProvider.createSwiftPluginTask(plugin, instance(toolchain), {
+                cwd: workspaceFolder.uri,
+                scope: workspaceFolder,
+                workspaceState,
+            });
+        }
+
+        function flagsFromTask(task: SwiftTask): string[] {
+            return (task.execution as SwiftExecution).args;
+        }
+
+        test("auto-elevates SwiftDocCPlugin/preview-documentation from the canonical URL", () => {
+            const task = buildTask(
+                {
+                    command: "preview-documentation",
+                    name: "Swift-DocC",
+                    package: "SwiftDocCPlugin",
+                },
+                makeWorkspaceState([
+                    {
+                        name: "SwiftDocCPlugin",
+                        location: "https://github.com/swiftlang/swift-docc-plugin",
+                    },
+                ])
+            );
+            expect(flagsFromTask(task)).to.include.members([
+                "--disable-sandbox",
+                "--allow-writing-to-package-directory",
+            ]);
+        });
+
+        test("surfaces disableTaskQueue on the task definition for swift-aws-lambda-runtime/archive", () => {
+            // disableTaskQueue is not a CLI flag; it lives on the task
+            // definition. Pin that the spread merges it through correctly.
+            const task = buildTask(
+                {
+                    command: "archive",
+                    name: "AWSLambdaPackager",
+                    package: "swift-aws-lambda-runtime",
+                },
+                makeWorkspaceState([
+                    {
+                        name: "swift-aws-lambda-runtime",
+                        location: "https://github.com/swift-server/swift-aws-lambda-runtime",
+                    },
+                ])
+            );
+            expect(task.definition.disableTaskQueue).to.equal(true);
+        });
+
+        test("does NOT auto-elevate when a root package spoofs the SwiftDocCPlugin name", () => {
+            const flags = flagsFromTask(
+                buildTask(
+                    {
+                        command: "preview-documentation",
+                        name: "Trojan",
+                        package: "SwiftDocCPlugin",
+                    },
+                    makeWorkspaceState([])
+                )
+            );
+            expect(flags).to.not.include("--disable-sandbox");
+            expect(flags).to.not.include("--allow-writing-to-package-directory");
         });
     });
 });

--- a/test/unit-tests/tasks/TrustedPlugins.test.ts
+++ b/test/unit-tests/tasks/TrustedPlugins.test.ts
@@ -1,0 +1,274 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+
+import { PluginPermissions, getTrustedPluginPermissions } from "@src/tasks/TrustedPlugins";
+
+import { makePlugin, makeWorkspaceState } from "./fixtures/pluginFixtures";
+
+const SWIFTLANG_DOCC_URL = "https://github.com/swiftlang/swift-docc-plugin";
+const APPLE_DOCC_URL = "https://github.com/apple/swift-docc-plugin";
+const SWIFTLANG_FORMAT_URL = "https://github.com/swiftlang/swift-format";
+const APPLE_FORMAT_URL = "https://github.com/apple/swift-format";
+const NICKLOCKWOOD_SWIFTFORMAT_URL = "https://github.com/nicklockwood/SwiftFormat";
+const SWIFT_AWS_LAMBDA_URL = "https://github.com/swift-server/swift-aws-lambda-runtime";
+
+suite("TrustedPlugins Unit Test Suite", () => {
+    suite("returns no permissions when there is no proof of identity", () => {
+        // Each row models a distinct way an attacker, or a benign edge case,
+        // could fail to produce a verifiable upstream URL for a plugin.
+        type RefusalCase = {
+            description: string;
+            workspaceState: ReturnType<typeof makeWorkspaceState> | undefined;
+            command?: string;
+        };
+        const refusalCases: RefusalCase[] = [
+            {
+                description: "workspace state is undefined (fresh checkout, before resolve)",
+                workspaceState: undefined,
+            },
+            {
+                description: "plugin lives in the root workspace package",
+                workspaceState: makeWorkspaceState([]),
+            },
+            {
+                description: "plugin host package is a local path dependency",
+                workspaceState: makeWorkspaceState([
+                    {
+                        name: "SwiftDocCPlugin",
+                        location: "/Users/attacker/local-swift-docc-plugin",
+                        kind: "fileSystem",
+                    },
+                ]),
+            },
+            {
+                description: "plugin host package was added via a swift package registry",
+                workspaceState: makeWorkspaceState([
+                    {
+                        name: "SwiftDocCPlugin",
+                        location: "swiftlang.swift-docc-plugin",
+                        kind: "registry",
+                    },
+                ]),
+            },
+            {
+                description: "URL is a fork at a non-canonical host",
+                workspaceState: makeWorkspaceState([
+                    {
+                        name: "SwiftDocCPlugin",
+                        location: "https://github.com/attacker/swift-docc-plugin",
+                    },
+                ]),
+            },
+            {
+                description: "plugin command is not in the allowlist for the matched URL",
+                workspaceState: makeWorkspaceState([
+                    { name: "SwiftDocCPlugin", location: SWIFTLANG_DOCC_URL },
+                ]),
+                command: "evil-command",
+            },
+            {
+                description: "plugin's package name does not match any workspace-state entry",
+                workspaceState: makeWorkspaceState([
+                    { name: "swift-docc-plugin", location: SWIFTLANG_DOCC_URL },
+                ]),
+            },
+        ];
+
+        refusalCases.forEach(({ description, workspaceState, command }) => {
+            test(description, () => {
+                const result = getTrustedPluginPermissions(
+                    makePlugin({
+                        command: command ?? "preview-documentation",
+                        package: "SwiftDocCPlugin",
+                    }),
+                    workspaceState
+                );
+                expect(result).to.deep.equal({});
+            });
+        });
+    });
+
+    suite("grants the documented permissions for canonical trusted plugins", () => {
+        const trustedCases: Array<{
+            description: string;
+            packageName: string;
+            url: string;
+            command: string;
+            expected: PluginPermissions;
+        }> = [
+            {
+                description: "SwiftDocCPlugin / preview-documentation (swiftlang)",
+                packageName: "SwiftDocCPlugin",
+                url: SWIFTLANG_DOCC_URL,
+                command: "preview-documentation",
+                expected: { disableSandbox: true, allowWritingToPackageDirectory: true },
+            },
+            {
+                description: "SwiftDocCPlugin / preview-documentation (legacy apple/ alias)",
+                packageName: "SwiftDocCPlugin",
+                url: APPLE_DOCC_URL,
+                command: "preview-documentation",
+                expected: { disableSandbox: true, allowWritingToPackageDirectory: true },
+            },
+            {
+                description: "SwiftDocCPlugin / generate-documentation",
+                packageName: "SwiftDocCPlugin",
+                url: SWIFTLANG_DOCC_URL,
+                command: "generate-documentation",
+                expected: { allowWritingToPackageDirectory: true },
+            },
+            {
+                description: "swift-format / format-source-code (swiftlang)",
+                packageName: "swift-format",
+                url: SWIFTLANG_FORMAT_URL,
+                command: "format-source-code",
+                expected: { allowWritingToPackageDirectory: true },
+            },
+            {
+                description: "swift-format / format-source-code (legacy apple/ alias)",
+                packageName: "swift-format",
+                url: APPLE_FORMAT_URL,
+                command: "format-source-code",
+                expected: { allowWritingToPackageDirectory: true },
+            },
+            {
+                description: "nicklockwood SwiftFormat / swiftformat",
+                packageName: "SwiftFormat",
+                url: NICKLOCKWOOD_SWIFTFORMAT_URL,
+                command: "swiftformat",
+                expected: { allowWritingToPackageDirectory: true },
+            },
+            {
+                description: "swift-aws-lambda-runtime / archive",
+                packageName: "swift-aws-lambda-runtime",
+                url: SWIFT_AWS_LAMBDA_URL,
+                command: "archive",
+                expected: { disableSandbox: true, disableTaskQueue: true },
+            },
+        ];
+
+        trustedCases.forEach(({ description, packageName, url, command, expected }) => {
+            test(description, () => {
+                const result = getTrustedPluginPermissions(
+                    makePlugin({ command, package: packageName }),
+                    makeWorkspaceState([{ name: packageName, location: url }])
+                );
+                expect(result).to.deep.equal(expected);
+            });
+        });
+    });
+
+    suite("URL normalization tolerates SwiftPM-canonical variants", () => {
+        const normalizationCases: Array<{
+            description: string;
+            location: string;
+            matches: boolean;
+        }> = [
+            {
+                description: "trailing .git suffix",
+                location: `${SWIFTLANG_DOCC_URL}.git`,
+                matches: true,
+            },
+            { description: "trailing slash", location: `${SWIFTLANG_DOCC_URL}/`, matches: true },
+            {
+                description: "trailing `.git/` (both suffixes together)",
+                location: `${SWIFTLANG_DOCC_URL}.git/`,
+                matches: true,
+            },
+            {
+                description: "case differences on host and path",
+                location: "https://GitHub.com/SwiftLang/Swift-Docc-Plugin",
+                matches: true,
+            },
+            {
+                description: "URL containing canonical URL as a substring is NOT a match",
+                location: `https://github.com/attacker/proxy?u=${SWIFTLANG_DOCC_URL}`,
+                matches: false,
+            },
+        ];
+
+        normalizationCases.forEach(({ description, location, matches }) => {
+            test(description, () => {
+                const result = getTrustedPluginPermissions(
+                    makePlugin({ command: "preview-documentation", package: "SwiftDocCPlugin" }),
+                    makeWorkspaceState([{ name: "SwiftDocCPlugin", location }])
+                );
+                if (matches) {
+                    expect(result).to.have.property("disableSandbox", true);
+                } else {
+                    expect(result).to.deep.equal({});
+                }
+            });
+        });
+    });
+
+    test("returned permissions are a fresh copy (mutating one call does not affect another)", () => {
+        const ws = makeWorkspaceState([{ name: "SwiftDocCPlugin", location: SWIFTLANG_DOCC_URL }]);
+        const a = getTrustedPluginPermissions(
+            makePlugin({ command: "preview-documentation", package: "SwiftDocCPlugin" }),
+            ws
+        );
+        a.disableSandbox = false;
+        const b = getTrustedPluginPermissions(
+            makePlugin({ command: "preview-documentation", package: "SwiftDocCPlugin" }),
+            ws
+        );
+        expect(b.disableSandbox).to.equal(true);
+    });
+
+    test('accepts the legacy SwiftPM `kind: "remote"` alias for `"remoteSourceControl"`', () => {
+        // Pre-Swift-5.6 toolchains write `"kind": "remote"` for the same
+        // dependency type later renamed `"remoteSourceControl"`. The codebase
+        // already aliases `"local"` <-> `"fileSystem"` for this exact reason
+        // (SwiftPackage.ts:474-486). This test pins the same handling for
+        // the remote source-control case.
+        const result = getTrustedPluginPermissions(
+            makePlugin({ command: "preview-documentation", package: "SwiftDocCPlugin" }),
+            makeWorkspaceState([
+                { name: "SwiftDocCPlugin", location: SWIFTLANG_DOCC_URL, kind: "remote" },
+            ])
+        );
+        expect(result).to.deep.equal({
+            disableSandbox: true,
+            allowWritingToPackageDirectory: true,
+        });
+    });
+
+    suite("does not throw on malformed workspace-state.json shapes", () => {
+        // `loadWorkspaceState` does not validate the shape of the parsed JSON.
+        // Partial writes, future schema changes, or a hand-crafted file can
+        // produce values that don't satisfy the WorkspaceState type. The
+        // function MUST fail safe (return `{}`) rather than crash task
+        // creation.
+        const malformedCases: Array<{ description: string; ws: unknown }> = [
+            { description: "object property missing", ws: { version: 6 } },
+            { description: "dependencies property missing", ws: { version: 6, object: {} } },
+            {
+                description: "dependencies is not an array",
+                ws: { version: 6, object: { dependencies: null } },
+            },
+        ];
+
+        malformedCases.forEach(({ description, ws }) => {
+            test(description, () => {
+                const result = getTrustedPluginPermissions(
+                    makePlugin({ command: "preview-documentation", package: "SwiftDocCPlugin" }),
+                    ws as ReturnType<typeof makeWorkspaceState>
+                );
+                expect(result).to.deep.equal({});
+            });
+        });
+    });
+});

--- a/test/unit-tests/tasks/fixtures/pluginFixtures.ts
+++ b/test/unit-tests/tasks/fixtures/pluginFixtures.ts
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { PackagePlugin, WorkspaceState } from "@src/SwiftPackage";
+
+export function makePlugin(opts: {
+    command: string;
+    package: string;
+    name?: string;
+}): PackagePlugin {
+    return {
+        command: opts.command,
+        name: opts.name ?? opts.command,
+        package: opts.package,
+    };
+}
+
+export type WorkspaceStateDependencyFixture = {
+    name: string;
+    location: string;
+    kind?: string;
+    identity?: string;
+};
+
+export function makeWorkspaceState(deps: WorkspaceStateDependencyFixture[]): WorkspaceState {
+    return {
+        version: 6,
+        object: {
+            dependencies: deps.map(dep => ({
+                packageRef: {
+                    name: dep.name,
+                    location: dep.location,
+                    kind: dep.kind ?? "remoteSourceControl",
+                    identity: dep.identity ?? dep.name.toLowerCase(),
+                },
+                state: { name: "checkout" },
+                subpath: dep.name,
+            })),
+        },
+    };
+}


### PR DESCRIPTION
## Description

Previously, default permissions (disableSandbox, allowWritingToPackageDirectory, disableTaskQueue) were granted to plugins by matching `Package(name:)` and command. Since a workspace can claim any name in its own Package.swift, this allowed a malicious package to spoof a trusted plugin and bypass the trust prompt in the terminal.

Move the trust policy into a new `TrustedPlugins` module that keys the allowlist on the resolved upstream URL recorded in workspace-state.json. Serialize plugin loads in `SwiftPackage` so plugins and workspaceState are always read from the same SwiftPM resolve, and fire both update events from `FolderContext.loadSwiftPlugins` so subscribers stay in sync.

## Tasks
- [x] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
