### PR TITLE
Support SwiftBuild backend progress format and show planning phase

### DIFF
--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -587,8 +587,8 @@ export class TestRunner {
 
             task.execution.onDidWrite(str => {
                 const replaced = str
-                    .replace("[1/1] Planning build", "") // Work around SPM still emitting progress when doing --no-build.
-                    .replace(/\[1\/1\] Write swift-version-.*/gm, "")
+                    .replace(/\[1\s*\/\s*1\] Planning build/g, "") // Work around SPM still emitting progress when doing --no-build.
+                    .replace(/\[1\s*\/\s*1\] Write swift-version-.*/gm, "")
                     .replace(
                         /LLVM Profile Error: Failed to write file "default.profraw": Operation not permitted\r\n/gm,
                         ""

--- a/src/ui/SwiftBuildStatus.ts
+++ b/src/ui/SwiftBuildStatus.ts
@@ -160,6 +160,11 @@ export class SwiftBuildStatus implements Disposable {
                     started = true;
                     return false;
                 }
+                if (this.checkIfPlanning(line)) {
+                    update({ message: `${name}: Planning...` });
+                    started = true;
+                    return false;
+                }
             }
             return false;
         };
@@ -194,8 +199,13 @@ export class SwiftBuildStatus implements Disposable {
         return !!fetchRegex.exec(line);
     }
 
+    private checkIfPlanning(line: string): boolean {
+        const planningRegex = /^\[Planning\b/g;
+        return !!planningRegex.exec(line);
+    }
+
     private findBuildProgress(line: string): SwiftProgress | undefined {
-        const buildingRegex = /^\[(\d+)\/(\d+)\]/g;
+        const buildingRegex = /^\[(\d+)\s*\/\s*(\d+)\]/g;
         const match = buildingRegex.exec(line);
         if (match) {
             return { completed: parseInt(match[1]), total: parseInt(match[2]) };

--- a/test/unit-tests/ui/SwiftBuildStatus.test.ts
+++ b/test/unit-tests/ui/SwiftBuildStatus.test.ts
@@ -260,4 +260,35 @@ suite("SwiftBuildStatus Unit Test Suite", function () {
         // Report only the preparing message
         expect(mockedProgress.report).to.have.been.calledWith({ message: "My Task: Preparing..." });
     });
+
+    test("Parses progress with spaces around the slash (newer toolchains)", async () => {
+        configurationMock.setValue("progress");
+        buildStatus = new SwiftBuildStatus();
+        await didStartTaskMock.fire({ execution: mockedTaskExecution });
+
+        // swift-build emits a U+2009 THIN SPACE on either side of the slash
+        // via activityMessageFractionString; SwiftPM forwards it verbatim.
+        testSwiftProcess.write("[191 / 195] SimpleLibraryTests-product\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [191/195]",
+            increment: 97,
+        });
+    });
+
+    test("Reports Planning status during planning phase, then switches to progress", async () => {
+        configurationMock.setValue("progress");
+        buildStatus = new SwiftBuildStatus();
+        await didStartTaskMock.fire({ execution: mockedTaskExecution });
+
+        testSwiftProcess.write("[Planning 123 / 124]\n[Planning deferred tasks]\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: Planning...",
+        });
+
+        testSwiftProcess.write("[36 / 75]\n");
+        expect(mockedProgress.report).to.have.been.calledWith({
+            message: "My Task: [36/75]",
+            increment: 48,
+        });
+    });
 });


### PR DESCRIPTION
## Description
https://github.com/swiftlang/swift-package-manager/pull/10068 reworked how progress was printed using swift-build.

Progress is emitted as  `[N / M] target-name` (with spaces around the slash) plus `[Planning N / M]` / `[Planning deferred tasks]` lines during the planning phase. Our existing parser only matched `[N/M]`, so SwiftBuild progress never reached the status bar.

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
