### PR TITLE
Use xcrun to run executables in Xcode toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Fix swift-testing timeout when doing a Run All tests w/ multiple test targets when using swift-build ([#2207](https://github.com/swiftlang/vscode-swift/pull/2207))
 - Run toolchain executables via `swiftly run <tool>` when the active toolchain is managed by swiftly ([#2177](https://github.com/swiftlang/vscode-swift/pull/2177))
+- Run toolchain executables via `xcrun <tool>` when the active toolchain is managed by Xcode ([#2253](https://github.com/swiftlang/vscode-swift/pull/2253))
 - Fix swift.buildPath being ignored by swift package plugin tasks ([#2235](https://github.com/swiftlang/vscode-swift/pull/2235))
 - Fix nightly toolchains providing a value to `--swift-testing-event-stream-version` that swift-testing doesn't support ([#2247](https://github.com/swiftlang/vscode-swift/pull/2247))
 - Fix error during toolchain selection when swiftly has no active toolchain ([#2246](https://github.com/swiftlang/vscode-swift/pull/2246))

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -405,10 +405,14 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
      * @param args Arguments to pass to the executable (after any manager prefix).
      */
     public getToolchainInvocation(executable: string, args: string[]): ToolchainInvocation {
-        if (this.manager === "swiftly") {
-            return { command: "swiftly", args: ["run", executable, ...args] };
+        switch (this.manager) {
+            case "swiftly":
+                return { command: "swiftly", args: ["run", executable, ...args] };
+            case "xcrun":
+                return { command: "xcrun", args: [executable, ...args] };
+            default:
+                return { command: this.getToolchainExecutablePath(executable), args };
         }
-        return { command: this.getToolchainExecutablePath(executable), args };
     }
 
     private static _getToolchainExecutable(toolchainPath: string, executable: string): string {

--- a/test/unit-tests/toolchain/toolchain.test.ts
+++ b/test/unit-tests/toolchain/toolchain.test.ts
@@ -58,17 +58,15 @@ suite("SwiftToolchain Unit Test Suite", () => {
             expect(inv.args).to.deep.equal(["build", "--configuration", "debug"]);
         });
 
-        test("xcrun toolchain returns direct binary path with caller args", () => {
+        test("xcrun toolchain wraps as xcrun <tool>", () => {
             mockedPlatform.setValue("darwin");
             const tc = createToolchain(
                 "xcrun",
                 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr"
             );
             const inv = tc.getToolchainInvocation("swift", ["package", "describe"]);
-            expect(inv.command).to.equalPath(
-                "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
-            );
-            expect(inv.args).to.deep.equal(["package", "describe"]);
+            expect(inv.command).to.equalPath("xcrun");
+            expect(inv.args).to.deep.equal(["swift", "package", "describe"]);
         });
 
         test("swiftly toolchain wraps as swiftly run <tool>", () => {


### PR DESCRIPTION
## Description
Some executables in Xcode toolchains (e.g. `lldb-dap`) are not in the same folder as the `swift` executable. We can simplify our logic for this by just running all executables in Xcode toolchains via `xcrun` the same way we do for `swiftly`.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
