### PR TITLE
Change ESLint warnings to errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,9 +64,9 @@ export default defineConfig([
         },
         rules: {
             curly: "error",
-            eqeqeq: "warn",
-            "no-throw-literal": "warn",
-            "no-console": "warn",
+            eqeqeq: "error",
+            "no-throw-literal": "error",
+            "no-console": "error",
             "no-restricted-syntax": [
                 "error",
                 {
@@ -88,9 +88,9 @@ export default defineConfig([
                 },
             ],
 
-            "@typescript-eslint/no-floating-promises": ["warn", { checkThenables: true }],
+            "@typescript-eslint/no-floating-promises": ["error", { checkThenables: true }],
             "@typescript-eslint/no-misused-promises": "error",
-            "@typescript-eslint/await-thenable": "warn",
+            "@typescript-eslint/await-thenable": "error",
             "@typescript-eslint/no-non-null-assertion": "off",
             "@typescript-eslint/no-require-imports": "off",
             "@typescript-eslint/no-unused-vars": [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -304,9 +304,9 @@ export function registerCommands(api: InternalSwiftExtensionApi): Disposable[] {
             }
         }),
         vscode.commands.registerCommand("swift.attachDebugger", attachDebugger),
-        vscode.commands.registerCommand("swift.clearDiagnosticsCollection", () => {
-            api.withWorkspaceContext(ctx => ctx.diagnostics.clear());
+        vscode.commands.registerCommand("swift.clearDiagnosticsCollection", async () => {
             clearTestWarningDiagnostics();
+            await api.withWorkspaceContext(ctx => ctx.diagnostics.clear());
         }),
         vscode.commands.registerCommand("swift.captureDiagnostics", async () =>
             api.withWorkspaceContext(ctx => captureDiagnostics(ctx))


### PR DESCRIPTION
## Description
Some code quality issues made it into `main` because some of our ESLint rules are warnings. Change all warnings to errors so that this doesn't happen again.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
