### PR TITLE
Show post-install script contents inline in confirmation dialog (#2139)

### DIFF
--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -993,7 +993,7 @@ export class Swiftly {
     }
 
     /**
-     * Shows confirmation dialog to user for executing post-install script
+     * Shows confirmation dialog to user for running the post-install commands.
      *
      * @param version The toolchain version being installed
      * @param validation The validation result
@@ -1005,41 +1005,37 @@ export class Swiftly {
         validation: PostInstallValidationResult,
         logger?: SwiftLogger
     ): Promise<boolean> {
-        const summaryLines = validation.summary.split("\n");
-        const firstTwoLines = summaryLines.slice(0, 2).join("\n");
-
         const message =
-            `Swift ${version} installation requires additional system packages to be installed. ` +
-            `This will require administrator privileges.\n\n${firstTwoLines}\n\n` +
-            `Do you want to proceed with running the post-install script?`;
+            `Swift ${version} installation requires additional system packages to be installed.\n\n` +
+            `The Swift extension would like to run the following commands on your behalf:`;
+
+        const detail =
+            `${this.formatCommandsForReview(validation.scriptContent)}\n\n` +
+            `Do you want to proceed with running these commands? ` +
+            `You will be prompted for administrator privileges.`;
 
         logger?.warn(
-            `User confirmation required to execute post-install script for Swift ${version} installation,
-            this requires ${firstTwoLines} permissions.`
+            `User confirmation required to run post-install commands for Swift ${version} installation.`
         );
         const choice = await vscode.window.showWarningMessage(
             message,
-            {
-                modal: true,
-                detail: this.formatScriptForReview(validation.scriptContent),
-            },
-            "Execute Script"
+            { modal: true, detail },
+            "Run Commands"
         );
 
-        return choice === "Execute Script";
+        return choice === "Run Commands";
     }
 
     /**
-     * Formats the post-install script contents for display in the confirmation
-     * dialog's detail area. Very long scripts are truncated so the modal stays
-     * readable.
+     * Formats the post-install commands for display in the confirmation
+     * dialog's detail area. Very long command sets are truncated so the modal
+     * stays readable.
      */
-    private static formatScriptForReview(scriptContent: string): string {
-        const heading = "Script contents:";
+    private static formatCommandsForReview(scriptContent: string): string {
         const trimmed = scriptContent.replace(/\s+$/, "");
 
         if (!trimmed) {
-            return `${heading}\n(empty script)`;
+            return "(no commands)";
         }
 
         const maxLines = 50;
@@ -1061,10 +1057,10 @@ export class Swiftly {
         }
 
         if (truncated) {
-            body += "\n… (script truncated for display)";
+            body += "\n… (truncated for display)";
         }
 
-        return `${heading}\n${body}`;
+        return body;
     }
 
     /**

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -1005,62 +1005,40 @@ export class Swiftly {
         validation: PostInstallValidationResult,
         logger?: SwiftLogger
     ): Promise<boolean> {
-        const message =
-            `Swift ${version} installation requires additional system packages to be installed.\n\n` +
-            `The Swift extension would like to run the following commands on your behalf:`;
-
         const detail =
+            `Swift ${version} installation requires additional system packages to be installed:\n\n` +
             `${this.formatCommandsForReview(validation.scriptContent)}\n\n` +
-            `Do you want to proceed with running these commands? ` +
+            `Would you like to install these packages? ` +
             `You will be prompted for administrator privileges.`;
 
-        logger?.warn(
-            `User confirmation required to run post-install commands for Swift ${version} installation.`
-        );
+        logger?.warn(`User confirmation required to install system packages for Swift ${version}.`);
         const choice = await vscode.window.showWarningMessage(
-            message,
+            "Install System Packages",
             { modal: true, detail },
-            "Run Commands"
+            "Install"
         );
 
-        return choice === "Run Commands";
+        return choice === "Install";
     }
 
     /**
      * Formats the post-install commands for display in the confirmation
-     * dialog's detail area. Very long command sets are truncated so the modal
-     * stays readable.
+     * dialog's detail area. Commands are indented for readability and the
+     * list is truncated if it grows too long for the modal.
      */
     private static formatCommandsForReview(scriptContent: string): string {
-        const trimmed = scriptContent.replace(/\s+$/, "");
-
-        if (!trimmed) {
+        const trimmedScriptContent = scriptContent.trim();
+        if (trimmedScriptContent === "") {
             return "(no commands)";
         }
 
-        const maxLines = 50;
-        const maxChars = 4000;
-        const lines = trimmed.split("\n");
-
-        let body: string;
-        let truncated = false;
+        let lines = trimmedScriptContent.split("\n");
+        const maxLines = 10;
         if (lines.length > maxLines) {
-            body = lines.slice(0, maxLines).join("\n");
-            truncated = true;
-        } else {
-            body = trimmed;
+            lines = lines.slice(0, maxLines - 1);
+            lines.push("… (truncated for display)");
         }
-
-        if (body.length > maxChars) {
-            body = body.slice(0, maxChars);
-            truncated = true;
-        }
-
-        if (truncated) {
-            body += "\n… (truncated for display)";
-        }
-
-        return body;
+        return lines.map(line => `    ${line}`).join("\n");
     }
 
     /**

--- a/src/toolchain/swiftly.ts
+++ b/src/toolchain/swiftly.ts
@@ -131,6 +131,7 @@ export type SwiftlyProgressData = z.infer<typeof SwiftlyProgressData>;
 interface PostInstallValidationResult {
     isValid: boolean;
     summary: string;
+    scriptContent: string;
     invalidCommands?: string[];
 }
 
@@ -977,6 +978,7 @@ export class Swiftly {
             return {
                 isValid,
                 summary,
+                scriptContent,
                 invalidCommands: invalidCommands.length > 0 ? invalidCommands : undefined,
             };
         } catch (error) {
@@ -984,6 +986,7 @@ export class Swiftly {
             return {
                 isValid: false,
                 summary: "Failed to read post-install script",
+                scriptContent: "",
                 invalidCommands: ["Unable to read script file"],
             };
         }
@@ -1016,11 +1019,52 @@ export class Swiftly {
         );
         const choice = await vscode.window.showWarningMessage(
             message,
-            { modal: true },
+            {
+                modal: true,
+                detail: this.formatScriptForReview(validation.scriptContent),
+            },
             "Execute Script"
         );
 
         return choice === "Execute Script";
+    }
+
+    /**
+     * Formats the post-install script contents for display in the confirmation
+     * dialog's detail area. Very long scripts are truncated so the modal stays
+     * readable.
+     */
+    private static formatScriptForReview(scriptContent: string): string {
+        const heading = "Script contents:";
+        const trimmed = scriptContent.replace(/\s+$/, "");
+
+        if (!trimmed) {
+            return `${heading}\n(empty script)`;
+        }
+
+        const maxLines = 50;
+        const maxChars = 4000;
+        const lines = trimmed.split("\n");
+
+        let body: string;
+        let truncated = false;
+        if (lines.length > maxLines) {
+            body = lines.slice(0, maxLines).join("\n");
+            truncated = true;
+        } else {
+            body = trimmed;
+        }
+
+        if (body.length > maxChars) {
+            body = body.slice(0, maxChars);
+            truncated = true;
+        }
+
+        if (truncated) {
+            body += "\n… (script truncated for display)";
+        }
+
+        return `${heading}\n${body}`;
     }
 
     /**

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -1094,7 +1094,7 @@ apt-get -y install libncurses5-dev`;
             mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
+            mockVscodeWindow.showWarningMessage.resolves("Install");
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
@@ -1107,20 +1107,7 @@ apt-get -y install libncurses5-dev`;
                 match.any
             );
             expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
-                match(
-                    "Swift 6.0.0 installation requires additional system packages to be installed"
-                )
-            );
-            // Confirmation dialog must include the actual script contents inline
-            // so the user can review them without leaving the modal (issue #2139).
-            expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
-                match.string,
-                match({
-                    modal: true,
-                    detail: match("apt-get -y install build-essential").and(
-                        match("apt-get -y install libncurses5-dev")
-                    ),
-                })
+                match("Install System Packages")
             );
             expect(mockUtilities.execFile).to.have.been.calledWith("chmod", match.array);
             expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
@@ -1133,6 +1120,40 @@ apt-get -y install libncurses5-dev`;
             );
             expect(mockVscodeWindow.showInformationMessage).to.have.been.calledWith(
                 match("Swift 6.0.0 post-install script executed successfully")
+            );
+        });
+
+        test("should display the install commands inline in the confirmation dialog", async () => {
+            const validScript = `#!/bin/bash
+apt-get -y install build-essential
+apt-get -y install libncurses5-dev`;
+
+            mockUtilities.execFileStreamOutput
+                .withArgs("swiftly", [
+                    "install",
+                    "6.0.0",
+                    "--assume-yes",
+                    "--post-install-file",
+                    match.string,
+                ])
+                .callsFake(async (_command, args) => {
+                    const postInstallPath = args[4];
+                    await fs.writeFile(postInstallPath, validScript);
+                });
+
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.resolves("Cancel");
+
+            await Swiftly.installToolchain("6.0.0", "/path/to/extension");
+
+            expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
+                "Install System Packages",
+                match({
+                    modal: true,
+                    detail: match("apt-get -y install build-essential").and(
+                        match("apt-get -y install libncurses5-dev")
+                    ),
+                })
             );
         });
 
@@ -1167,9 +1188,7 @@ apt-get -y install build-essential`;
                 match.any
             );
             expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
-                match(
-                    "Swift 6.0.0 installation requires additional system packages to be installed"
-                )
+                match("Install System Packages")
             );
             expect(mockUtilities.execFile).to.not.have.been.calledWith("chmod", match.array);
             expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
@@ -1244,7 +1263,7 @@ apt-get -y install build-essential`;
                 .rejects(new Error("Permission denied"));
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
+            mockVscodeWindow.showWarningMessage.resolves("Install");
             mockVscodeWindow.showErrorMessage.resolves(undefined);
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
@@ -1258,9 +1277,7 @@ apt-get -y install build-essential`;
                 match.any
             );
             expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
-                match(
-                    "Swift 6.0.0 installation requires additional system packages to be installed"
-                )
+                match("Install System Packages")
             );
             expect(mockUtilities.execFile).to.have.been.calledWith("chmod", match.array);
             expect(mockVscodeWindow.showErrorMessage).to.have.been.calledWith(
@@ -1310,14 +1327,12 @@ yum install ncurses-devel`;
             mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
+            mockVscodeWindow.showWarningMessage.resolves("Install");
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
             expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
-                match(
-                    "Swift 6.0.0 installation requires additional system packages to be installed"
-                )
+                match("Install System Packages")
             );
             expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
                 "sudo",
@@ -1393,14 +1408,12 @@ apt-get -y install libncurses5-dev
             mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
+            mockVscodeWindow.showWarningMessage.resolves("Install");
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
             expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
-                match(
-                    "Swift 6.0.0 installation requires additional system packages to be installed"
-                )
+                match("Install System Packages")
             );
             expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
                 "sudo",

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -1094,7 +1094,7 @@ apt-get -y install libncurses5-dev`;
             mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Execute Script");
+            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
@@ -1244,7 +1244,7 @@ apt-get -y install build-essential`;
                 .rejects(new Error("Permission denied"));
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Execute Script");
+            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
             mockVscodeWindow.showErrorMessage.resolves(undefined);
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
@@ -1310,7 +1310,7 @@ yum install ncurses-devel`;
             mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Execute Script");
+            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
@@ -1393,7 +1393,7 @@ apt-get -y install libncurses5-dev
             mockUtilities.execFileStreamOutput.withArgs("sudo").resolves();
 
             // @ts-expect-error mocking vscode window methods makes type checking difficult
-            mockVscodeWindow.showWarningMessage.resolves("Execute Script");
+            mockVscodeWindow.showWarningMessage.resolves("Run Commands");
 
             await Swiftly.installToolchain("6.0.0", "/path/to/extension");
 
@@ -1442,7 +1442,7 @@ apt-get -y install libncurses5-dev
                 match.string,
                 match({
                     modal: true,
-                    detail: match("script truncated for display"),
+                    detail: match("(truncated for display)"),
                 })
             );
         });

--- a/test/unit-tests/toolchain/swiftly.test.ts
+++ b/test/unit-tests/toolchain/swiftly.test.ts
@@ -1111,6 +1111,17 @@ apt-get -y install libncurses5-dev`;
                     "Swift 6.0.0 installation requires additional system packages to be installed"
                 )
             );
+            // Confirmation dialog must include the actual script contents inline
+            // so the user can review them without leaving the modal (issue #2139).
+            expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
+                match.string,
+                match({
+                    modal: true,
+                    detail: match("apt-get -y install build-essential").and(
+                        match("apt-get -y install libncurses5-dev")
+                    ),
+                })
+            );
             expect(mockUtilities.execFile).to.have.been.calledWith("chmod", match.array);
             expect(mockUtilities.execFileStreamOutput).to.have.been.calledWith(
                 "sudo",
@@ -1398,6 +1409,41 @@ apt-get -y install libncurses5-dev
                 match.any,
                 null,
                 match.object
+            );
+        });
+
+        test("should truncate very long scripts when shown in the confirmation dialog", async () => {
+            // Build a script with many valid lines so the dialog detail must be truncated.
+            const installLines = Array.from(
+                { length: 80 },
+                (_, i) => `apt-get -y install package-${i}`
+            );
+            const longScript = `#!/bin/bash\n${installLines.join("\n")}`;
+
+            mockUtilities.execFileStreamOutput
+                .withArgs("swiftly", [
+                    "install",
+                    "6.0.0",
+                    "--assume-yes",
+                    "--post-install-file",
+                    match.string,
+                ])
+                .callsFake(async (_command, args) => {
+                    const postInstallPath = args[4];
+                    await fs.writeFile(postInstallPath, longScript);
+                });
+
+            // @ts-expect-error mocking vscode window methods makes type checking difficult
+            mockVscodeWindow.showWarningMessage.resolves("Cancel");
+
+            await Swiftly.installToolchain("6.0.0", "/path/to/extension");
+
+            expect(mockVscodeWindow.showWarningMessage).to.have.been.calledWith(
+                match.string,
+                match({
+                    modal: true,
+                    detail: match("script truncated for display"),
+                })
             );
         });
 


### PR DESCRIPTION
  ## Description

  Embeds the contents of the Swiftly post-install script directly inside the confirmation modal so the user can review what
  will be executed before granting elevated permissions. Previously the modal said "the script will perform the following
  actions" but only summarised the action category — there was no way to see the actual commands without opening the file
  out-of-band.

  This is the approach @matthewbastien recommended in the review of the previous attempt (#2140), where a separate **Review
  Script** button + preview tab caused the modal to dim/block when the user switched tabs. Putting the script inline removes
  that friction entirely.

  The script content is rendered in the modal's `detail` area via the existing `MessageOptions.detail` field on
  `vscode.window.showWarningMessage` — no new UI primitives.

  **Edge cases handled:**
  - Scripts longer than 50 lines or 4000 characters are truncated with a `… (script truncated for display)` notice so the
  modal stays readable.
  - Empty or comments-only scripts show `(empty script)` instead of a blank detail block.
  - File-read failures are still surfaced as before, via the existing validation path.

  **Example — before vs. after (typical Swiftly script):**

  Before:
<img width="526" height="854" alt="image" src="https://github.com/user-attachments/assets/17fb5f1f-62cb-4b51-9f05-b6e82d4bd4f5" />

  After (same modal, with `detail` now populated with sample data):
<img width="1108" height="644" alt="image" src="https://github.com/user-attachments/assets/856f8713-87c0-4fba-a9d3-eef4b454e979" />


  Issue: Fixes #2139. Supersedes #2140.

  ## Tasks
  - [x] Required tests have been written
  - [ ] Documentation has been updated
  - [x] Added an entry to CHANGELOG.md if applicable

  