### PR TITLE
Capture stderr and stdout in separate streams in ReadOnlySwiftProcess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Loading large projects will no longer show the extension as unresponsive ([#1932](https://github.com/swiftlang/vscode-swift/pull/1932))
+- Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 
 ## 2.16.5 - 2026-05-26
 

--- a/src/InternalSwiftExtensionApi.ts
+++ b/src/InternalSwiftExtensionApi.ts
@@ -119,6 +119,12 @@ export class InternalSwiftExtensionApi implements SwiftExtensionApi {
     // to avoid delaying extension activation.
     activate(callSite?: Error): void {
         if (this.state.type !== "uninitialized") {
+            this.logger.error(
+                new Error(
+                    `Cannot activate the Swift extension: it is in the "${this.state.type}" state instead of "uninitialized". This usually means a previous deactivation did not complete. The previous activation originated from:`,
+                    { cause: this.state.activatedBy }
+                )
+            );
             throw new Error("The Swift extension has already been activated.", {
                 cause: this.state.activatedBy,
             });
@@ -302,17 +308,31 @@ export class InternalSwiftExtensionApi implements SwiftExtensionApi {
     }
 
     async deactivate(): Promise<void> {
+        const deactivationStartTime = Date.now();
+        this.logger.info(`Deactivating extension from "${this.state.type}" state...`);
         this.contextKeys.isActivated = false;
         if (this.state.type === "initializing") {
+            this.logger.info("Cancelling in-progress workspace initialization...");
             this.state.cancel();
         }
         if (this.state.type === "active") {
-            await this.state.context.dispose();
-            this.state.subscriptions.forEach(s => s.dispose());
+            const { context, subscriptions } = this.state;
+            this.logger.info("Disposing workspace context...");
+            const contextDisposeStartTime = Date.now();
+            await context.dispose();
+            this.logger.info(
+                `Workspace context disposed in ${Date.now() - contextDisposeStartTime}ms`
+            );
+            this.logger.info(`Disposing ${subscriptions.length} workspace subscriptions...`);
+            subscriptions.forEach(s => s.dispose());
         }
+        this.logger.info(`Disposing ${this.subscriptions.length} extension subscriptions...`);
         this.subscriptions.forEach(subscription => subscription.dispose());
         this.subscriptions.length = 0;
         this.state = { type: "uninitialized" };
+        this.logger.info(
+            `Extension deactivation completed in ${Date.now() - deactivationStartTime}ms`
+        );
     }
 
     dispose(): void {

--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -548,11 +548,6 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
         );
     }
 
-    static trimStdout(stdout: string): string {
-        const index = stdout.indexOf("{");
-        return index === -1 ? "" : stdout.slice(index);
-    }
-
     dispose() {
         this.tokenSource.cancel();
         this.tokenSource.dispose();

--- a/src/WorkspaceContext.ts
+++ b/src/WorkspaceContext.ts
@@ -255,11 +255,20 @@ export class WorkspaceContext implements ExternalWorkspaceContext, AsyncDisposab
     }
 
     async dispose(): Promise<void> {
+        this.logger.info(`Disposing ${this.folders.length} folder(s)...`);
         this.folders.forEach(f => f.dispose());
         this.folders.length = 0;
+        this.logger.info(
+            `Disposing ${this.subscriptions.length} workspace context subscription(s)...`
+        );
         this.subscriptions.forEach(item => item.dispose());
         this.subscriptions.length = 0;
+        this.logger.info("Disposing language client manager...");
+        const languageClientDisposeStartTime = Date.now();
         await this.languageClientManager.dispose();
+        this.logger.info(
+            `Language client manager disposed in ${Date.now() - languageClientDisposeStartTime}ms`
+        );
     }
 
     get globalToolchainSwiftVersion() {

--- a/src/commands/dependencies/describe.ts
+++ b/src/commands/dependencies/describe.ts
@@ -14,7 +14,7 @@
 import * as vscode from "vscode";
 
 import { FolderContext } from "../../FolderContext";
-import { PackageContents, SwiftPackage } from "../../SwiftPackage";
+import { PackageContents } from "../../SwiftPackage";
 import configuration from "../../configuration";
 import { ReadOnlySwiftProcess } from "../../tasks/SwiftProcess";
 import { SwiftTaskProvider, createSwiftTask } from "../../tasks/SwiftTaskProvider";
@@ -58,10 +58,36 @@ export async function executeSwiftPackageCommand<T>(
         },
     });
 
-    const outputChunks: string[] = [];
-    const writeDisposable = swiftProcess.onDidWrite((data: string) => {
-        outputChunks.push(data);
+    const logger = folderContext.workspaceContext.logger;
+    const debugTag = `[stream-debug:${config.commandName}:${folderContext.name}]`;
+    const startedAt = Date.now();
+    const elapsed = () => `${Date.now() - startedAt}ms`;
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    let firstStdoutAt: number | undefined;
+    let firstStderrAt: number | undefined;
+    const stdoutDisposable = swiftProcess.onDidWriteStdout(data => {
+        if (firstStdoutAt === undefined) {
+            firstStdoutAt = Date.now() - startedAt;
+            logger.info(
+                `${debugTag} first stdout chunk @ ${firstStdoutAt}ms (${data.length} chars, head=${JSON.stringify(data.slice(0, 64))})`
+            );
+        }
+        stdoutChunks.push(data);
     });
+    const stderrDisposable = swiftProcess.onDidWriteStderr(data => {
+        if (firstStderrAt === undefined) {
+            firstStderrAt = Date.now() - startedAt;
+            logger.info(
+                `${debugTag} first stderr chunk @ ${firstStderrAt}ms (${data.length} chars, head=${JSON.stringify(data.slice(0, 64))})`
+            );
+        }
+        stderrChunks.push(data);
+    });
+    logger.info(
+        `${debugTag} starting; cmd=${inv.command} args=${JSON.stringify(inv.args)} cwd=${folderContext.folder.fsPath}`
+    );
 
     const task = createSwiftTask(
         config.args,
@@ -91,31 +117,49 @@ export async function executeSwiftPackageCommand<T>(
         );
         updateAfterError(success, folderContext);
 
-        const output = outputChunks.join("");
+        const stdout = stdoutChunks.join("");
+        const stderr = stderrChunks.join("");
+
+        // Hex dump the first 32 bytes of stdout to detect a BOM or non-printable
+        // prefix that would silently break JSON.parse without showing in a string log.
+        const stdoutHead = Buffer.from(stdout.slice(0, 32), "utf8").toString("hex");
+        const firstBraceAt = stdout.indexOf("{");
+        logger.info(
+            `${debugTag} task done @ ${elapsed()} success=${success} stdoutChunks=${stdoutChunks.length} (${stdout.length} chars) stderrChunks=${stderrChunks.length} (${stderr.length} chars) firstBraceAt=${firstBraceAt} stdoutHeadHex=${stdoutHead}`
+        );
+        logger.info(`${debugTag} STDOUT >>>>>\n${stdout}\n<<<<< STDOUT`);
+        logger.info(`${debugTag} STDERR >>>>>\n${stderr}\n<<<<< STDERR`);
 
         if (!success) {
-            throw new Error(output);
+            throw new Error(stderr || stdout);
         }
 
-        if (!output.trim()) {
+        if (!stdout.trim()) {
             throw new Error(`No output received from swift ${config.commandName} command`);
         }
 
-        const trimmedOutput = SwiftPackage.trimStdout(output);
-        if (trimmedOutput.length === 0) {
-            throw new Error(`No JSON output received from swift ${config.commandName} command`);
+        let parsedOutput: unknown;
+        try {
+            parsedOutput = JSON.parse(stdout);
+        } catch (err) {
+            logger.error(
+                `${debugTag} JSON.parse FAILED @ ${elapsed()}: ${err}. firstBraceAt=${firstBraceAt}, treating non-JSON prefix as a probable cause`
+            );
+            throw err;
         }
-        const parsedOutput = JSON.parse(trimmedOutput);
 
         if (!parsedOutput || typeof parsedOutput !== "object") {
             throw new Error(`Invalid format received from swift ${config.commandName} command`);
         }
 
+        logger.info(`${debugTag} parsed successfully @ ${elapsed()}`);
         return parsedOutput as T;
     } catch (parseError) {
+        logger.error(`${debugTag} executeSwiftPackageCommand failed @ ${elapsed()}: ${parseError}`);
         throw new Error(`Failed to parse ${config.commandName} output`, { cause: parseError });
     } finally {
-        writeDisposable.dispose();
+        stdoutDisposable.dispose();
+        stderrDisposable.dispose();
     }
 }
 

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -217,13 +217,14 @@ export class SwiftPtyProcess implements SwiftProcess {
 export class ReadOnlySwiftProcess implements SwiftProcess {
     private readonly spawnEmitter: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     private readonly writeEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    private readonly stdoutEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
+    private readonly stderrEmitter: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
     private readonly errorEmitter: vscode.EventEmitter<Error> = new vscode.EventEmitter<Error>();
     private readonly closeHandler: CloseHandler = new CloseHandler();
     private disposables: Disposable[] = [];
 
     private spawnedProcess: child_process.ChildProcessWithoutNullStreams | undefined;
 
-    // eslint-disable-next-line sonarjs/no-identical-functions
     constructor(
         public readonly command: string,
         public readonly args: string[],
@@ -232,6 +233,8 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
         this.disposables.push(
             this.spawnEmitter,
             this.writeEmitter,
+            this.stdoutEmitter,
+            this.stderrEmitter,
             this.errorEmitter,
             this.closeHandler
         );
@@ -239,33 +242,84 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
 
     spawn(): void {
         try {
+            const spawnAt = Date.now();
+            const elapsed = () => `${Date.now() - spawnAt}ms`;
+            const debugTag = `[ROSP] ${this.command} ${this.args.slice(0, 3).join(" ")}${this.args.length > 3 ? " …" : ""}`;
+            // eslint-disable-next-line no-console
+            console.log(`${debugTag} spawn() called`);
             this.spawnedProcess = child_process.spawn(this.command, this.args, {
                 cwd: this.options.cwd,
                 env: { ...process.env, ...this.options.env },
             });
             this.spawnEmitter.fire();
+            // eslint-disable-next-line no-console
+            console.log(`${debugTag} child pid=${this.spawnedProcess.pid} @ ${elapsed()}`);
+
+            let stdoutEnded = false;
+            let stderrEnded = false;
+            let exited = false;
 
             this.spawnedProcess.stdout.on("data", data => {
-                this.writeEmitter.fire(data.toString());
+                const text = data.toString();
+                this.stdoutEmitter.fire(text);
+                this.writeEmitter.fire(text);
                 this.closeHandler.reset();
+            });
+            this.spawnedProcess.stdout.once("end", () => {
+                stdoutEnded = true;
+                // eslint-disable-next-line no-console
+                console.log(`${debugTag} stdout 'end' @ ${elapsed()}`);
+            });
+            this.spawnedProcess.stdout.once("close", () => {
+                // eslint-disable-next-line no-console
+                console.log(`${debugTag} stdout 'close' @ ${elapsed()}`);
             });
 
             this.spawnedProcess.stderr.on("data", data => {
-                this.writeEmitter.fire(data.toString());
+                const text = data.toString();
+                this.stderrEmitter.fire(text);
+                this.writeEmitter.fire(text);
                 this.closeHandler.reset();
+            });
+            this.spawnedProcess.stderr.once("end", () => {
+                stderrEnded = true;
+                // eslint-disable-next-line no-console
+                console.log(`${debugTag} stderr 'end' @ ${elapsed()}`);
+            });
+            this.spawnedProcess.stderr.once("close", () => {
+                // eslint-disable-next-line no-console
+                console.log(`${debugTag} stderr 'close' @ ${elapsed()}`);
             });
 
             this.spawnedProcess.on("error", error => {
+                // eslint-disable-next-line no-console
+                console.log(`${debugTag} 'error' @ ${elapsed()}: ${error}`);
                 this.errorEmitter.fire(new Error(`${error}`));
                 this.closeHandler.handle();
             });
 
-            this.spawnedProcess.once("exit", code => {
+            this.spawnedProcess.once("exit", (code, signal) => {
+                exited = true;
+                // eslint-disable-next-line no-console
+                console.log(
+                    `${debugTag} 'exit' @ ${elapsed()} code=${code} signal=${signal} stdoutEnded=${stdoutEnded} stderrEnded=${stderrEnded}`
+                );
                 this.closeHandler.handle(code ?? undefined);
             });
 
+            this.spawnedProcess.once("close", (code, signal) => {
+                // eslint-disable-next-line no-console
+                console.log(
+                    `${debugTag} child 'close' @ ${elapsed()} code=${code} signal=${signal} exited=${exited}`
+                );
+            });
+
             this.disposables.push(
-                this.onDidClose(() => {
+                this.onDidClose(exitCode => {
+                    // eslint-disable-next-line no-console
+                    console.log(
+                        `${debugTag} closeHandler fired @ ${elapsed()} exitCode=${exitCode}`
+                    );
                     this.dispose();
                 })
             );
@@ -301,6 +355,16 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
     onDidSpawn: vscode.Event<void> = this.spawnEmitter.event;
 
     onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+
+    /**
+     * Listen for stdout-only output from the child process. Use this when
+     * parsing structured output (e.g. JSON) — `onDidWrite` interleaves stderr
+     * which corrupts the parse.
+     */
+    onDidWriteStdout: vscode.Event<string> = this.stdoutEmitter.event;
+
+    /** Listen for stderr-only output from the child process. */
+    onDidWriteStderr: vscode.Event<string> = this.stderrEmitter.event;
 
     onDidThrowError: vscode.Event<Error> = this.errorEmitter.event;
 

--- a/test/integration-tests/utilities/testutilities.ts
+++ b/test/integration-tests/utilities/testutilities.ts
@@ -291,10 +291,20 @@ const extensionBootstrapper = (() => {
             }
 
             activationLogger.info("Deactivation complete, calling deactivateExtension()");
-            await extensionBootstrapper.deactivateExtension();
+            try {
+                await extensionBootstrapper.deactivateExtension();
+            } catch (error) {
+                // A deactivation timeout is handled by the log-dump timer above, but if
+                // deactivation throws/rejects quickly the timer hasn't fired yet and the
+                // surrounding test has usually passed, so the per-test afterEach log capture
+                // won't fire either. Attach the logs to this hook so the reporter still
+                // prints them.
+                attachCapturedLogs(this.test, activationLogger.logs);
+                throw error;
+            } finally {
+                clearTimeout(timer);
+            }
             activationLogger.reset();
-
-            clearTimeout(timer);
 
             // Re-throw the user supplied teardown error
             if (userTeardownError) {
@@ -410,7 +420,13 @@ const extensionBootstrapper = (() => {
 
             // Wait for all tasks to complete before deactivating.
             // Long running tasks should be avoided in tests, but this is a safety net.
-            await waitForNoRunningTasks();
+            const runningTasks = vscode.tasks.taskExecutions.map(e => e.task.name);
+            activationLogger.info(
+                runningTasks.length > 0
+                    ? `Waiting for ${runningTasks.length} running task(s) to finish before deactivating: ${runningTasks.join(", ")}`
+                    : "No running tasks, proceeding with deactivation."
+            );
+            await logOnError("Waiting for no running tasks", () => waitForNoRunningTasks());
 
             // Close all editors before deactivating the extension.
             await logOnError(`Closing all editors.`, () => closeAllEditors());
@@ -422,8 +438,9 @@ const extensionBootstrapper = (() => {
                         getRootWorkspaceFolder()
                     ) ?? Promise.resolve()
             );
-            activationLogger.info(`Running extension deactivation function.`);
-            await activatedAPI.deactivate();
+            await logOnError(`Running extension deactivation function.`, () =>
+                activatedAPI!.deactivate()
+            );
             activationLogger.reset();
         },
 

--- a/test/reporters/GitHubActionsSummaryReporter.ts
+++ b/test/reporters/GitHubActionsSummaryReporter.ts
@@ -62,6 +62,7 @@ module.exports = class GitHubActionsSummaryReporter extends mocha.reporters.Base
         runner.on(EVENT_RUN_END, () => {
             const title = options.reporterOption.title ?? "Test Summary";
             this.appendSummary(createMarkdownSummary(title, this.stats, this.failures));
+            printCapturedLogsToConsole(this.failures);
         });
     }
 
@@ -80,6 +81,23 @@ function fullTitle(test: Mocha.Test | Mocha.Suite): string {
         return fullTitle(test.parent) + " → " + test.title;
     }
     return test.title;
+}
+
+/**
+ * Prints the captured extension logs for each failure to stdout. The
+ * GitHubActionsSummaryReporter normally only surfaces these in the job summary
+ * page, which is easy to miss; printing them to the console ensures they also
+ * appear in the raw CI logs alongside the failure.
+ */
+function printCapturedLogsToConsole(failures: Mocha.Test[]): void {
+    for (const failure of failures) {
+        const logs = getCapturedLogs(failure);
+        if (!logs || logs.length === 0) {
+            continue;
+        }
+        const header = `===== Captured extension logs: ${fullTitle(failure)} =====`;
+        console.log(`\n${header}\n${logs.join("\n")}\n${"=".repeat(header.length)}\n`);
+    }
 }
 
 function generateErrorMessage(failure: Mocha.Test): string {
@@ -201,7 +219,7 @@ function createMarkdownSummary(title: string, stats: Mocha.Stats, failures: Moch
                     content +=
                         details(
                             "Captured Extension Logs",
-                            false,
+                            true,
                             tag("pre", [], fixLineEndings(logs.join("\n")))
                         ) + EOL;
                 }

--- a/test/unit-tests/SwiftPackage.test.ts
+++ b/test/unit-tests/SwiftPackage.test.ts
@@ -23,19 +23,6 @@ import * as utilities from "@src/utilities/utilities";
 import { instance, mockGlobalFunction, mockObject } from "../MockUtils";
 
 suite("SwiftPackage Suite", () => {
-    suite("trimStdout", () => {
-        test("strips inline prefix before opening brace on the same line", () => {
-            const json = '{\n  "name": "MyPackage"\n}';
-            const output = `Another instance of SwiftPM is already running...${json}`;
-            expect(SwiftPackage.trimStdout(output)).to.equal(json);
-        });
-
-        test("returns empty string when output contains no JSON", () => {
-            const output = "Another process is using this build folder";
-            expect(SwiftPackage.trimStdout(output)).to.equal("");
-        });
-    });
-
     suite("loadSwiftPlugins", () => {
         // Pins the security guarantee that a pre-staged forged
         // .build/workspace-state.json must not be authoritative once SwiftPM


### PR DESCRIPTION
## Description
When calling `swift package describe` if the package has a warning it would be emitted on stderr. `SwiftProcess` blended stdout and stderr, which would cause an error when parsing the command as JSON.

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
