### PR TITLE
Override git safe.bareRepository for SwiftPM commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Loading large projects will no longer show the extension as unresponsive ([#1932](https://github.com/swiftlang/vscode-swift/pull/1932))
 - Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 - Reveal the task terminal when clicking the Swift build status item instead of showing a popup ([#2254](https://github.com/swiftlang/vscode-swift/pull/2254))
+- Override VS Code setting git `safe.bareRepository` to allow SwiftPM to resolve dependencies ([#2266](https://github.com/swiftlang/vscode-swift/pull/2266))
 
 ## 2.16.5 - 2026-05-26
 

--- a/src/tasks/SwiftProcess.ts
+++ b/src/tasks/SwiftProcess.ts
@@ -16,6 +16,7 @@ import type * as nodePty from "node-pty";
 import * as vscode from "vscode";
 
 import { Disposable } from "../utilities/Disposable";
+import { safeBareRepositoryEnvironmentOverride } from "../utilities/gitConfig";
 import { requireNativeModule } from "../utilities/native";
 
 const { spawn } = requireNativeModule<typeof nodePty>("node-pty");
@@ -138,9 +139,10 @@ export class SwiftPtyProcess implements SwiftProcess {
             // The pty process hangs on Windows when debugging the extension if we use conpty
             // See https://github.com/microsoft/node-pty/issues/640
             const useConpty = isWindows && process.env["VSCODE_DEBUG"] === "1" ? false : true;
+            const env = { ...process.env, ...this.options.env };
             this.spawnedProcess = spawn(this.command, this.args, {
                 cwd: this.options.cwd,
-                env: { ...process.env, ...this.options.env },
+                env: { ...env, ...safeBareRepositoryEnvironmentOverride(env) },
                 useConpty,
                 // https://github.com/swiftlang/vscode-swift/issues/1074
                 // Causing weird truncation issues
@@ -242,9 +244,10 @@ export class ReadOnlySwiftProcess implements SwiftProcess {
 
     spawn(): void {
         try {
+            const env = { ...process.env, ...this.options.env };
             this.spawnedProcess = child_process.spawn(this.command, this.args, {
                 cwd: this.options.cwd,
-                env: { ...process.env, ...this.options.env },
+                env: { ...env, ...safeBareRepositoryEnvironmentOverride(env) },
             });
             this.spawnEmitter.fire();
 

--- a/src/utilities/gitConfig.ts
+++ b/src/utilities/gitConfig.ts
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/**
+ * VS Code hardening injects `safe.bareRepository=explicit` into the environment
+ * using git's indexed `GIT_CONFIG_*` variables. SwiftPM does not understand this
+ * setting and fails to clone dependencies.
+ *
+ * Produce an environment override that resets each matching `GIT_CONFIG_VALUE_<n>`
+ * back to `all`, scoped to the swift processes we spawn. Only entries currently set
+ * to `explicit` are touched; all other git configuration is left untouched.
+ *
+ * This can be removed when the following issue is resolved:
+ * https://github.com/swiftlang/swift-package-manager/issues/8068
+ *
+ * @param env environment to inspect, defaults to the current process environment
+ * @returns the `GIT_CONFIG_VALUE_<n>` overrides to merge into a child environment
+ */
+export function safeBareRepositoryEnvironmentOverride(env: NodeJS.ProcessEnv = process.env): {
+    [key: string]: string;
+} {
+    const count = parseInt(env.GIT_CONFIG_COUNT ?? "", 10);
+    if (!Number.isFinite(count) || count <= 0) {
+        return {};
+    }
+    const indices = Array.from({ length: count }, (_, n) => n);
+    return indices.reduce<{ [key: string]: string }>((overrides, n) => {
+        const isExplicitBareRepository =
+            env[`GIT_CONFIG_KEY_${n}`] === "safe.bareRepository" &&
+            env[`GIT_CONFIG_VALUE_${n}`] === "explicit";
+        return isExplicitBareRepository
+            ? { ...overrides, [`GIT_CONFIG_VALUE_${n}`]: "all" }
+            : overrides;
+    }, {});
+}

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -20,6 +20,7 @@ import { FolderContext } from "../FolderContext";
 import configuration from "../configuration";
 import { SwiftToolchain } from "../toolchain/toolchain";
 import { Disposable } from "./Disposable";
+import { safeBareRepositoryEnvironmentOverride } from "./gitConfig";
 
 /**
  * Whether or not this is a production build.
@@ -162,6 +163,10 @@ export async function execFile(
             ...configuration.swiftEnvironmentVariables,
         };
     }
+    const bareRepositoryOverride = safeBareRepositoryEnvironmentOverride(options.env);
+    if (Object.keys(bareRepositoryOverride).length > 0) {
+        options.env = { ...(options.env ?? process.env), ...bareRepositoryOverride };
+    }
     options = {
         ...options,
         maxBuffer: options.maxBuffer ?? 1024 * 1024 * 64, // 64MB
@@ -216,6 +221,10 @@ export async function execFileStreamOutput(
         if (runtimeEnv && Object.keys(runtimeEnv).length > 0) {
             options.env = { ...(options.env ?? process.env), ...runtimeEnv };
         }
+    }
+    const bareRepositoryOverride = safeBareRepositoryEnvironmentOverride(options.env);
+    if (Object.keys(bareRepositoryOverride).length > 0) {
+        options.env = { ...(options.env ?? process.env), ...bareRepositoryOverride };
     }
     return new Promise<void>((resolve, reject) => {
         let cancellation: Disposable;

--- a/test/unit-tests/tasks/SwiftProcess.test.ts
+++ b/test/unit-tests/tasks/SwiftProcess.test.ts
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+import * as child_process from "child_process";
+import { EventEmitter } from "events";
+
+import { ReadOnlySwiftProcess } from "@src/tasks/SwiftProcess";
+
+import { mockGlobalModule } from "../../MockUtils";
+
+suite("ReadOnlySwiftProcess", () => {
+    const childProcessMock = mockGlobalModule(child_process);
+
+    function fakeChildProcess(): child_process.ChildProcessWithoutNullStreams {
+        const proc = new EventEmitter() as unknown as child_process.ChildProcessWithoutNullStreams;
+        (proc as unknown as { stdout: EventEmitter }).stdout = new EventEmitter();
+        (proc as unknown as { stderr: EventEmitter }).stderr = new EventEmitter();
+        return proc;
+    }
+
+    test("resets safe.bareRepository=explicit to all in the spawned environment", () => {
+        childProcessMock.spawn.returns(fakeChildProcess());
+
+        new ReadOnlySwiftProcess("swift", ["package", "resolve"], {
+            env: {
+                GIT_CONFIG_COUNT: "1",
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "explicit",
+            },
+        }).spawn();
+
+        expect(childProcessMock.spawn).to.have.been.calledOnce;
+        const spawnedEnv = childProcessMock.spawn.firstCall.args[2]?.env;
+        expect(spawnedEnv).to.include({ GIT_CONFIG_VALUE_0: "all" });
+    });
+
+    test("leaves the environment untouched when safe.bareRepository is not explicit", () => {
+        childProcessMock.spawn.returns(fakeChildProcess());
+
+        new ReadOnlySwiftProcess("swift", ["package", "resolve"], {
+            env: {
+                GIT_CONFIG_COUNT: "1",
+                GIT_CONFIG_KEY_0: "core.autocrlf",
+                GIT_CONFIG_VALUE_0: "false",
+            },
+        }).spawn();
+
+        const spawnedEnv = childProcessMock.spawn.firstCall.args[2]?.env;
+        expect(spawnedEnv).to.include({ GIT_CONFIG_VALUE_0: "false" });
+    });
+});

--- a/test/unit-tests/utilities/gitConfig.test.ts
+++ b/test/unit-tests/utilities/gitConfig.test.ts
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+
+import { safeBareRepositoryEnvironmentOverride } from "@src/utilities/gitConfig";
+
+suite("safeBareRepositoryEnvironmentOverride", () => {
+    test("returns nothing when no GIT_CONFIG variables are present", () => {
+        expect(safeBareRepositoryEnvironmentOverride({})).to.deep.equal({});
+    });
+
+    test("returns nothing when GIT_CONFIG_COUNT is missing but keys exist", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "explicit",
+            })
+        ).to.deep.equal({});
+    });
+
+    test("overrides safe.bareRepository=explicit at index 0", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "1",
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "explicit",
+            })
+        ).to.deep.equal({ GIT_CONFIG_VALUE_0: "all" });
+    });
+
+    test("overrides safe.bareRepository=explicit at a non-zero index", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "3",
+                GIT_CONFIG_KEY_0: "http.sslVerify",
+                GIT_CONFIG_VALUE_0: "true",
+                GIT_CONFIG_KEY_1: "core.autocrlf",
+                GIT_CONFIG_VALUE_1: "false",
+                GIT_CONFIG_KEY_2: "safe.bareRepository",
+                GIT_CONFIG_VALUE_2: "explicit",
+            })
+        ).to.deep.equal({ GIT_CONFIG_VALUE_2: "all" });
+    });
+
+    test("overrides every safe.bareRepository=explicit entry", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "2",
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "explicit",
+                GIT_CONFIG_KEY_1: "safe.bareRepository",
+                GIT_CONFIG_VALUE_1: "explicit",
+            })
+        ).to.deep.equal({ GIT_CONFIG_VALUE_0: "all", GIT_CONFIG_VALUE_1: "all" });
+    });
+
+    test("leaves safe.bareRepository entries that are not explicit untouched", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "1",
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "all",
+            })
+        ).to.deep.equal({});
+    });
+
+    test("ignores entries beyond GIT_CONFIG_COUNT", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "1",
+                GIT_CONFIG_KEY_0: "http.sslVerify",
+                GIT_CONFIG_VALUE_0: "true",
+                GIT_CONFIG_KEY_1: "safe.bareRepository",
+                GIT_CONFIG_VALUE_1: "explicit",
+            })
+        ).to.deep.equal({});
+    });
+
+    test("returns nothing when GIT_CONFIG_COUNT is not a valid number", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "not-a-number",
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "explicit",
+            })
+        ).to.deep.equal({});
+    });
+
+    test("returns nothing when GIT_CONFIG_COUNT is zero or negative", () => {
+        expect(
+            safeBareRepositoryEnvironmentOverride({
+                GIT_CONFIG_COUNT: "0",
+                GIT_CONFIG_KEY_0: "safe.bareRepository",
+                GIT_CONFIG_VALUE_0: "explicit",
+            })
+        ).to.deep.equal({});
+    });
+});


### PR DESCRIPTION
## Description
New VS Code versions do hardening and injects `safe.bareRepository=explicit` via GIT_CONFIG_* env vars. SwiftPM currently fails to pull dependencies from bare repositories (see https://github.com/swiftlang/swift-package-manager/issues/8068)

Add `safeBareRepositoryEnvironmentOverride` to reset matching entries to `all`, applied at every swift spawn.

Issue: #2263

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
