### PR TITLE
Use xcrun to launch debugger executables when swiftly is using an Xcode toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 - Reveal the task terminal when clicking the Swift build status item instead of showing a popup ([#2254](https://github.com/swiftlang/vscode-swift/pull/2254))
 - Override VS Code setting git `safe.bareRepository` to allow SwiftPM to resolve dependencies ([#2266](https://github.com/swiftlang/vscode-swift/pull/2266))
+- Fix debug sessions not being launched when swiftly is using an Xcode toolchain ([#2268](https://github.com/swiftlang/vscode-swift/pull/2268))
 
 ## 2.16.5 - 2026-05-26
 

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -317,7 +317,7 @@ export class LLDBDebugConfigurationProvider implements vscode.DebugConfiguration
             return true;
         }
 
-        const inv = toolchain.getToolchainInvocation("lldb-dap", []);
+        const inv = await toolchain.getDebuggerToolchainInvocation("lldb-dap", []);
         // lldb-dap requires that the debugAdapterExecutable always be an absolute path.
         if (!path.isAbsolute(inv.command)) {
             inv.command = await findBinaryInPath(inv.command);

--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -50,7 +50,7 @@ export async function getLLDBLibPath(toolchain: SwiftToolchain): Promise<Result<
     try {
         const statement = `print('<!' + lldb.SBHostOS.GetLLDBPath(lldb.ePathTypeLLDBShlibDir).fullpath + '!>')`;
         const lldbArgs = ["-b", "-O", `script ${statement}`];
-        const inv = toolchain.getToolchainInvocation("lldb", lldbArgs);
+        const inv = await toolchain.getDebuggerToolchainInvocation("lldb", lldbArgs);
         const { stdout } = await execFile(inv.command, inv.args);
         const m = /^<!([^!]*)!>/m.exec(stdout);
         if (m) {

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -405,9 +405,41 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
      * @param args Arguments to pass to the executable (after any manager prefix).
      */
     public getToolchainInvocation(executable: string, args: string[]): ToolchainInvocation {
+        if (["lldb", "lldb-dap"].includes(executable)) {
+            throw Error("Use getAlternativeToolchainInvocation() for lldb related binaries.");
+        }
         switch (this.manager) {
             case "swiftly":
                 return { command: "swiftly", args: ["run", executable, ...args] };
+            case "xcrun":
+                return { command: "xcrun", args: [executable, ...args] };
+            default:
+                return { command: this.getToolchainExecutablePath(executable), args };
+        }
+    }
+
+    /**
+     * Returns the command and arguments needed for running a given executable from the toolchain.
+     *
+     * The difference between this and {@link getToolchainInvocation} is that it will query xcrun if swiftly reports
+     * that it's using an xcode toolchain. This was added as a workaround until the upstream swiftly bug
+     * [swiftlang/swiftly#521](https://github.com/swiftlang/swiftly/issues/521) is fixed.
+     *
+     * @param executable The name of the executable to run
+     * @param args The arguments to pass to the executable
+     * @returns A Promise that resolves to the {@link ToolchainInvocation}
+     */
+    public async getDebuggerToolchainInvocation(
+        executable: "lldb" | "lldb-dap",
+        args: string[]
+    ): Promise<ToolchainInvocation> {
+        switch (this.manager) {
+            case "swiftly": {
+                if ((await Swiftly.inUseVersion()) === "xcode") {
+                    return { command: "xcrun", args: [executable, ...args] };
+                }
+                return { command: "swiftly", args: ["run", executable, ...args] };
+            }
             case "xcrun":
                 return { command: "xcrun", args: [executable, ...args] };
             default:

--- a/test/unit-tests/debugger/debugAdapterFactory.test.ts
+++ b/test/unit-tests/debugger/debugAdapterFactory.test.ts
@@ -61,7 +61,7 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
             swiftVersion: new Version(6, 0, 0),
             buildFlags: instance(mockBuildFlags),
             manager: "unknown",
-            getToolchainInvocation: mockFn(s =>
+            getDebuggerToolchainInvocation: mockFn(s =>
                 s.callsFake((executable: string, args: string[]) => ({
                     command: `/path/to/${executable}`,
                     args,
@@ -603,7 +603,7 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
 
         setup(() => {
             mockDebugAdapter.getLaunchConfigType.returns(LaunchConfigType.LLDB_DAP);
-            (mockToolchain as any).getToolchainInvocation = mockFn(s =>
+            (mockToolchain as any).getDebuggerToolchainInvocation = mockFn(s =>
                 s
                     .withArgs("lldb-dap", [])
                     .returns({ command: "swiftly", args: ["run", "lldb-dap"] })
@@ -689,7 +689,7 @@ suite("LLDBDebugConfigurationProvider Tests", () => {
         mockToolchain = mockObject<SwiftToolchain>({
             swiftVersion: new Version(5, 10, 0),
             manager: "unknown",
-            getToolchainInvocation: mockFn(s =>
+            getDebuggerToolchainInvocation: mockFn(s =>
                 s.withArgs("lldb-dap", []).returns({ command: debugAdapterPath, args: [] })
             ),
         });

--- a/test/unit-tests/debugger/lldb.test.ts
+++ b/test/unit-tests/debugger/lldb.test.ts
@@ -41,7 +41,7 @@ suite("debugger.lldb Tests", () => {
             mockToolchain = mockObject<SwiftToolchain>({
                 swiftFolderPath: "/usr/bin",
                 toolchainPath: "/toolchain",
-                getToolchainInvocation: mockFn(s =>
+                getDebuggerToolchainInvocation: mockFn(s =>
                     s.callsFake((_exe: string, args: string[]) => ({
                         command: "/toolchain/bin/lldb",
                         args,

--- a/test/unit-tests/toolchain/toolchain.test.ts
+++ b/test/unit-tests/toolchain/toolchain.test.ts
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import { expect } from "chai";
 
+import { Swiftly } from "@src/toolchain/swiftly";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
 import * as utilities from "@src/utilities/utilities";
 import { Version } from "@src/utilities/version";
@@ -22,6 +23,7 @@ import { mockGlobalModule, mockGlobalValue } from "../../MockUtils";
 import mockFS = require("mock-fs");
 
 suite("SwiftToolchain Unit Test Suite", () => {
+    const mockedSwiftly = mockGlobalModule(Swiftly);
     const mockedUtilities = mockGlobalModule(utilities);
     const mockedPlatform = mockGlobalValue(process, "platform");
 
@@ -85,12 +87,22 @@ suite("SwiftToolchain Unit Test Suite", () => {
             expect(inv.args).to.deep.equal(["run", "sourcekit-lsp"]);
         });
 
-        test("swiftly toolchain wraps lldb-dap correctly with no extra args", () => {
+        test("swiftly toolchain wraps lldb-dap correctly", async () => {
             mockedPlatform.setValue("linux");
+            mockedSwiftly.inUseVersion.resolves("6.2.0");
             const tc = createToolchain("swiftly", "/home/user/.swiftly/toolchains/6.0.0/usr");
-            const inv = tc.getToolchainInvocation("lldb-dap", []);
+            const inv = await tc.getDebuggerToolchainInvocation("lldb-dap", []);
             expect(inv.command).to.equal("swiftly");
             expect(inv.args).to.deep.equal(["run", "lldb-dap"]);
+        });
+
+        test("swiftly toolchain uses xcrun to launch lldb-dap if toolchain is xcode", async () => {
+            mockedPlatform.setValue("linux");
+            mockedSwiftly.inUseVersion.resolves("xcode");
+            const tc = createToolchain("swiftly", "/home/user/.swiftly/toolchains/6.0.0/usr");
+            const inv = await tc.getDebuggerToolchainInvocation("lldb-dap", []);
+            expect(inv.command).to.equal("xcrun");
+            expect(inv.args).to.deep.equal(["lldb-dap"]);
         });
 
         test("getToolchainExecutablePath always returns raw path regardless of manager", () => {


### PR DESCRIPTION
## Description
The extension will now use `xcrun` to launch `lldb` and `lldb-dap` binaries if `swiftly` reports that it's using an Xcode toolchain. 

This is a workaround for swiftlang/swiftly#521. Once it's fixed this can be removed.

Issue: #2264

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
