### PR TITLE
Update changelog for 2.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
 ### Fixed
 
 - Loading large projects will no longer show the extension as unresponsive ([#1932](https://github.com/swiftlang/vscode-swift/pull/1932))
-- Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 - Reveal the task terminal when clicking the Swift build status item instead of showing a popup ([#2254](https://github.com/swiftlang/vscode-swift/pull/2254))
+
+## 2.16.6 - 2026-06-04
+
+### Fixed
+
+- Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 - Override VS Code setting git `safe.bareRepository` to allow SwiftPM to resolve dependencies ([#2266](https://github.com/swiftlang/vscode-swift/pull/2266))
 - Fix debug sessions not being launched when swiftly is using an Xcode toolchain ([#2268](https://github.com/swiftlang/vscode-swift/pull/2268))
 


### PR DESCRIPTION
## Description
We branched to release 2.16.6 because we didn't want to include all of the changes from main. Update the changelog to reflect which changes went out in 2.16.6 and which ones are still only available in pre-release.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
