### PR TITLE
Update sourcekit-lsp schema logic for new swiftlang branch structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Loading large projects will no longer show the extension as unresponsive ([#1932](https://github.com/swiftlang/vscode-swift/pull/1932))
 - Reveal the task terminal when clicking the Swift build status item instead of showing a popup ([#2254](https://github.com/swiftlang/vscode-swift/pull/2254))
+- Update sourcekit-lsp schema logic for new branch structure ([#2270](https://github.com/swiftlang/vscode-swift/pull/2270))
 
 ## 2.16.6 - 2026-06-04
 
@@ -14,7 +15,6 @@
 - Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 - Override VS Code setting git `safe.bareRepository` to allow SwiftPM to resolve dependencies ([#2266](https://github.com/swiftlang/vscode-swift/pull/2266))
 - Fix debug sessions not being launched when swiftly is using an Xcode toolchain ([#2268](https://github.com/swiftlang/vscode-swift/pull/2268))
-- Update sourcekit-lsp schema logic for new branch structure ([#2270](https://github.com/swiftlang/vscode-swift/pull/2270))
 
 ## 2.16.5 - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Packages that produced a warning during `swift package resolve` would not load ([#2262](https://github.com/swiftlang/vscode-swift/pull/2262))
 - Override VS Code setting git `safe.bareRepository` to allow SwiftPM to resolve dependencies ([#2266](https://github.com/swiftlang/vscode-swift/pull/2266))
 - Fix debug sessions not being launched when swiftly is using an Xcode toolchain ([#2268](https://github.com/swiftlang/vscode-swift/pull/2268))
+- Update sourcekit-lsp schema logic for new branch structure ([#2270](https://github.com/swiftlang/vscode-swift/pull/2270))
 
 ## 2.16.5 - 2026-05-26
 

--- a/src/commands/generateSourcekitConfiguration.ts
+++ b/src/commands/generateSourcekitConfiguration.ts
@@ -128,15 +128,28 @@ async function checkURLExists(url: string): Promise<boolean> {
     }
 }
 
+// Resolves the sourcekit-lsp config schema URL for the toolchain, trying
+// release branches in order (e.g. release/6.4.x, release/6.4) and falling
+// back to main when none of the candidates exist on GitHub.
 export async function determineSchemaURL(folderContext: FolderContext): Promise<string> {
     const version = folderContext.toolchain.swiftVersion;
     const versionString = `${version.major}.${version.minor}`;
-    let branch =
-        configuration.lspConfigurationBranch || (version.dev ? "main" : `release/${versionString}`);
-    if (!(await checkURLExists(schemaURL(branch)))) {
-        branch = "main";
+    let candidates: string[];
+    if (configuration.lspConfigurationBranch) {
+        candidates = [configuration.lspConfigurationBranch, "main"];
+    } else if (version.dev) {
+        candidates = ["main"];
+    } else {
+        candidates = [`release/${versionString}.x`, `release/${versionString}`, "main"];
     }
-    return schemaURL(branch);
+    let resolved = "main";
+    for (const branch of candidates) {
+        if (await checkURLExists(schemaURL(branch))) {
+            resolved = branch;
+            break;
+        }
+    }
+    return schemaURL(resolved);
 }
 
 async function getValidatedFolderContext(

--- a/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
+++ b/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
@@ -48,6 +48,15 @@ suite("Generate SourceKit-LSP configuration Command", function () {
         return JSON.parse(contents);
     }
 
+    function expectedBranchForVersion(version: Version): string {
+        if (version.dev || version.isLessThan(new Version(6, 1, 0))) {
+            return "main";
+        } else if (version.isGreaterThanOrEqual(new Version(6, 4, 0))) {
+            return `release/${version.major}.${version.minor}.x`;
+        }
+        return `release/${version.major}.${version.minor}`;
+    }
+
     activateExtensionForSuite({
         async setup(api) {
             const ctx = await api.waitForWorkspaceContext();
@@ -75,13 +84,7 @@ suite("Generate SourceKit-LSP configuration Command", function () {
         const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
         expect(result).to.be.true;
         const config = await getSchema();
-        const version = folderContext.swiftVersion;
-        let branch: string;
-        if (folderContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 1, 0))) {
-            branch = version.dev ? "main" : `release/${version.major}.${version.minor}`;
-        } else {
-            branch = "main";
-        }
+        const branch = expectedBranchForVersion(folderContext.swiftVersion);
         expect(config).to.have.property(
             "$schema",
             `https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/${branch}/config.schema.json`
@@ -134,13 +137,7 @@ suite("Generate SourceKit-LSP configuration Command", function () {
             await handleSchemaUpdate(document, workspaceContext);
 
             const config = await getSchema();
-            const version = folderContext.swiftVersion;
-            let branch: string;
-            if (folderContext.swiftVersion.isGreaterThanOrEqual(new Version(6, 1, 0))) {
-                branch = version.dev ? "main" : `release/${version.major}.${version.minor}`;
-            } else {
-                branch = "main";
-            }
+            const branch = expectedBranchForVersion(folderContext.swiftVersion);
             expect(config).to.have.property(
                 "$schema",
                 `https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/${branch}/config.schema.json`


### PR DESCRIPTION
## Description
With Swift release 6.4 and later the branches may have a structure of release/6.4.x. Update the schema generation logic to reflect this change.

## Tasks
- [x] Required tests have been updated
~-[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
