### PR TITLE
Make "Capture Diagnostics Bundle" work even without a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Reveal the task terminal when clicking the Swift build status item instead of showing a popup ([#2254](https://github.com/swiftlang/vscode-swift/pull/2254))
 - Update sourcekit-lsp schema logic for new branch structure ([#2270](https://github.com/swiftlang/vscode-swift/pull/2270))
 - Work around an issue in older lldb-dap binaries where breakpoints would show up as unresolved even when they were hit ([#2283](https://github.com/swiftlang/vscode-swift/pull/2283))
+- Capturing a diagnostics bundle will no longer fail if the extension fails to activate ([#2273](https://github.com/swiftlang/vscode-swift/pull/2273))
 
 ## 2.16.6 - 2026-06-04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/ttf2woff": "^2.0.4",
         "@types/vscode": "^1.88.0",
         "@types/xml2js": "^0.4.14",
+        "@types/yauzl": "^3.3.0",
         "@typescript-eslint/eslint-plugin": "^8.59.2",
         "@typescript-eslint/parser": "^8.58.1",
         "@vscode/debugprotocol": "^1.68.0",
@@ -88,7 +89,8 @@
         "typescript": "^6.0.3",
         "vscode-tmgrammar-test": "^0.1.3",
         "winston": "^3.19.0",
-        "winston-transport": "^4.9.0"
+        "winston-transport": "^4.9.0",
+        "yauzl": "^3.4.0"
       },
       "engines": {
         "vscode": "^1.88.0"
@@ -3306,6 +3308,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-7YJZZveDGYqCMt0PrN0sjZj9gT07xLqnHBimKwhWYTJ4lh5MxDGmaCaN4+6x1TOPt+dk3Ge8w9cO3uJXoy/qrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
@@ -4217,19 +4229,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/yauzl": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -4671,6 +4670,22 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/azure-devops-node-api": {
       "version": "12.5.0",
@@ -5158,6 +5173,25 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -6088,6 +6122,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-unzip/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/decompress/node_modules/make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -6166,6 +6211,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/define-lazy-prop": {
@@ -7033,8 +7096,9 @@
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -7165,6 +7229,22 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -7625,6 +7705,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -7908,6 +8001,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -8041,6 +8147,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -10327,6 +10449,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -11154,6 +11286,24 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -12239,9 +12389,24 @@
       }
     },
     "node_modules/to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12374,6 +12539,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/typed-rest-client": {
@@ -12810,6 +12990,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -13135,13 +13337,16 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yazl": {
@@ -15395,6 +15600,15 @@
         "@types/node": "*"
       }
     },
+    "@types/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-7YJZZveDGYqCMt0PrN0sjZj9gT07xLqnHBimKwhWYTJ4lh5MxDGmaCaN4+6x1TOPt+dk3Ge8w9cO3uJXoy/qrA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
@@ -15883,16 +16097,6 @@
             "sax": ">=0.6.0",
             "xmlbuilder": "~11.0.0"
           }
-        },
-        "yauzl": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
-          "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
-          "dev": true,
-          "requires": {
-            "buffer-crc32": "~0.2.3",
-            "pend": "~1.2.0"
-          }
         }
       }
     },
@@ -16289,6 +16493,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "requires": {
+        "possible-typed-array-names": "^1.0.0"
+      }
+    },
     "azure-devops-node-api": {
       "version": "12.5.0",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
@@ -16645,6 +16858,18 @@
             }
           }
         }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
       }
     },
     "call-bind-apply-helpers": {
@@ -17316,6 +17541,16 @@
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
           "dev": true
+        },
+        "yauzl": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+          "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+          "dev": true,
+          "requires": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
+          }
         }
       }
     },
@@ -17356,6 +17591,17 @@
       "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true
+    },
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
     },
     "define-lazy-prop": {
       "version": "3.0.0",
@@ -17954,7 +18200,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -18049,6 +18295,15 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.2.7"
+      }
     },
     "foreground-child": {
       "version": "3.3.1",
@@ -18371,6 +18626,15 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "requires": {
+        "es-define-property": "^1.0.0"
+      }
+    },
     "has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -18563,6 +18827,12 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
+    },
     "is-docker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -18642,6 +18912,15 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "dev": true
+    },
+    "is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "requires": {
+        "which-typed-array": "^1.1.16"
+      }
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -20283,6 +20562,12 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
     },
+    "possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true
+    },
     "prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -20850,6 +21135,20 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -21611,10 +21910,23 @@
       "dev": true
     },
     "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "requires": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+          "dev": true
+        }
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -21704,6 +22016,17 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true
+    },
+    "typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "requires": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      }
     },
     "typed-rest-client": {
       "version": "1.8.11",
@@ -22028,6 +22351,21 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      }
+    },
     "wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -22259,13 +22597,12 @@
       }
     },
     "yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
       }
     },
     "yazl": {

--- a/package.json
+++ b/package.json
@@ -2161,6 +2161,7 @@
     "@types/ttf2woff": "^2.0.4",
     "@types/vscode": "^1.88.0",
     "@types/xml2js": "^0.4.14",
+    "@types/yauzl": "^3.3.0",
     "@typescript-eslint/eslint-plugin": "^8.59.2",
     "@typescript-eslint/parser": "^8.58.1",
     "@vscode/debugprotocol": "^1.68.0",
@@ -2204,7 +2205,8 @@
     "typescript": "^6.0.3",
     "vscode-tmgrammar-test": "^0.1.3",
     "winston": "^3.19.0",
-    "winston-transport": "^4.9.0"
+    "winston-transport": "^4.9.0",
+    "yauzl": "^3.4.0"
   },
   "dependencies": {
     "@vscode/codicons": "^0.0.45",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -313,8 +313,16 @@ export function registerCommands(api: InternalSwiftExtensionApi): Disposable[] {
             clearTestWarningDiagnostics();
             await api.withWorkspaceContext(ctx => ctx.diagnostics.clear());
         }),
-        vscode.commands.registerCommand("swift.captureDiagnostics", async () =>
-            api.withWorkspaceContext(ctx => captureDiagnostics(ctx))
+        vscode.commands.registerCommand("swift.captureDiagnostics", () =>
+            captureDiagnostics(
+                {
+                    logFolderUri: api.loggerFactory.logFolderUri,
+                    globalToolchain: api.workspaceContext?.globalToolchain,
+                    folders: api.workspaceContext?.folders,
+                    showSwiftOutputChannel: () => api.outputChannel.show(),
+                },
+                api.logger
+            )
         ),
         vscode.commands.registerCommand(Commands.RUN_ALL_TESTS_PARALLEL, item =>
             api.withWorkspaceContext(ctx =>

--- a/src/commands/captureDiagnostics.ts
+++ b/src/commands/captureDiagnostics.ts
@@ -23,20 +23,33 @@ import * as vscode from "vscode";
 import { FolderContext } from "../FolderContext";
 import { WorkspaceContext } from "../WorkspaceContext";
 import configuration from "../configuration";
-import { DebugAdapter } from "../debugger/debugAdapter";
+import { DebugAdapter, LaunchConfigType } from "../debugger/debugAdapter";
 import { SwiftLogger } from "../logging/SwiftLogger";
+import { SwiftToolchain } from "../toolchain/toolchain";
 import { Extension } from "../utilities/extensions";
 import { destructuredPromise, execFileStreamOutput, randomString } from "../utilities/utilities";
 import { Version } from "../utilities/version";
 
-export async function captureDiagnostics(
-    ctx: WorkspaceContext,
-    allowMinimalCapture: boolean = true
-): Promise<string | undefined> {
-    try {
-        const captureMode = await captureDiagnosticsMode(ctx, allowMinimalCapture);
+export interface CaptureDiagnosticsOptions {
+    logFolderUri: vscode.Uri;
+    globalToolchain?: SwiftToolchain;
+    folders?: FolderContext[];
+    requiresFullDiagnostics?: boolean;
+    showSwiftOutputChannel(): void;
+}
 
-        // dialog was cancelled
+export async function captureDiagnostics(
+    options: CaptureDiagnosticsOptions,
+    logger: SwiftLogger
+): Promise<string | undefined> {
+    const {
+        logFolderUri,
+        globalToolchain,
+        folders = [],
+        requiresFullDiagnostics = false,
+    } = options;
+    try {
+        const captureMode = await promptForDiagnosticsMode(!requiresFullDiagnostics);
         if (!captureMode) {
             return;
         }
@@ -52,23 +65,27 @@ export async function captureDiagnostics(
         const zipFilePath = path.join(zipDir, `${path.basename(diagnosticsDir)}.zip`);
         const { archive, done: archivingDone } = configureZipArchiver(zipFilePath);
 
-        const archivedLldbDapLogFolders = await captureDefaultLldbDapLogs(
-            ctx,
+        const archivedLldbDapLogFolders = await captureGlobalLldbDapLogs(
+            globalToolchain?.swiftVersion,
+            logFolderUri,
             captureMode,
-            diagnosticsDir
+            diagnosticsDir,
+            logger
         );
 
-        for (const folder of ctx.folders) {
-            await captureFolderDiagnostics(
-                ctx,
-                folder,
-                captureMode,
-                diagnosticsDir,
-                archivedLldbDapLogFolders
-            );
-        }
+        await Promise.all(
+            folders.map(folder =>
+                captureFolderDiagnostics(
+                    folder,
+                    captureMode,
+                    diagnosticsDir,
+                    archivedLldbDapLogFolders,
+                    logger
+                )
+            )
+        );
 
-        await copyLogFolder(diagnosticsDir, ctx.loggerFactory.logFolderUri.fsPath, ctx.logger);
+        await copyLogFolder(diagnosticsDir, logFolderUri.fsPath, logger);
 
         archive.directory(diagnosticsDir, false);
         void archive.finalize();
@@ -76,74 +93,73 @@ export async function captureDiagnostics(
 
         await fsPromises.rm(diagnosticsDir, { recursive: true, force: true });
 
-        ctx.logger.info(`Saved diagnostics to ${zipFilePath}`);
+        logger.info(`Saved diagnostics to ${zipFilePath}`);
         await showCapturedDiagnosticsResults(zipFilePath);
 
         return zipFilePath;
     } catch (error) {
-        void vscode.window.showErrorMessage(`Unable to capture diagnostic logs: ${error}`);
+        logger.error(Error("Failed to capture diagnostics bundle.", { cause: error }));
+        void vscode.window.showErrorMessage(`Failed to capture diagnostics bundle: ${error}`);
     }
 }
 
-async function captureDefaultLldbDapLogs(
-    ctx: WorkspaceContext,
+async function captureGlobalLldbDapLogs(
+    globalToolchainVersion: Version | undefined,
+    logFolderUri: vscode.Uri,
     captureMode: "Minimal" | "Full",
-    diagnosticsDir: string
+    diagnosticsDir: string,
+    logger: SwiftLogger
 ): Promise<Set<string>> {
-    const archivedLldbDapLogFolders = new Set<string>();
-    const includeLldbDapLogs = DebugAdapter.getLaunchConfigType(ctx.globalToolchainSwiftVersion);
+    const includeLldbDapLogs = globalToolchainVersion
+        ? DebugAdapter.getLaunchConfigType(globalToolchainVersion) === LaunchConfigType.LLDB_DAP
+        : false;
 
     if (captureMode !== "Full" || !includeLldbDapLogs) {
-        return archivedLldbDapLogFolders;
+        return new Set();
     }
 
-    for (const logFolder of [defaultLldbDapLogFolder(ctx), lldbDapLogFolder()]) {
-        if (!logFolder || archivedLldbDapLogFolders.has(logFolder)) {
-            continue;
-        }
-        archivedLldbDapLogFolders.add(logFolder);
-        await copyLogFolder(diagnosticsDir, logFolder, ctx.logger);
+    const rootLogFolder = path.dirname(logFolderUri.fsPath);
+    const logFolder = path.join(rootLogFolder, Extension.LLDBDAP);
+    if (!logFolder) {
+        return new Set();
     }
-
-    return archivedLldbDapLogFolders;
+    await copyLogFolder(diagnosticsDir, logFolder, logger);
+    return new Set([logFolder]);
 }
 
 async function captureFolderDiagnostics(
-    ctx: WorkspaceContext,
     folder: FolderContext,
     captureMode: "Minimal" | "Full",
-    diagnosticsDir: string,
-    archivedLldbDapLogFolders: Set<string>
+    outputDir: string,
+    archivedLldbDapLogFolders: Set<string>,
+    logger: SwiftLogger
 ): Promise<void> {
-    const baseName = path.basename(folder.folder.fsPath);
-    const guid = randomString(10, 36);
-    const singleFolderWorkspace = ctx.folders.length === 1;
-    const outputDir = singleFolderWorkspace ? diagnosticsDir : path.join(diagnosticsDir, baseName);
+    if (!folder.isRootFolder) {
+        const baseName = path.basename(folder.folder.fsPath);
+        const guid = randomString(10, 36);
+        outputDir = path.join(outputDir, `${baseName}-${guid}`);
+    }
 
     await fsPromises.mkdir(outputDir, { recursive: true });
-    await writeLogFile(outputDir, `${baseName}-${guid}-settings.txt`, settingsLogs(folder));
+    await writeLogFile(outputDir, `settings.txt`, settingsLogs(folder));
 
     if (captureMode !== "Full") {
         return;
     }
 
-    await writeLogFile(
-        outputDir,
-        `${baseName}-${guid}-source-code-diagnostics.txt`,
-        diagnosticLogs()
-    );
+    await writeLogFile(outputDir, `source-code-diagnostics.txt`, diagnosticLogs());
 
     if (folder.toolchain.swiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))) {
         await sourcekitDiagnose(folder, outputDir);
     }
-    await captureFolderLldbDapLogs(ctx, folder, outputDir, archivedLldbDapLogFolders);
+    await captureFolderLldbDapLogs(folder, outputDir, archivedLldbDapLogFolders, logger);
 }
 
 async function captureFolderLldbDapLogs(
-    ctx: WorkspaceContext,
     folder: FolderContext,
     outputDir: string,
-    archivedLldbDapLogFolders: Set<string>
+    archivedLldbDapLogFolders: Set<string>,
+    logger: SwiftLogger
 ): Promise<void> {
     const includeLldbDapLogs = DebugAdapter.getLaunchConfigType(folder.swiftVersion);
     if (!includeLldbDapLogs) {
@@ -156,7 +172,7 @@ async function captureFolderLldbDapLogs(
     }
 
     archivedLldbDapLogFolders.add(lldbDapLogs);
-    await copyLogFolder(outputDir, lldbDapLogs, ctx.logger);
+    await copyLogFolder(outputDir, lldbDapLogs, logger);
 }
 
 function configureZipArchiver(zipFilePath: string): {
@@ -182,31 +198,35 @@ function configureZipArchiver(zipFilePath: string): {
 }
 
 export async function promptForDiagnostics(ctx: WorkspaceContext) {
-    const ok = "OK";
-    const cancel = "Cancel";
+    const ok = "Capture Diagnostics";
     const result = await vscode.window.showInformationMessage(
         "SourceKit-LSP has been restored. Would you like to capture a diagnostic bundle to file an issue?",
-        ok,
-        cancel
+        ok
     );
 
-    if (!result || result === cancel) {
+    if (result !== ok) {
         return;
     }
 
-    return await captureDiagnostics(ctx, false);
+    return await captureDiagnostics(
+        {
+            logFolderUri: ctx.loggerFactory.logFolderUri,
+            globalToolchain: ctx.globalToolchain,
+            folders: ctx.folders,
+            requiresFullDiagnostics: true,
+            showSwiftOutputChannel: () => ctx.showSwiftOutputChannel(),
+        },
+        ctx.logger
+    );
 }
 
-async function captureDiagnosticsMode(
-    ctx: WorkspaceContext,
+async function promptForDiagnosticsMode(
     allowMinimalCapture: boolean
 ): Promise<"Minimal" | "Full" | undefined> {
-    if (ctx.globalToolchainSwiftVersion.isGreaterThanOrEqual(new Version(6, 0, 0))) {
-        const fullButton = "Capture Full Diagnostics";
-        const minimalButton = "Capture Minimal Diagnostics";
-        const buttons = allowMinimalCapture ? [fullButton, minimalButton] : [fullButton];
-        const fullCaptureResult = await vscode.window.showInformationMessage(
-            `A Diagnostic Bundle collects information that helps the developers of the Swift for VS Code extension diagnose and fix issues.
+    const fullButton = "Capture Full Diagnostics";
+    const minimalButton = "Capture Minimal Diagnostics";
+    const buttons = allowMinimalCapture ? [fullButton, minimalButton] : [fullButton];
+    let detail = `A Diagnostic Bundle collects information that helps the developers of the Swift for VS Code extension diagnose and fix issues.
 
 This information includes:
 - Extension logs
@@ -222,23 +242,23 @@ If you allow capturing a Full Diagnostic Bundle, the information will also inclu
 
 All information is collected locally and you can inspect the diagnose bundle before sharing it with developers of the Swift for VS Code extension.
 
-Please file an issue with a description of the problem you are seeing at https://github.com/swiftlang/vscode-swift, and attach this diagnose bundle.`,
-            {
-                modal: true,
-                detail: allowMinimalCapture
-                    ? `If you wish to omit potentially sensitive information choose "${minimalButton}"`
-                    : undefined,
-            },
-            ...buttons
-        );
-        if (!fullCaptureResult) {
-            return undefined;
-        }
-
-        return fullCaptureResult === fullButton ? "Full" : "Minimal";
-    } else {
-        return "Minimal";
+Please file an issue with a description of the problem you are seeing at https://github.com/swiftlang/vscode-swift, and attach this diagnose bundle.`;
+    if (allowMinimalCapture) {
+        detail += `\n\nIf you wish to omit potentially sensitive information choose "${minimalButton}"`;
     }
+    const fullCaptureResult = await vscode.window.showInformationMessage(
+        "Capture Swift Diagnostic Bundle",
+        {
+            modal: true,
+            detail,
+        },
+        ...buttons
+    );
+    if (!fullCaptureResult) {
+        return undefined;
+    }
+
+    return fullCaptureResult === fullButton ? "Full" : "Minimal";
 }
 
 async function showCapturedDiagnosticsResults(diagnosticsPath: string) {
@@ -304,11 +324,6 @@ async function createDiagnosticsZipDir(): Promise<string> {
     return diagnosticsDir;
 }
 
-function defaultLldbDapLogFolder(ctx: WorkspaceContext): string {
-    const rootLogFolder = path.dirname(ctx.loggerFactory.logFolderUri.fsPath);
-    return path.join(rootLogFolder, Extension.LLDBDAP);
-}
-
 function lldbDapLogFolder(workspaceFolder?: vscode.WorkspaceFolder): string | undefined {
     const config = vscode.workspace.workspaceFile
         ? vscode.workspace.getConfiguration("lldb-dap")
@@ -349,7 +364,7 @@ function diagnosticLogs(): string {
 
 async function sourcekitDiagnose(ctx: FolderContext, dir: string) {
     const sourcekitDiagnosticDir = path.join(dir, "sourcekit-lsp");
-    await fsPromises.mkdir(sourcekitDiagnosticDir);
+    await fsPromises.mkdir(sourcekitDiagnosticDir, { recursive: true });
 
     const lspConfig = configuration.lsp;
     const serverPathConfig = lspConfig.serverPath;

--- a/test/chai-regex-plugin.ts
+++ b/test/chai-regex-plugin.ts
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Chai {
+        interface Assertion {
+            /**
+             * Asserts that an array of strings contains at least one member
+             * that matches the given regular expression.
+             *
+             * @param pattern The regular expression to match against.
+             */
+            includeMatch(pattern: RegExp): Assertion;
+
+            /**
+             * Asserts that an array of strings contains at least one member
+             * that matches the given regular expression.
+             *
+             * @param pattern The regular expression to match against.
+             */
+            includesMatch(pattern: RegExp): Assertion;
+        }
+
+        interface PromisedAssertion {
+            /**
+             * Asserts that an array of strings contains at least one member
+             * that matches the given regular expression.
+             *
+             * @param pattern The regular expression to match against.
+             */
+            includeMatch(pattern: RegExp): PromisedAssertion;
+
+            /**
+             * Asserts that an array of strings contains at least one member
+             * that matches the given regular expression.
+             *
+             * @param pattern The regular expression to match against.
+             */
+            includesMatch(pattern: RegExp): PromisedAssertion;
+        }
+    }
+}
+
+export function chaiRegexPlugin(chai: Chai.ChaiStatic, _utils: Chai.ChaiUtils): void {
+    function assertIncludesMatch(this: Chai.AssertionStatic, pattern: RegExp) {
+        const obj: string[] = this._obj;
+        new chai.Assertion(obj).to.be.an("array");
+        this.assert(
+            obj.some(item => pattern.test(item)),
+            `expected array to include a member matching ${pattern}`,
+            `expected array to not include a member matching ${pattern}`,
+            pattern,
+            obj
+        );
+    }
+    chai.Assertion.addMethod("includeMatch", assertIncludesMatch);
+    chai.Assertion.addMethod("includesMatch", assertIncludesMatch);
+}

--- a/test/common.ts
+++ b/test/common.ts
@@ -19,6 +19,7 @@ import * as sourceMapSupport from "source-map-support";
 import * as tsConfigPaths from "tsconfig-paths";
 
 import { chaiPathPlugin } from "./chai-path-plugin";
+import { chaiRegexPlugin } from "./chai-regex-plugin";
 import { installTagSupport } from "./tags";
 
 import chaiAsPromised = require("chai-as-promised");
@@ -55,6 +56,7 @@ tsConfigPaths.register({
 chai.use(sinonChai);
 chai.use(chaiSubset);
 chai.use(chaiPathPlugin);
+chai.use(chaiRegexPlugin);
 // chai-as-promised must always be installed last!
 chai.use(chaiAsPromised);
 

--- a/test/integration-tests/commands/captureDiagnostics.test.ts
+++ b/test/integration-tests/commands/captureDiagnostics.test.ts
@@ -11,206 +11,272 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import * as assert from "assert";
 import { expect } from "chai";
-import { mkdir, rm } from "fs/promises";
-import * as os from "os";
-import * as path from "path";
+import * as fs from "fs/promises";
 import * as vscode from "vscode";
+import * as yauzl from "yauzl";
 
 import { WorkspaceContext } from "@src/WorkspaceContext";
 import { captureDiagnostics } from "@src/commands/captureDiagnostics";
-import { randomString } from "@src/utilities/utilities";
+import { createBuildAllTask } from "@src/tasks/SwiftTaskProvider";
+import { unwrapPromise } from "@src/utilities/utilities";
 import { Version } from "@src/utilities/version";
 
-import { mockGlobalObject } from "../../MockUtils";
+import { mockFn, mockGlobalObject } from "../../MockUtils";
 import { tag } from "../../tags";
-import {
-    activateExtensionForSuite,
-    folderInRootWorkspace,
-    updateSettings,
-} from "../utilities/testutilities";
+import { TestLogger } from "../../utilities/TestLogger";
+import { executeTaskAndWaitForResult } from "../../utilities/tasks";
+import { activateExtensionForSuite, folderInRootWorkspace } from "../utilities/testutilities";
 
-import decompress = require("decompress");
-
-tag("medium").suite("captureDiagnostics Test Suite", () => {
+tag("medium").suite("captureDiagnostics() Test Suite", function () {
     let workspaceContext: WorkspaceContext;
+    let zipFilePath: string | undefined;
     const mockWindow = mockGlobalObject(vscode, "window");
     const progressReport = { report: () => {} } as vscode.Progress<{ message?: string }>;
 
-    suite("Minimal", () => {
-        activateExtensionForSuite({
-            async setup(api) {
-                workspaceContext = await api.waitForWorkspaceContext();
-            },
-            testAssets: ["defaultPackage"],
-        });
+    activateExtensionForSuite({
+        async setup(api) {
+            workspaceContext = await api.waitForWorkspaceContext();
+        },
+        testAssets: ["defaultPackage", "dependencies"],
+    });
 
-        setup(() => {
-            mockWindow.showInformationMessage.resolves("Capture Minimal Diagnostics" as any);
-            mockWindow.withProgress.callsFake(async (_options, task) => {
-                return await task(progressReport, new vscode.CancellationTokenSource().token);
-            });
-        });
-
-        test("Should capture dianostics to a zip file", async () => {
-            const zipPath = await captureDiagnostics(workspaceContext);
-            expect(zipPath).to.not.be.undefined;
-        });
-
-        test("Should validate a single folder project zip file has contents", async () => {
-            const zipPath = await captureDiagnostics(workspaceContext);
-            expect(zipPath).to.not.be.undefined;
-
-            const { files, folder } = await decompressZip(zipPath as string);
-
-            validate(
-                files.map(file => file.path),
-                [
-                    "swift-vscode-extension.log",
-                    "sourcekit-lsp-[0-9.]+.log",
-                    "defaultPackage-[a-z0-9]+-settings.txt",
-                ]
-            );
-
-            await rm(folder, { recursive: true, force: true });
-        });
-
-        suite("Multiple folder project", () => {
-            setup(async () => {
-                await folderInRootWorkspace("dependencies", workspaceContext);
-            });
-
-            test("Should validate a multiple folder project zip file has contents", async () => {
-                const zipPath = await captureDiagnostics(workspaceContext);
-                expect(zipPath).to.not.be.undefined;
-
-                const { files, folder } = await decompressZip(zipPath as string);
-                validate(
-                    files.map(file => file.path),
-                    [
-                        "swift-vscode-extension.log",
-                        "sourcekit-lsp-[0-9.]+.log",
-                        "defaultPackage/",
-                        "defaultPackage/defaultPackage-[a-z0-9]+-settings.txt",
-                        "dependencies/",
-                        "dependencies/dependencies-[a-z0-9]+-settings.txt",
-                    ]
-                );
-                await rm(folder, { recursive: true, force: true });
-            });
+    setup(() => {
+        mockWindow.showInformationMessage.resolves("Capture Minimal Diagnostics" as any);
+        mockWindow.withProgress.callsFake(async (_options, task) => {
+            return await task(progressReport, new vscode.CancellationTokenSource().token);
         });
     });
 
-    tag("large").suite("Full", function () {
-        activateExtensionForSuite({
-            async setup(api) {
-                workspaceContext = await api.waitForWorkspaceContext();
+    teardown(async () => {
+        if (!zipFilePath) {
+            return;
+        }
+
+        await fs.rm(zipFilePath);
+        zipFilePath = undefined;
+    });
+
+    test("Does not offer minimal capture when requiresFullDiagnostics is true", async () => {
+        mockWindow.showInformationMessage.resolves(undefined);
+
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                requiresFullDiagnostics: true,
+                showSwiftOutputChannel: mockFn(),
             },
-            testAssets: ["defaultPackage"],
+            new TestLogger()
+        );
+
+        expect(mockWindow.showInformationMessage).to.have.been.calledOnce;
+        const showInfoArgs = mockWindow.showInformationMessage.firstCall.args;
+        expect(showInfoArgs).to.not.include("Capture Minimal Diagnostics");
+        expect(showInfoArgs).to.include("Capture Full Diagnostics");
+    });
+
+    test("Offers both capture modes when requiresFullDiagnostics is false", async () => {
+        mockWindow.showInformationMessage.resolves(undefined);
+
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                requiresFullDiagnostics: false,
+                showSwiftOutputChannel: mockFn(),
+            },
+            new TestLogger()
+        );
+
+        expect(mockWindow.showInformationMessage).to.have.been.calledOnce;
+        const showInfoArgs = mockWindow.showInformationMessage.firstCall.args;
+        expect(showInfoArgs).to.include("Capture Minimal Diagnostics");
+        expect(showInfoArgs).to.include("Capture Full Diagnostics");
+    });
+
+    test("Returns undefined when user dismisses the diagnostics mode prompt", async () => {
+        mockWindow.showInformationMessage.resolves(undefined);
+        mockWindow.withProgress.callsFake(async (_options, task) => {
+            return await task(progressReport, new vscode.CancellationTokenSource().token);
+        });
+
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                showSwiftOutputChannel: mockFn(),
+            },
+            new TestLogger()
+        );
+
+        expect(zipFilePath).to.be.undefined;
+    });
+
+    test("Returns a path to a zip file on disk", async () => {
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                showSwiftOutputChannel: mockFn(),
+            },
+            new TestLogger()
+        );
+
+        expect(zipFilePath).to.match(/\.zip$/);
+        const stat = await fs.stat(zipFilePath!);
+        expect(stat.isFile()).to.be.true;
+        expect(stat.size).to.be.greaterThan(0);
+    });
+
+    test("Should capture extension log and per-folder settings", async () => {
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                showSwiftOutputChannel: mockFn(),
+            },
+            new TestLogger()
+        );
+        assert.ok(zipFilePath);
+
+        const entries = await readZipEntries(zipFilePath!);
+        expect(entries).to.include("swift-vscode-extension.log");
+        expect(entries).to.includeMatch(/^sourcekit-lsp-[0-9.]+\.log$/);
+        expect(entries).to.includeMatch(/^defaultPackage-[a-z0-9]+\/settings\.txt$/);
+        expect(entries).to.includeMatch(/^dependencies-[a-z0-9]+\/settings\.txt$/);
+    });
+
+    test("Should not include source-code diagnostics or sourcekit-lsp diagnose output", async () => {
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                showSwiftOutputChannel: mockFn(),
+            },
+            new TestLogger()
+        );
+        assert.ok(zipFilePath);
+
+        const entries = await readZipEntries(zipFilePath!);
+        expect(entries).to.not.includeMatch(/^source-code-diagnostics\.txt$/);
+        expect(entries).to.not.includeMatch(/^defaultPackage-[a-z0-9]+\/sourcekit-lsp\//);
+        expect(entries).to.not.includeMatch(/^dependencies-[a-z0-9]+\/sourcekit-lsp\//);
+    });
+
+    test("Shows an error message and returns undefined on failure", async () => {
+        mockWindow.showInformationMessage.resolves("Capture Minimal Diagnostics" as any);
+        mockWindow.showErrorMessage.resolves(undefined);
+
+        const badUri = vscode.Uri.file("/nonexistent/path/that/should/not/exist");
+        const logger = new TestLogger();
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: badUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                showSwiftOutputChannel: mockFn(),
+            },
+            logger
+        );
+
+        expect(zipFilePath).to.be.undefined;
+        expect(mockWindow.showErrorMessage).to.have.been.calledOnce;
+    });
+
+    test("Logs the error when capture fails", async () => {
+        mockWindow.showInformationMessage.resolves("Capture Minimal Diagnostics" as any);
+        mockWindow.showErrorMessage.resolves(undefined);
+
+        const badUri = vscode.Uri.file("/nonexistent/path/that/should/not/exist");
+        const logger = new TestLogger();
+        zipFilePath = await captureDiagnostics(
+            {
+                logFolderUri: badUri,
+                globalToolchain: workspaceContext.globalToolchain,
+                folders: workspaceContext.folders,
+                showSwiftOutputChannel: mockFn(),
+            },
+            logger
+        );
+
+        expect(logger.logs).to.includeMatch(/Failed to capture/);
+    });
+
+    tag("large").suite("Capture Full Diagnostics", function () {
+        suiteSetup(async () => {
+            // Trigger diagnostics to appear
+            const diagnosticsFolder = await folderInRootWorkspace("diagnostics", workspaceContext);
+            await executeTaskAndWaitForResult(await createBuildAllTask(diagnosticsFolder));
         });
 
         setup(async () => {
             mockWindow.showInformationMessage.resolves("Capture Full Diagnostics" as any);
-            mockWindow.withProgress.callsFake(async (_options, task) => {
-                return await task(progressReport, new vscode.CancellationTokenSource().token);
-            });
-            resetSettings = await updateSettings({
-                "lldb-dap.logFolder": "logs",
-            });
         });
 
-        let resetSettings: (() => Promise<void>) | undefined;
-        teardown(async () => {
-            if (resetSettings) {
-                await resetSettings();
-            }
-        });
-
-        test("Should validate a single folder project zip file has contents", async () => {
-            const zipPath = await captureDiagnostics(workspaceContext, false);
-            expect(zipPath).to.not.be.undefined;
-
-            const { files, folder } = await decompressZip(zipPath as string);
-
-            const post60Logs = workspaceContext.globalToolchainSwiftVersion.isGreaterThanOrEqual(
-                new Version(6, 0, 0)
-            )
-                ? ["sourcekit-lsp/", "lldb-dap-session-123456789.log", "LLDB-DAP.log"]
-                : [];
-
-            validate(
-                files.map(file => file.path),
-                [
-                    "swift-vscode-extension.log",
-                    "defaultPackage-[a-z0-9]+-settings.txt",
-                    ...post60Logs,
-                ],
-                false // Sometime are diagnostics, sometimes not but not point of this test
+        test("Includes source-code diagnostics file for each folder", async () => {
+            zipFilePath = await captureDiagnostics(
+                {
+                    logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                    globalToolchain: workspaceContext.globalToolchain,
+                    folders: workspaceContext.folders,
+                    showSwiftOutputChannel: mockFn(),
+                },
+                new TestLogger()
             );
+            assert.ok(zipFilePath);
 
-            await rm(folder, { recursive: true, force: true });
+            const entries = await readZipEntries(zipFilePath!);
+            expect(entries).to.includeMatch(
+                /^diagnostics-[a-z0-9]+\/source-code-diagnostics\.txt$/
+            );
         });
 
-        suite("Multiple folder project", () => {
-            setup(async () => {
-                await folderInRootWorkspace("dependencies", workspaceContext);
-            });
+        test("Includes sourcekit-lsp diagnose output on Swift 6+", async function () {
+            const swiftVersion = workspaceContext.globalToolchainSwiftVersion;
+            if (swiftVersion.isLessThan(new Version(6, 0, 0))) {
+                this.skip();
+            }
 
-            test("Should validate a multiple folder project zip file has contents", async () => {
-                const zipPath = await captureDiagnostics(workspaceContext, false);
-                expect(zipPath).to.not.be.undefined;
+            zipFilePath = await captureDiagnostics(
+                {
+                    logFolderUri: workspaceContext.loggerFactory.logFolderUri,
+                    globalToolchain: workspaceContext.globalToolchain,
+                    folders: workspaceContext.folders,
+                    showSwiftOutputChannel: mockFn(),
+                },
+                new TestLogger()
+            );
+            assert.ok(zipFilePath);
 
-                const { files, folder } = await decompressZip(zipPath as string);
-
-                const post60Logs =
-                    workspaceContext.globalToolchainSwiftVersion.isGreaterThanOrEqual(
-                        new Version(6, 0, 0)
-                    )
-                        ? [
-                              "dependencies/sourcekit-lsp/",
-                              "LLDB-DAP.log",
-                              "lldb-dap-session-123456789.log",
-                              "defaultPackage/sourcekit-lsp/",
-                          ]
-                        : [];
-
-                validate(
-                    files.map(file => file.path),
-                    [
-                        "swift-vscode-extension.log",
-                        "defaultPackage/",
-                        "defaultPackage/defaultPackage-[a-z0-9]+-settings.txt",
-                        "dependencies/",
-                        "dependencies/dependencies-[a-z0-9]+-settings.txt",
-                        ...post60Logs,
-                    ],
-                    false // Sometime are diagnostics, sometimes not but not point of this test
-                );
-                await rm(folder, { recursive: true, force: true });
-            });
+            const entries = await readZipEntries(zipFilePath!);
+            expect(entries).to.includeMatch(/^dependencies-[a-z0-9]+\/sourcekit-lsp\/.*$/);
         });
     });
 
-    async function decompressZip(
-        zipPath: string
-    ): Promise<{ folder: string; files: decompress.File[] }> {
-        const tempDir = path.join(os.tmpdir(), `vscode-swift-test-${randomString(7, 36)}`);
-        await mkdir(tempDir, { recursive: true });
-        return { folder: tempDir, files: await decompress(zipPath as string, tempDir) };
-    }
+    function readZipEntries(zipFilePath: string): Promise<string[]> {
+        const { promise, resolve, reject } = unwrapPromise<string[]>();
+        yauzl.open(zipFilePath, { lazyEntries: true }, (err, zipFile) => {
+            if (err || !zipFile) {
+                return reject(err);
+            }
 
-    function validate(paths: string[], patterns: string[], matchCount: boolean = true): void {
-        if (matchCount) {
-            expect(paths.length).to.equal(
-                patterns.length,
-                `Expected ${patterns.length} files: ${JSON.stringify(patterns)}\n\n...but found ${paths.length}: ${JSON.stringify(paths)}`
-            );
-        }
-        const regexes = patterns.map(pattern => new RegExp(`^${pattern}$`));
-        for (const regex of regexes) {
-            const matched = paths.some(path => regex.test(path));
-            expect(matched, `No path matches the pattern: ${regex}, got paths: ${paths}`).to.be
-                .true;
-        }
+            const entries: string[] = [];
+            zipFile.readEntry();
+            zipFile.on("entry", (entry: { fileName: string }) => {
+                entries.push(entry.fileName);
+                zipFile.readEntry();
+            });
+            zipFile.on("end", () => resolve(entries));
+            zipFile.on("error", reject);
+        });
+        return promise;
     }
 });


### PR DESCRIPTION
## Description
`captureDiagnostics()` will no longer rely on a `WorkspaceContext` to be provided. Instead, it accepts only the exact dependencies it needs to generate logs. I've also reworked the tests to be more explicit in what they're testing.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
