### PR TITLE
Re-resolve unresolved breakpoints when the debugger stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Loading large projects will no longer show the extension as unresponsive ([#1932](https://github.com/swiftlang/vscode-swift/pull/1932))
 - Reveal the task terminal when clicking the Swift build status item instead of showing a popup ([#2254](https://github.com/swiftlang/vscode-swift/pull/2254))
 - Update sourcekit-lsp schema logic for new branch structure ([#2270](https://github.com/swiftlang/vscode-swift/pull/2270))
+- Work around an issue in older lldb-dap binaries where breakpoints would show up as unresolved even when they were hit ([#2283](https://github.com/swiftlang/vscode-swift/pull/2283))
 
 ## 2.16.6 - 2026-06-04
 

--- a/src/debugger/breakpointVerificationTracker.ts
+++ b/src/debugger/breakpointVerificationTracker.ts
@@ -1,0 +1,112 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { DebugProtocol } from "@vscode/debugprotocol";
+import * as vscode from "vscode";
+
+import { Disposable } from "../utilities/Disposable";
+import { LaunchConfigType } from "./debugAdapter";
+
+/**
+ * Works around a bug in lldb-dap where source breakpoints set before process
+ * launch are never marked as verified, even after the process loads and the
+ * breakpoints resolve internally.
+ *
+ * When a breakpoint is hit, it queries the debug session for each source
+ * breakpoint's verified state. Any breakpoints the adapter still reports as
+ * unverified are removed and re-added, which causes VS Code to attempt to
+ * resolve them again.
+ */
+export class BreakpointVerificationTracker implements vscode.DebugAdapterTracker {
+    private hasRefreshed = false;
+
+    constructor(private readonly session: vscode.DebugSession) {}
+
+    onDidSendMessage(message: DebugProtocol.ProtocolMessage): void {
+        void this.onDidSendMessageAsync(message);
+    }
+
+    // Exposed for testing purposes.
+    async onDidSendMessageAsync(message: DebugProtocol.ProtocolMessage): Promise<void> {
+        if (this.hasRefreshed) {
+            return;
+        }
+        if (
+            isDAPEvent(message) &&
+            isStoppedEvent(message) &&
+            message.body.reason === "breakpoint"
+        ) {
+            this.hasRefreshed = true;
+            await this.refreshUnverifiedBreakpoints();
+        }
+    }
+
+    private async refreshUnverifiedBreakpoints(): Promise<void> {
+        const breakpointsToRefresh: vscode.SourceBreakpoint[] = await this.getSourceBreakpoints(
+            async bp => {
+                const dapBp = await this.session.getDebugProtocolBreakpoint(bp);
+                return Boolean(dapBp && !isBreakpointVerified(dapBp));
+            }
+        );
+        if (breakpointsToRefresh.length === 0) {
+            return;
+        }
+        vscode.debug.removeBreakpoints(breakpointsToRefresh);
+        vscode.debug.addBreakpoints(breakpointsToRefresh);
+    }
+
+    private async getSourceBreakpoints(
+        predicate: (bp: vscode.SourceBreakpoint) => Promise<boolean>
+    ): Promise<vscode.SourceBreakpoint[]> {
+        const allSourceBreakpoints = vscode.debug.breakpoints.filter(isSourceBreakpoint);
+        const filteredSourceBreakpoints: vscode.SourceBreakpoint[] = [];
+        for (const bp of allSourceBreakpoints) {
+            if (!(await predicate(bp))) {
+                continue;
+            }
+            filteredSourceBreakpoints.push(bp);
+        }
+        return filteredSourceBreakpoints;
+    }
+}
+
+class BreakpointVerificationTrackerFactory implements vscode.DebugAdapterTrackerFactory {
+    createDebugAdapterTracker(
+        session: vscode.DebugSession
+    ): vscode.ProviderResult<vscode.DebugAdapterTracker> {
+        return new BreakpointVerificationTracker(session);
+    }
+}
+
+export function registerBreakpointVerificationTracker(): Disposable {
+    return vscode.debug.registerDebugAdapterTrackerFactory(
+        LaunchConfigType.LLDB_DAP,
+        new BreakpointVerificationTrackerFactory()
+    );
+}
+
+function isDAPEvent(message: DebugProtocol.ProtocolMessage): message is DebugProtocol.Event {
+    return message.type === "event";
+}
+
+function isStoppedEvent(event: DebugProtocol.Event): event is DebugProtocol.StoppedEvent {
+    return event.event === "stopped";
+}
+
+function isSourceBreakpoint(bp: vscode.Breakpoint): bp is vscode.SourceBreakpoint {
+    return bp instanceof vscode.SourceBreakpoint;
+}
+
+function isBreakpointVerified(bp: vscode.DebugProtocolBreakpoint): boolean {
+    return "verified" in bp && typeof bp.verified === "boolean" && bp.verified;
+}

--- a/src/debugger/debugAdapterFactory.ts
+++ b/src/debugger/debugAdapterFactory.ts
@@ -22,6 +22,7 @@ import { Disposable } from "../utilities/Disposable";
 import { fileExists } from "../utilities/filesystem";
 import { findBinaryInPath } from "../utilities/shell";
 import { getErrorDescription, swiftRuntimeEnv } from "../utilities/utilities";
+import { registerBreakpointVerificationTracker } from "./breakpointVerificationTracker";
 import { DebugAdapter, LaunchConfigType, SWIFT_LAUNCH_CONFIG_TYPE } from "./debugAdapter";
 import { getTargetBinaryPath, swiftPrelaunchBuildTaskArguments } from "./launch";
 import { getLLDBLibPath, updateLaunchConfigForCI } from "./lldb";
@@ -50,6 +51,7 @@ export function registerDebugger(api: InternalSwiftExtensionApi): Disposable {
 
     function register() {
         subscriptions.push(registerLoggingDebugAdapterTracker(api));
+        subscriptions.push(registerBreakpointVerificationTracker());
         subscriptions.push(registerLLDBDebugAdapter(api));
     }
 

--- a/test/unit-tests/debugger/breakpointVerificationTracker.test.ts
+++ b/test/unit-tests/debugger/breakpointVerificationTracker.test.ts
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { DebugProtocol } from "@vscode/debugprotocol";
+import { expect } from "chai";
+import * as vscode from "vscode";
+
+import { BreakpointVerificationTracker } from "@src/debugger/breakpointVerificationTracker";
+
+import {
+    MockedObject,
+    instance,
+    mockFn,
+    mockGlobalFunction,
+    mockGlobalValue,
+    mockObject,
+} from "../../MockUtils";
+
+suite("BreakpointVerificationTracker Unit Test Suite", () => {
+    const removeBreakpointsStub = mockGlobalFunction(vscode.debug, "removeBreakpoints");
+    const addBreakpointsStub = mockGlobalFunction(vscode.debug, "addBreakpoints");
+    const breakpointsValue = mockGlobalValue(vscode.debug, "breakpoints");
+
+    let tracker: BreakpointVerificationTracker;
+    let mockSession: MockedObject<vscode.DebugSession>;
+
+    setup(() => {
+        mockSession = mockObject<vscode.DebugSession>({
+            getDebugProtocolBreakpoint: mockFn(),
+        });
+        tracker = new BreakpointVerificationTracker(instance(mockSession));
+    });
+
+    function stoppedEvent(reason: string): DebugProtocol.StoppedEvent {
+        return {
+            seq: 0,
+            type: "event",
+            event: "stopped",
+            body: { reason, threadId: 1 },
+        };
+    }
+
+    test("does not refresh when all breakpoints are verified", async () => {
+        const bp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        breakpointsValue.setValue([bp]);
+        mockSession.getDebugProtocolBreakpoint.resolves({ verified: true });
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+
+    test("refreshes only unverified breakpoints on first stop", async () => {
+        const unverifiedBp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        const verifiedBp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(19, 0))
+        );
+        breakpointsValue.setValue([unverifiedBp, verifiedBp]);
+        mockSession.getDebugProtocolBreakpoint.withArgs(unverifiedBp).resolves({ verified: false });
+        mockSession.getDebugProtocolBreakpoint.withArgs(verifiedBp).resolves({ verified: true });
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(removeBreakpointsStub).to.have.been.calledOnceWithExactly([unverifiedBp]);
+        expect(addBreakpointsStub).to.have.been.calledOnceWithExactly([unverifiedBp]);
+    });
+
+    test("only refreshes once even with multiple stopped events", async () => {
+        const bp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        breakpointsValue.setValue([bp]);
+        mockSession.getDebugProtocolBreakpoint.resolves({ verified: false });
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(removeBreakpointsStub).to.have.been.calledOnce;
+        expect(addBreakpointsStub).to.have.been.calledOnce;
+    });
+
+    test("does not refresh before a stopped event", async () => {
+        breakpointsValue.setValue([]);
+
+        const processEvent: DebugProtocol.ProcessEvent = {
+            seq: 0,
+            type: "event",
+            event: "process",
+            body: { name: "test" },
+        };
+        await tracker.onDidSendMessageAsync(processEvent);
+
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+
+    test("skips breakpoints the adapter has no state for", async () => {
+        const bp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        breakpointsValue.setValue([bp]);
+        mockSession.getDebugProtocolBreakpoint.resolves(undefined);
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+
+    test("ignores non-source breakpoints", async () => {
+        const fnBp = new vscode.FunctionBreakpoint("main");
+        breakpointsValue.setValue([fnBp]);
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(mockSession.getDebugProtocolBreakpoint).to.not.have.been.called;
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+
+    test("ignores non-event messages", async () => {
+        const requestMessage: DebugProtocol.Request = {
+            seq: 1,
+            type: "request",
+            command: "continue",
+        };
+        const responseMessage: DebugProtocol.Response = {
+            seq: 2,
+            type: "response",
+            request_seq: 1,
+            command: "continue",
+            success: true,
+        };
+        await tracker.onDidSendMessageAsync(requestMessage);
+        await tracker.onDidSendMessageAsync(responseMessage);
+
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+
+    test("does not refresh on non-breakpoint stop reasons", async () => {
+        const bp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        breakpointsValue.setValue([bp]);
+        mockSession.getDebugProtocolBreakpoint.resolves({ verified: false });
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("step"));
+
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+
+    test("treats breakpoints without a verified field as unverified", async () => {
+        const bp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        breakpointsValue.setValue([bp]);
+        mockSession.getDebugProtocolBreakpoint.resolves({});
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(removeBreakpointsStub).to.have.been.calledOnce;
+        expect(addBreakpointsStub).to.have.been.calledOnce;
+    });
+
+    test("treats breakpoints with a non-boolean verified field as unverified", async () => {
+        const bp = new vscode.SourceBreakpoint(
+            new vscode.Location(vscode.Uri.file("/test.swift"), new vscode.Position(9, 0))
+        );
+        breakpointsValue.setValue([bp]);
+        mockSession.getDebugProtocolBreakpoint.resolves({ verified: 1 });
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(removeBreakpointsStub).to.have.been.calledOnce;
+        expect(addBreakpointsStub).to.have.been.calledOnce;
+    });
+
+    test("does not refresh when there are no source breakpoints", async () => {
+        breakpointsValue.setValue([]);
+
+        await tracker.onDidSendMessageAsync(stoppedEvent("breakpoint"));
+
+        expect(mockSession.getDebugProtocolBreakpoint).to.not.have.been.called;
+        expect(removeBreakpointsStub).to.not.have.been.called;
+        expect(addBreakpointsStub).to.not.have.been.called;
+    });
+});


### PR DESCRIPTION
## Description
Works around an issue in older versions of `lldb-dap` where breakpoints would not be resolved correctly on startup. The extension will now force the resolution of unverified breakpoints when a breakpoint stop event is received from the debug adapter.

Issue: #1871 

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
