### PR TITLE
Use swift folder path when resolving toolchain executables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update sourcekit-lsp schema logic for new branch structure ([#2270](https://github.com/swiftlang/vscode-swift/pull/2270))
 - Work around an issue in older lldb-dap binaries where breakpoints would show up as unresolved even when they were hit ([#2283](https://github.com/swiftlang/vscode-swift/pull/2283))
 - Capturing a diagnostics bundle will no longer fail if the extension fails to activate ([#2273](https://github.com/swiftlang/vscode-swift/pull/2273))
+- Stop assuming that `swift.path` will point at a directory named `bin` ([#2288](https://github.com/swiftlang/vscode-swift/pull/2288))
 
 ## 2.16.6 - 2026-06-04
 

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -144,6 +144,7 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
         folder?: vscode.Uri
     ): Promise<SwiftToolchain> {
         const swiftBinaryPath = await this.findSwiftBinaryInPath();
+        const swiftFolderPath = path.dirname(swiftBinaryPath);
         const { toolchainPath, toolchainManager } = await this.getToolchainPath(
             swiftBinaryPath,
             extensionRoot,
@@ -151,7 +152,7 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
             folder
         );
         const targetInfo = await this.getSwiftTargetInfo(
-            this._getToolchainExecutable(toolchainPath, "swift"),
+            this._getToolchainExecutable(swiftFolderPath, "swift"),
             logger
         );
         const swiftVersion = this.getSwiftVersion(targetInfo);
@@ -181,7 +182,7 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
 
         return new SwiftToolchain(
             toolchainManager,
-            path.dirname(swiftBinaryPath),
+            swiftFolderPath,
             toolchainPath,
             targetInfo,
             swiftVersion,
@@ -392,7 +393,7 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
      * {@link getToolchainInvocation} instead.
      */
     public getToolchainExecutablePath(executable: string): string {
-        return SwiftToolchain._getToolchainExecutable(this.toolchainPath, executable);
+        return SwiftToolchain._getToolchainExecutable(this.swiftFolderPath, executable);
     }
 
     /**
@@ -447,10 +448,10 @@ export class SwiftToolchain implements ExternalSwiftToolchain {
         }
     }
 
-    private static _getToolchainExecutable(toolchainPath: string, executable: string): string {
+    private static _getToolchainExecutable(swiftFolderPath: string, executable: string): string {
         // should we add `.exe` at the end of the executable name
         const executableSuffix = process.platform === "win32" ? ".exe" : "";
-        return path.join(toolchainPath, "bin", executable + executableSuffix);
+        return path.join(swiftFolderPath, executable + executableSuffix);
     }
 
     /**

--- a/test/unit-tests/toolchain/toolchain.test.ts
+++ b/test/unit-tests/toolchain/toolchain.test.ts
@@ -60,6 +60,20 @@ suite("SwiftToolchain Unit Test Suite", () => {
             expect(inv.args).to.deep.equal(["build", "--configuration", "debug"]);
         });
 
+        test("normal toolchain returns the path to the binary when it's not in a bin folder", () => {
+            mockedPlatform.setValue("linux");
+            const tc = new SwiftToolchain(
+                "unknown",
+                "/path/to/custom/toolchain",
+                "/path/to/custom",
+                { compilerVersion: "6.0.0", paths: { runtimeLibraryPaths: [] } },
+                new Version(6, 0, 0)
+            );
+            const inv = tc.getToolchainInvocation("swift", ["build"]);
+            expect(inv.command).to.equalPath("/path/to/custom/toolchain/swift");
+            expect(inv.args).to.deep.equal(["build"]);
+        });
+
         test("xcrun toolchain wraps as xcrun <tool>", () => {
             mockedPlatform.setValue("darwin");
             const tc = createToolchain(


### PR DESCRIPTION
## Description
The logic for finding executables in a direct toolchain installation was assuming that a `bin` directory existed within `toolchainPath`. However, this is not always the case (especially when setting `swift.path` to a custom toolchain build). Use the already known `swiftFolderPath` instead which is guaranteed to exist.

## Tasks
- [x] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
