### PR TITLE
Expose backgroundPreparationMode setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Toolchain changes will now automatically reload the workspace ([#2196](https://github.com/swiftlang/vscode-swift/pull/2196))
+- Add `swift.sourcekit-lsp.backgroundPreparationMode` setting to control SourceKit-LSP's prepare-for-indexing mode. ([#2291](https://github.com/swiftlang/vscode-swift/pull/2291))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -957,6 +957,23 @@
             "order": 4,
             "scope": "machine-overridable"
           },
+          "swift.sourcekit-lsp.backgroundPreparationMode": {
+            "type": "string",
+            "enum": [
+              "enabled",
+              "noLazy",
+              "disabled"
+            ],
+            "enumDescriptions": [
+              "Lazy prepare-for-indexing (fastest; default).",
+              "Full prepare-for-indexing. Slower, but emits complete swiftmodules which may result in more precise/correct indexing, especially when macros add conformances to protocols.",
+              "Skip prepare-for-indexing entirely."
+            ],
+            "default": "enabled",
+            "markdownDescription": "Controls SourceKit-LSP's prepare-for-indexing mode. The `noLazy` mode may be necessary in projects where with extensive use of macros. Has no effect when `#swift.sourcekit-lsp.backgroundIndexing#` is `off` or for Swift versions prior to 6.0.",
+            "order": 5,
+            "scope": "machine-overridable"
+          },
           "swift.sourcekit-lsp.trace.server": {
             "type": "string",
             "default": "off",
@@ -966,14 +983,14 @@
               "verbose"
             ],
             "markdownDescription": "Controls logging the communication between VS Code and the SourceKit-LSP language server. Logs can be viewed in Output > SourceKit Language Server.",
-            "order": 5,
+            "order": 6,
             "scope": "machine-overridable"
           },
           "swift.sourcekit-lsp.disable": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Disable SourceKit-LSP. This will turn off features like code completion, error diagnostics and jump-to-definition. Features like swift-testing test discovery will not work correctly.",
-            "order": 6,
+            "order": 7,
             "scope": "machine-overridable"
           },
           "swift.sourcekit-lsp.includeDeclarationInFindAllReferences": {
@@ -990,7 +1007,7 @@
               "Never include the symbol declaration in `Find All References` results."
             ],
             "markdownDescription": "Controls whether the symbol declaration is included in the results of `Find All References`.",
-            "order": 7,
+            "order": 8,
             "scope": "machine-overridable"
           },
           "sourcekit-lsp.inlayHints.enabled": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -612,6 +612,15 @@ const configuration = {
             );
         }
     },
+    /** prepare-for-indexing mode used when background indexing is enabled */
+    get backgroundPreparationMode(): "enabled" | "noLazy" | "disabled" {
+        return validateStringSetting<"enabled" | "noLazy" | "disabled">(
+            vscode.workspace
+                .getConfiguration("swift.sourcekit-lsp")
+                .get<"enabled" | "noLazy" | "disabled">("backgroundPreparationMode", "enabled"),
+            "swift.sourcekit-lsp.backgroundPreparationMode"
+        );
+    },
     /** focus on problems view whenever there is a build error */
     get actionAfterBuildError(): ActionAfterBuildError {
         return validateStringSetting(

--- a/src/sourcekit-lsp/LanguageClientConfiguration.ts
+++ b/src/sourcekit-lsp/LanguageClientConfiguration.ts
@@ -73,7 +73,7 @@ function initializationOptions(swiftVersion: Version): Record<string, unknown> {
         options = {
             ...options,
             backgroundIndexing: true,
-            backgroundPreparationMode: "enabled",
+            backgroundPreparationMode: configuration.backgroundPreparationMode,
         };
     }
 

--- a/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientManager.test.ts
@@ -230,6 +230,7 @@ suite("LanguageClientManager Suite", () => {
         mockedConfig.path = "";
         mockedConfig.buildArguments = [];
         mockedConfig.backgroundIndexing = "off";
+        mockedConfig.backgroundPreparationMode = "enabled";
         mockedConfig.swiftEnvironmentVariables = {};
         mockedLspConfig.supportCFamily = "cpptools-inactive";
         mockedLspConfig.disable = false;
@@ -463,6 +464,86 @@ suite("LanguageClientManager Suite", () => {
             match.string,
             match.object,
             match.hasNested("initializationOptions.backgroundIndexing", match.truthy)
+        );
+    });
+
+    test("forwards backgroundPreparationMode default ('enabled')", async () => {
+        mockedFolder.swiftVersion = new Version(6, 1, 0);
+        mockedConfig.backgroundIndexing = "on";
+        mockedConfig.backgroundPreparationMode = "enabled";
+
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions.backgroundPreparationMode", "enabled")
+        );
+    });
+
+    test("forwards backgroundPreparationMode 'noLazy'", async () => {
+        mockedFolder.swiftVersion = new Version(6, 1, 0);
+        mockedConfig.backgroundIndexing = "on";
+        mockedConfig.backgroundPreparationMode = "noLazy";
+
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions.backgroundPreparationMode", "noLazy")
+        );
+    });
+
+    test("forwards backgroundPreparationMode 'disabled'", async () => {
+        mockedFolder.swiftVersion = new Version(6, 1, 0);
+        mockedConfig.backgroundIndexing = "on";
+        mockedConfig.backgroundPreparationMode = "disabled";
+
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions.backgroundPreparationMode", "disabled")
+        );
+    });
+
+    test("does not send backgroundPreparationMode when backgroundIndexing is off", async () => {
+        mockedFolder.swiftVersion = new Version(6, 1, 0);
+        mockedConfig.backgroundIndexing = "off";
+        mockedConfig.backgroundPreparationMode = "noLazy";
+
+        coordinator = new LanguageClientToolchainCoordinator(
+            instance(mockedWorkspace),
+            {},
+            languageClientFactoryMock
+        );
+        await waitForReturnedPromises(languageClientMock.start);
+
+        expect(languageClientFactoryMock.createLanguageClient).to.have.been.calledOnceWith(
+            match.string,
+            match.string,
+            match.object,
+            match.hasNested("initializationOptions", doesNotHave("backgroundPreparationMode"))
         );
     });
 

--- a/userdocs/userdocs.docc/Articles/Reference/settings.md
+++ b/userdocs/userdocs.docc/Articles/Reference/settings.md
@@ -135,6 +135,10 @@ On startup, SourceKit-LSP will read your project information from your `Package.
 
 You can enable or disable this feature with the [`swift.sourcekit-lsp.backgroundIndexing`](vscode://settings/swift.sourcekit-lsp.backgroundIndexing) setting.
 
+By default, background indexing uses a "lazy" prepare-for-indexing mode that produces stripped `.swiftmodule` files for upstream targets. This is faster, but can omit information added by macros or extensions, e.g. protocol conformances added by macros. 
+If you encounter `does not conform to protocol` errors in the editor that don't appear building the project, consider setting [`swift.sourcekit-lsp.backgroundPreparationMode`](vscode://settings/swift.sourcekit-lsp.backgroundPreparationMode) to `noLazy`, as this may resolve the issue with missing macro-generated conformances. 
+Set it to `disabled` to skip the preparation completely.
+
 ### Support for 'Expand Macro'
 
 If you are using a nightly (`main`) toolchain you can enable support for the "Peek Macro" Quick Action, accessible through the light bulb icon when the cursor is on a macro.


### PR DESCRIPTION
I've been hitting various mysterious issues in swift-java and finally tracked it down to being caused by the lazy indexing.

It seems to have problems when macros add conformances through extensions to existing types. Changing to the noLazy mode resolves the issues.

I have verified in swift-java that this can be fixed by configuring this setting in  `.sourcekit-lsp/config.json` file, but I think it's probably worth exposing it as a setting in the plugin.

## Tasks
- [x] Required tests have been written
- [x] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
