### PR TITLE
Respect scratch path when listing Swift package plugins

### DIFF
--- a/src/SwiftPackage.ts
+++ b/src/SwiftPackage.ts
@@ -296,6 +296,7 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
         folder: vscode.Uri,
         toolchain: SwiftToolchain,
         logger: SwiftLogger,
+        buildDirectory: string,
         disableSwiftPMIntegration: boolean = false
     ): Promise<PackagePlugin[]> {
         // When SwiftPM integration is disabled, return empty plugin list
@@ -304,9 +305,16 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
         }
 
         try {
-            const { stdout } = await execSwift(["package", "plugin", "--list"], toolchain, {
-                cwd: folder.fsPath,
-            });
+            // Pin the scratch path so `swift package plugin --list` regenerates
+            // workspace-state.json in the exact directory loadWorkspaceState
+            // reads it back from.
+            const { stdout } = await execSwift(
+                ["package", "--scratch-path", buildDirectory, "plugin", "--list"],
+                toolchain,
+                {
+                    cwd: folder.fsPath,
+                }
+            );
             const plugins: PackagePlugin[] = [];
             const lines = stdout.split(lineBreakRegex).map(item => item.trim());
             for (const line of lines) {
@@ -333,11 +341,12 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
      * @returns Workspace state
      */
     private static async loadWorkspaceState(
-        folder: vscode.Uri
+        folder: vscode.Uri,
+        buildDirectory: string = BuildFlags.buildDirectoryFromWorkspacePath(folder.fsPath, true)
     ): Promise<WorkspaceState | undefined> {
         try {
             const uri = vscode.Uri.joinPath(
-                vscode.Uri.file(BuildFlags.buildDirectoryFromWorkspacePath(folder.fsPath, true)),
+                vscode.Uri.file(buildDirectory),
                 "workspace-state.json"
             );
             const contents = await fs.readFile(uri.fsPath, "utf8");
@@ -384,13 +393,21 @@ export class SwiftPackage implements ExternalSwiftPackage, Disposable {
         // URL checks (see TrustedPlugins.ts) require the two fields to move
         // together.
         const next = this.pluginLoadQueue.then(async () => {
+            const buildDirectory = BuildFlags.buildDirectoryFromWorkspacePath(
+                this.folder.fsPath,
+                true
+            );
             const newPlugins = await SwiftPackage.loadPlugins(
                 this.folder,
                 toolchain,
                 logger,
+                buildDirectory,
                 disableSwiftPMIntegration
             );
-            const newWorkspaceState = await SwiftPackage.loadWorkspaceState(this.folder);
+            const newWorkspaceState = await SwiftPackage.loadWorkspaceState(
+                this.folder,
+                buildDirectory
+            );
             this.plugins = newPlugins;
             this.workspaceState = newWorkspaceState;
         });

--- a/test/unit-tests/SwiftPackage.test.ts
+++ b/test/unit-tests/SwiftPackage.test.ts
@@ -13,14 +13,17 @@
 //===----------------------------------------------------------------------===//
 import { expect } from "chai";
 import * as fs from "fs/promises";
+import * as path from "path";
 import * as vscode from "vscode";
 
 import { SwiftPackage } from "@src/SwiftPackage";
+import configuration from "@src/configuration";
 import { SwiftLogger } from "@src/logging/SwiftLogger";
+import { BuildFlags } from "@src/toolchain/BuildFlags";
 import { SwiftToolchain } from "@src/toolchain/toolchain";
 import * as utilities from "@src/utilities/utilities";
 
-import { instance, mockGlobalFunction, mockObject } from "../MockUtils";
+import { instance, mockGlobalFunction, mockGlobalValue, mockObject } from "../MockUtils";
 
 suite("SwiftPackage Suite", () => {
     suite("loadSwiftPlugins", () => {
@@ -200,6 +203,100 @@ suite("SwiftPackage Suite", () => {
             await callPromise;
 
             expect(pkg.workspaceState).to.deep.equal(JSON.parse(refreshedWs));
+        });
+    });
+
+    // `swift package plugin --list` regenerates workspace-state.json as a side
+    // effect, and loadSwiftPlugins reads it back immediately afterwards. The
+    // regeneration (write) and the read must resolve the SAME scratch
+    // directory, otherwise the in-memory workspaceState reflects a stale file
+    // left on disk rather than the one SwiftPM just wrote. `swift.buildArguments`
+    // can relocate the scratch directory via `--scratch-path`, so that
+    // redirection has to reach the `--list` invocation as well as the read.
+    suite("loadSwiftPlugins build directory consistency", () => {
+        const readFileMock = mockGlobalFunction(fs, "readFile");
+        const execSwiftMock = mockGlobalFunction(utilities, "execSwift");
+        const buildArgsConfig = mockGlobalValue(configuration, "buildArguments");
+        const buildPathConfig = mockGlobalValue(configuration, "buildPath");
+        const packageArgsConfig = mockGlobalValue(configuration, "packageArguments");
+
+        const workspacePath = "/tmp/swift-package-test";
+        const scratchDir = path.join(workspacePath, "custom-build");
+        const scratchStatePath = path.join(scratchDir, "workspace-state.json");
+
+        // A stale workspace-state.json already sitting in the relocated scratch
+        // directory before SwiftPM runs.
+        const staleState = JSON.stringify({
+            version: 7,
+            object: {
+                artifacts: [],
+                dependencies: [
+                    {
+                        subpath: "some-dependency",
+                        packageRef: {
+                            identity: "some-dependency",
+                            kind: "remoteSourceControl",
+                            name: "SomeDependency",
+                            location: "https://github.com/example/some-dependency",
+                        },
+                        state: { name: "sourceControlCheckout" },
+                    },
+                ],
+                prebuilts: [],
+            },
+        });
+        // What `swift package plugin --list` writes when it regenerates the file.
+        const regeneratedState = JSON.stringify({
+            version: 7,
+            object: { artifacts: [], dependencies: [], prebuilts: [] },
+        });
+
+        test("reads workspace-state.json from the directory `plugin --list` regenerated when swift.buildArguments redirects the scratch path", async () => {
+            buildArgsConfig.setValue(["--scratch-path", "custom-build"]);
+            buildPathConfig.setValue("");
+            packageArgsConfig.setValue([]);
+
+            // In-memory disk seeded with the stale file in the relocated dir.
+            const disk = new Map<string, string>([[scratchStatePath, staleState]]);
+
+            readFileMock.callsFake((async (filePath: unknown) => {
+                const p = String(filePath);
+                if (p.endsWith("Package.resolved")) {
+                    throw new Error("ENOENT");
+                }
+                const contents = disk.get(p);
+                if (contents === undefined) {
+                    throw new Error(`ENOENT: ${p}`);
+                }
+                return contents;
+            }) as typeof fs.readFile);
+
+            let listScratchPath: string | undefined;
+            execSwiftMock.callsFake((async (args: string[]) => {
+                // Model SwiftPM: `plugin --list` regenerates workspace-state.json
+                // in whatever scratch directory it is told to use, defaulting to
+                // `.build` when none is supplied.
+                listScratchPath = BuildFlags.lastFlagValue(args, "--scratch-path");
+                const dir = listScratchPath ?? path.join(workspacePath, ".build");
+                disk.set(path.join(dir, "workspace-state.json"), regeneratedState);
+                return { stdout: "", stderr: "" };
+            }) as typeof utilities.execSwift);
+
+            const pkg = await SwiftPackage.create(vscode.Uri.file(workspacePath));
+            // Baseline: the stale file is what is on disk before SwiftPM runs.
+            expect(pkg.workspaceState).to.deep.equal(JSON.parse(staleState));
+
+            await pkg.loadSwiftPlugins(
+                instance(mockObject<SwiftToolchain>({})),
+                instance(mockObject<SwiftLogger>({}))
+            );
+
+            // `--list` ran against the relocated scratch directory...
+            expect(listScratchPath).to.equalPath(scratchDir);
+            // ...so the file it regenerated is the one loadSwiftPlugins read back,
+            // not the stale copy that was sitting there beforehand.
+            expect(disk.get(scratchStatePath)).to.equal(regeneratedState);
+            expect(pkg.workspaceState).to.deep.equal(JSON.parse(regeneratedState));
         });
     });
 });


### PR DESCRIPTION
## Description
`swift package plugin --list` regenerates workspace-state.json as a side effect, and loadSwiftPlugins reads it back immediately afterwards. If the user has a `swift.buildArguments` setting that sets the scratch path these two paths could diverge, causing `loadSwiftPlugins` to read back a stale workspace-state.json instead of the one SwiftPM had just written.

Resolve the build directory once in loadSwiftPlugins and thread it into both loadPlugins (as an explicit --scratch-path on the --list call) and loadWorkspaceState, so the write and read always agree.

## Tasks
- [X] Required tests have been written
- [ ] ~Documentation has been updated~
- [ ] Added an entry to CHANGELOG.md if applicable
