### PR TITLE
Pass multiple coverage binaries to llvm-cov with `-object`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Work around an issue in older lldb-dap binaries where breakpoints would show up as unresolved even when they were hit ([#2283](https://github.com/swiftlang/vscode-swift/pull/2283))
 - Capturing a diagnostics bundle will no longer fail if the extension fails to activate ([#2273](https://github.com/swiftlang/vscode-swift/pull/2273))
 - Stop assuming that `swift.path` will point at a directory named `bin` ([#2288](https://github.com/swiftlang/vscode-swift/pull/2288))
+- Fixed code coverage information only showing for the first test target when buildnig with swift-build ([#2296](https://github.com/swiftlang/vscode-swift/pull/2296))
 
 ## 2.16.6 - 2026-06-04
 

--- a/src/coverage/LcovResults.ts
+++ b/src/coverage/LcovResults.ts
@@ -33,6 +33,22 @@ interface CodeCovFile {
     path: string;
 }
 
+/**
+ * Builds the positional binary arguments for `llvm-cov export`.
+ *
+ * `llvm-cov` only treats the first positional argument as an instrumented
+ * binary; every subsequent binary must be introduced with `-object` or it is
+ * silently interpreted as a source-file filter. This matters when the
+ * swiftbuild build system produces one test binary per target.
+ */
+export function llvmCovObjectArguments(binaries: string[]): string[] {
+    const [first, ...rest] = binaries;
+    if (!first) {
+        return [];
+    }
+    return [first, ...rest.flatMap(binary => ["-object", binary])];
+}
+
 export class TestCoverage {
     private lcovFiles: CodeCovFile[] = [];
     private _lcovTmpFiles?: DisposableFileCollection;
@@ -169,7 +185,7 @@ export class TestCoverage {
             "export",
             "--format",
             "lcov",
-            ...coveredBinaries,
+            ...llvmCovObjectArguments(coveredBinaries),
             `--ignore-filename-regex=${await this.ignoredFilenamesRegex()}`,
             `--instr-profile=${mergedProfileFile}`,
         ]);

--- a/test/unit-tests/coverage/LcovResults.test.ts
+++ b/test/unit-tests/coverage/LcovResults.test.ts
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+
+import { llvmCovObjectArguments } from "@src/coverage/LcovResults";
+
+suite("LcovResults Unit Tests", () => {
+    suite("llvmCovObjectArguments", () => {
+        test("returns no arguments when there are no binaries", () => {
+            expect(llvmCovObjectArguments([])).to.deep.equal([]);
+        });
+
+        test("passes a single binary as a bare positional argument", () => {
+            expect(llvmCovObjectArguments(["/bin/AppTests"])).to.deep.equal(["/bin/AppTests"]);
+        });
+
+        test("prefixes every binary after the first with -object", () => {
+            // llvm-cov export treats only the first positional argument as an
+            // instrumented binary; subsequent binaries must be introduced with
+            // -object or they are silently interpreted as source-file filters.
+            expect(
+                llvmCovObjectArguments([
+                    "/bin/S3StoreTests",
+                    "/bin/AuthenticationTests",
+                    "/bin/AppTests",
+                ])
+            ).to.deep.equal([
+                "/bin/S3StoreTests",
+                "-object",
+                "/bin/AuthenticationTests",
+                "-object",
+                "/bin/AppTests",
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
## Description
llvm-cov export treats only the first positional argument as an instrumented binary. We were passing a list of paths when building with swift-build and running tests across multiple test targets. Only the first is treated as an object, and subsequent paths are read as source-file filters. Consequently, only the first test target would show coverage information.

## Tasks
- [X] Required tests have been written
- [ ] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
