### PR TITLE
Add setting to configure the build system backend used by SourceKit-LSP

### DIFF
--- a/package.json
+++ b/package.json
@@ -1017,6 +1017,23 @@
             "order": 7,
             "scope": "machine-overridable"
           },
+          "swift.sourcekit-lsp.swiftPM.buildSystemBackend": {
+            "type": "string",
+            "default": "auto",
+            "enum": [
+              "auto",
+              "native",
+              "swiftbuild"
+            ],
+            "enumDescriptions": [
+              "Use the default build system backend selected by SourceKit-LSP.",
+              "Use the legacy SwiftPM build system.",
+              "Use SwiftPM's Swift Build backend (experimental)."
+            ],
+            "markdownDescription": "Which SwiftPM build system backend to use when preparing a package for indexing.",
+            "order": 8,
+            "scope": "machine-overridable"
+          },
           "sourcekit-lsp.support-c-cpp": {
             "type": "string",
             "default": "cpptools-inactive",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -64,6 +64,8 @@ interface LSPConfiguration {
     readonly disable: boolean;
     /** Include declaration in Find All References results */
     readonly includeDeclarationInFindAllReferences: "default" | "always" | "never";
+    /** Which SwiftPM build system backend SourceKit-LSP should use */
+    readonly swiftPMBuildSystem: "auto" | "native" | "swiftbuild";
     /** Is the trace server enabled */
     readonly traceServer: "off" | "messages" | "verbose";
 }
@@ -191,6 +193,14 @@ const configuration = {
                         .getConfiguration("swift.sourcekit-lsp")
                         .get<string>("includeDeclarationInFindAllReferences", "default"),
                     "swift.sourcekit-lsp.includeDeclarationInFindAllReferences"
+                );
+            },
+            get swiftPMBuildSystem(): "auto" | "native" | "swiftbuild" {
+                return validateStringSetting<"auto" | "native" | "swiftbuild">(
+                    vscode.workspace
+                        .getConfiguration("swift.sourcekit-lsp.swiftPM")
+                        .get<string>("buildSystemBackend", "auto"),
+                    "swift.sourcekit-lsp.swiftPM.buildSystemBackend"
                 );
             },
             get traceServer(): "off" | "messages" | "verbose" {

--- a/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
+++ b/src/sourcekit-lsp/LanguageClientToolchainCoordinator.ts
@@ -76,6 +76,7 @@ export class LanguageClientToolchainCoordinator implements AsyncDisposable {
             "swift.sourcekit-lsp.serverArguments",
             "swift.sourcekit-lsp.supported-languages",
             "swift.sourcekit-lsp.backgroundIndexing",
+            "swift.sourcekit-lsp.swiftPM.buildSystemBackend",
             "swift.sourcekit-lsp.support-c-cpp",
         ];
         if (restartSettings.some(s => event.affectsConfiguration(s))) {

--- a/src/sourcekit-lsp/client/SourceKitLanguageClient.ts
+++ b/src/sourcekit-lsp/client/SourceKitLanguageClient.ts
@@ -371,10 +371,18 @@ function initializationOptions(swiftVersion: Version): Record<string, unknown> {
         };
     }
 
+    const swiftPMOptions: Record<string, unknown> = {};
     if (configuration.swiftSDK !== "") {
+        swiftPMOptions.swiftSDK = configuration.swiftSDK;
+    }
+    // "auto" leaves the build system unset so that sourcekit-lsp picks its default.
+    if (configuration.lsp.swiftPMBuildSystem !== "auto") {
+        swiftPMOptions.buildSystem = configuration.lsp.swiftPMBuildSystem;
+    }
+    if (Object.keys(swiftPMOptions).length > 0) {
         options = {
             ...options,
-            swiftPM: { swiftSDK: configuration.swiftSDK },
+            swiftPM: swiftPMOptions,
         };
     }
 

--- a/test/unit-tests/sourcekit-lsp/LanguageClientToolchainCoordinator.test.ts
+++ b/test/unit-tests/sourcekit-lsp/LanguageClientToolchainCoordinator.test.ts
@@ -344,6 +344,20 @@ suite("LanguageClientToolchainCoordinator Unit Tests", () => {
             expect(client2.dispose).to.not.have.been.called;
         });
 
+        test("restarts every client when the swift.sourcekit-lsp.swiftPM.buildSystemBackend setting changes", async function () {
+            const folder1 = await addFolderToWorkspace(new Version(5, 10, 0));
+            const folder2 = await addFolderToWorkspace(new Version(6, 4, 0));
+            const client1 = coordinator.getClient(instance(folder1));
+            const client2 = coordinator.getClient(instance(folder2));
+
+            await fireConfigurationChange("swift.sourcekit-lsp.swiftPM.buildSystemBackend");
+
+            expect(client1.restart).to.have.been.calledOnce;
+            expect(client2.restart).to.have.been.calledOnce;
+            expect(client1.dispose).to.not.have.been.called;
+            expect(client2.dispose).to.not.have.been.called;
+        });
+
         test("restarts every client when the swift.sourcekit-lsp.support-c-cpp setting changes", async function () {
             const folder1 = await addFolderToWorkspace(new Version(5, 10, 0));
             const folder2 = await addFolderToWorkspace(new Version(6, 4, 0));


### PR DESCRIPTION
## Description
Add a setting to allow configuring the build system backend used by SourceKit-LSP to prepare a package for indexing and provide compiler arguments. This makes it easier to opt in to living on the experimental Swift Build BSP implementation as it's being developed.

## Tasks
- [x] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
