### PR TITLE
Clean up tsconfig files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2122,7 +2122,7 @@
     "watch": "npm run compile -- --watch",
     "compile-documentation-webview": "del-cli ./assets/documentation-webview && esbuild ./src/documentation/webview/webview.ts --bundle --outfile=assets/documentation-webview/index.js --define:process.env.NODE_ENV=\\\"production\\\" --define:process.env.CI=\\\"\\\" --format=cjs --sourcemap",
     "watch-documentation-webview": "npm run compile-documentation-webview -- --watch",
-    "lint": "eslint ./ --ext ts && tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json && knip",
+    "lint": "eslint ./ --ext ts && tsc --noEmit && knip",
     "build-swift-docc-render": "tsx ./scripts/build_swift_docc_render.ts",
     "compile-icons": "tsx ./scripts/compile_icons.ts",
     "format": "prettier --check .",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,20 +1,7 @@
 {
+  "extends": "../tsconfig-base.json",
   "compilerOptions": {
-    "composite": true,
-
-    "rootDir": "..",
-    "outDir": "../dist",
-
-    "lib": ["ES2021"],
-    "target": "ES2020",
-    "module": "commonjs",
-    "esModuleInterop": true,
-
-    "strict": true,
-
-    "sourceMap": true,
-
-    "types": []
+    "types": ["node"]
   },
   "include": ["**/*.ts", "../src/icons/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./src" },
     { "path": "./src/documentation/webview" },
-    { "path": "./test" }
+    { "path": "./test" },
+    { "path": "./scripts" }
   ]
 }


### PR DESCRIPTION
## Description
The `scripts/tsconfig.json` file was using outdated `lib` and `target` versions. Extend the `tsconfig.base.json` file so that it matches the rest of the project.

I also added `./scripts` as a reference to the main tsconfig.json file so that we don't have to remember to add it to all of our building and linting commands. While this does mean that local developer builds will build and include a `dist/scripts` directory, production is not impacted because we use a separate `esbuild` step which does not include scripts.

## Tasks
- ~[ ] Required tests have been written~
- ~[ ] Documentation has been updated~
- ~[ ] Added an entry to CHANGELOG.md if applicable~
