### PR TITLE
Fix test run never completing when debug session name mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Capturing a diagnostics bundle will no longer fail if the extension fails to activate ([#2273](https://github.com/swiftlang/vscode-swift/pull/2273))
 - Stop assuming that `swift.path` will point at a directory named `bin` ([#2288](https://github.com/swiftlang/vscode-swift/pull/2288))
 - Fixed code coverage information only showing for the first test target when buildnig with swift-build ([#2296](https://github.com/swiftlang/vscode-swift/pull/2296))
+- Fixed test run never completing when stopping a debug session ([#2329](https://github.com/swiftlang/vscode-swift/pull/2329))
 
 ## 2.16.6 - 2026-06-04
 

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -62,6 +62,17 @@ export enum TestLibrary {
     swiftTesting = "swift-testing",
 }
 
+export function debugSessionMatchesConfig(
+    config: vscode.DebugConfiguration,
+    startedSessionId: string | undefined,
+    session: Pick<vscode.DebugSession, "id" | "name">
+): boolean {
+    if (startedSessionId !== undefined && session.id === startedSessionId) {
+        return true;
+    }
+    return session.name === config.name;
+}
+
 /** Class used to run tests */
 export class TestRunner {
     public testRun: TestRunProxy;
@@ -927,7 +938,25 @@ export class TestRunner {
                 return;
             }
 
+            let startedSessionId: string | undefined;
+
+            let settled = false;
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                subscriptions.forEach(sub => sub.dispose());
+                if (config.testType === TestLibrary.swiftTesting) {
+                    void this.swiftTestOutputParser.close();
+                }
+                void vscode.commands
+                    .executeCommand("workbench.view.extension.test")
+                    .then(() => resolve());
+            };
+
             const startSession = vscode.debug.onDidStartDebugSession(session => {
+                startedSessionId = session.id;
                 const outputHandler = this.testOutputHandler(config.testType, runState);
                 outputHandler(`> ${config.program} ${config.args.join(" ")}\n\n\r`);
 
@@ -939,6 +968,10 @@ export class TestRunner {
                         if (exitCode === 9) {
                             this.debugSessionTerminatedEmitter.fire();
                         }
+                        this.workspaceContext.logger.debug("Test Debugging Process Exited", {
+                            label: this.folderContext.name,
+                        });
+                        finish();
                     }
                 );
 
@@ -946,24 +979,20 @@ export class TestRunner {
                     this.workspaceContext.logger.debug("Test Debugging Cancelled", {
                         label: this.folderContext.name,
                     });
-                    void vscode.debug.stopDebugging(session).then(resolve);
+                    void vscode.debug.stopDebugging(session).then(finish, finish);
                 });
                 subscriptions.push(cancellation);
             });
             subscriptions.push(startSession);
 
             const terminateSession = vscode.debug.onDidTerminateDebugSession(e => {
-                if (e.name !== config.name) {
+                if (!debugSessionMatchesConfig(config, startedSessionId, e)) {
                     return;
                 }
                 this.workspaceContext.logger.debug("Stop Test Debugging", {
                     label: this.folderContext.name,
                 });
-                subscriptions.forEach(sub => sub.dispose());
-
-                void vscode.commands
-                    .executeCommand("workbench.view.extension.test")
-                    .then(() => resolve());
+                finish();
             });
             subscriptions.push(terminateSession);
 
@@ -979,11 +1008,13 @@ export class TestRunner {
                             label: this.folderContext.name,
                         });
                     } else {
+                        settled = true;
                         subscriptions.forEach(sub => sub.dispose());
                         reject("Debugger not started");
                     }
                 },
                 reason => {
+                    settled = true;
                     subscriptions.forEach(sub => sub.dispose());
                     reject(reason);
                 }

--- a/src/debugger/logTracker.ts
+++ b/src/debugger/logTracker.ts
@@ -118,7 +118,7 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
             for (const o of loggingDebugAdapter.output) {
                 cb(o);
             }
-            if (loggingDebugAdapter.exitCode) {
+            if (loggingDebugAdapter.exitCode !== undefined) {
                 exitHandler(loggingDebugAdapter.exitCode);
             }
             loggingDebugAdapter.output = [];
@@ -143,7 +143,9 @@ export class LoggingDebugAdapterTracker implements vscode.DebugAdapterTracker {
             return;
         }
 
-        if (debugMessage.event === "exited" && debugMessage.body.exitCode) {
+        // https://github.com/swiftlang/vscode-swift/issues/2300
+        // exit code 0 must still be forwarded or the test run never finishes
+        if (debugMessage.event === "exited" && debugMessage.body.exitCode !== undefined) {
             this.exitCode = debugMessage.body.exitCode;
             this.exitHandler?.(debugMessage.body.exitCode);
         } else if (debugMessage.type === "event" && debugMessage.event === "output") {

--- a/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
+++ b/test/integration-tests/testexplorer/TestExplorerIntegration.test.ts
@@ -34,6 +34,7 @@ import { lineBreakRegex } from "@src/utilities/tasks";
 import { randomString } from "@src/utilities/utilities";
 import { Version } from "@src/utilities/version";
 
+import { mockGlobalFunction } from "../../MockUtils";
 import { tag } from "../../tags";
 import { executeTaskAndWaitForResult } from "../../utilities/tasks";
 import { waitForIndex } from "../utilities/lsputilities";
@@ -214,6 +215,64 @@ tag("large").suite("Test Explorer Suite", function () {
                     this.skip();
                 }
                 await runSwiftTesting.call(this);
+            });
+        });
+
+        suite("Session termination name mismatch", () => {
+            // Capture the real event before `mockGlobalFunction` replaces it so the fake
+            // can forward genuine terminate events with a disguised session name.
+            const realOnDidTerminate = vscode.debug.onDidTerminateDebugSession.bind(vscode.debug);
+            const onDidTerminate = mockGlobalFunction(vscode.debug, "onDidTerminateDebugSession");
+            let resetSettings: (() => Promise<void>) | undefined;
+
+            beforeEach(async function () {
+                // lldb-dap is only present/functional in the toolchain in 6.0.2 and up.
+                if (folderContext.swiftVersion.isLessThan(new Version(6, 0, 2))) {
+                    this.skip();
+                }
+                resetSettings = await updateSettings({
+                    "swift.debugger.debugAdapter": "lldb-dap",
+                });
+            });
+
+            afterEach(async () => {
+                if (resetSettings) {
+                    await resetSettings();
+                    resetSettings = undefined;
+                }
+            });
+
+            test("Registers completion when the terminated session name does not match", async function () {
+                this.timeout(60 * 1000);
+
+                onDidTerminate.callsFake((listener, thisArgs, disposables) =>
+                    realOnDidTerminate(
+                        session => {
+                            const disguised = new Proxy(session, {
+                                get(target, prop, receiver) {
+                                    if (prop === "name") {
+                                        return `xcrun ${target.name}`;
+                                    }
+                                    return Reflect.get(target, prop, receiver);
+                                },
+                            });
+                            listener.call(thisArgs, disguised);
+                        },
+                        undefined,
+                        disposables
+                    )
+                );
+
+                const suiteId = "PackageTests.PassingXCTestSuite";
+                const testId = `${suiteId}/testPassing`;
+
+                // The debug session should resolve even though the terminated session's
+                // name does not match, but the session ID does.
+                const testRun = await runTest(testExplorer, TestKind.debug, testId);
+                assertTestResults(testRun, {
+                    passed: [suiteId, testId],
+                });
+                assert.strictEqual(folderContext.hasActiveTestRun(), false);
             });
         });
     });

--- a/test/unit-tests/debugger/logTracker.test.ts
+++ b/test/unit-tests/debugger/logTracker.test.ts
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+
+import { LoggingDebugAdapterTracker } from "@src/debugger/logTracker";
+import { SwiftLogger } from "@src/logging/SwiftLogger";
+
+import { MockedObject, instance, mockFn, mockObject } from "../../MockUtils";
+
+suite("LoggingDebugAdapterTracker Unit Test Suite", () => {
+    let logger: MockedObject<SwiftLogger>;
+    let session: vscode.DebugSession;
+
+    setup(() => {
+        logger = mockObject<SwiftLogger>({ error: mockFn() });
+        session = { id: "session-1" } as vscode.DebugSession;
+    });
+
+    function exitedEvent(exitCode: number | undefined) {
+        return {
+            seq: 0,
+            type: "event",
+            event: "exited",
+            body: { exitCode },
+        };
+    }
+
+    test("Forwards a non-zero exit code to the exit handler", () => {
+        const tracker = new LoggingDebugAdapterTracker(session.id);
+        const exitHandler = sinon.stub();
+        LoggingDebugAdapterTracker.setDebugSessionCallback(
+            session,
+            instance(logger),
+            sinon.stub(),
+            exitHandler
+        );
+
+        tracker.onDidSendMessage(exitedEvent(9));
+
+        expect(exitHandler).to.have.been.calledOnceWithExactly(9);
+    });
+
+    test("Forwards a zero exit code to the exit handler", () => {
+        const tracker = new LoggingDebugAdapterTracker(session.id);
+        const exitHandler = sinon.stub();
+        LoggingDebugAdapterTracker.setDebugSessionCallback(
+            session,
+            instance(logger),
+            sinon.stub(),
+            exitHandler
+        );
+
+        tracker.onDidSendMessage(exitedEvent(0));
+
+        expect(exitHandler).to.have.been.calledOnceWithExactly(0);
+    });
+
+    test("Replays a buffered zero exit code when the callback is set after exit", () => {
+        const tracker = new LoggingDebugAdapterTracker(session.id);
+        // Exit arrives before the callback has been registered.
+        tracker.onDidSendMessage(exitedEvent(0));
+
+        const exitHandler = sinon.stub();
+        LoggingDebugAdapterTracker.setDebugSessionCallback(
+            session,
+            instance(logger),
+            sinon.stub(),
+            exitHandler
+        );
+
+        expect(exitHandler).to.have.been.calledOnceWithExactly(0);
+    });
+
+    test("Does not forward an exit when no exit code is present", () => {
+        const tracker = new LoggingDebugAdapterTracker(session.id);
+        const exitHandler = sinon.stub();
+        LoggingDebugAdapterTracker.setDebugSessionCallback(
+            session,
+            instance(logger),
+            sinon.stub(),
+            exitHandler
+        );
+
+        tracker.onDidSendMessage(exitedEvent(undefined));
+
+        expect(exitHandler).to.not.have.been.called;
+    });
+});

--- a/test/unit-tests/testexplorer/TestRunner.test.ts
+++ b/test/unit-tests/testexplorer/TestRunner.test.ts
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { expect } from "chai";
+import * as vscode from "vscode";
+
+import { debugSessionMatchesConfig } from "@src/TestExplorer/TestRunner";
+
+suite("TestRunner Unit Test Suite", () => {
+    suite("debugSessionMatchesConfig()", () => {
+        const config = {
+            type: "swift",
+            request: "launch",
+            name: "Swift Testing: Test MyPackage",
+        } as vscode.DebugConfiguration;
+
+        test("Matches when the session name equals the config name", () => {
+            expect(
+                debugSessionMatchesConfig(config, undefined, {
+                    id: "session-1",
+                    name: "Swift Testing: Test MyPackage",
+                })
+            ).to.be.true;
+        });
+
+        test("Does not match when neither the id nor the name match", () => {
+            expect(
+                debugSessionMatchesConfig(config, "session-1", {
+                    id: "session-2",
+                    name: "Some Other Session",
+                })
+            ).to.be.false;
+        });
+
+        test("Matches on the started session id even when the name differs", () => {
+            expect(
+                debugSessionMatchesConfig(config, "session-1", {
+                    id: "session-1",
+                    name: "lldb-dap",
+                })
+            ).to.be.true;
+        });
+
+        test("Falls back to the name when no started session id is known", () => {
+            expect(
+                debugSessionMatchesConfig(config, undefined, {
+                    id: "session-1",
+                    name: "Swift Testing: Test MyPackage",
+                })
+            ).to.be.true;
+        });
+    });
+});


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing to the VS Code extension for Swift! Please ensure you follow the
contributing guidelines for any contributions -->

<!-- Note for any contribution that is more than a bug fix, please open an issue first or discuss
it on the forums or on Slack. This ensures that you don't waste any time working on contributions that
won't get accepted! -->

## Description
- Match the terminated debug session by id, not just name which VSCode sometimes changes
- Make sure we always resolve the debug session and close the output parser on process exit and cancellation
- Add some integration and unit tests to watch for regressions

Issue: #2300
## Tasks
- [X] Required tests have been written
- ~[ ] Documentation has been updated~
- [x] Added an entry to CHANGELOG.md if applicable
