### PR TITLE
Make symbol links clickable in documentation preview

### DIFF
--- a/src/ContextKeyManager.ts
+++ b/src/ContextKeyManager.ts
@@ -16,7 +16,11 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "./FolderContext";
 import { SourceKitLanguageClient } from "./sourcekit-lsp/client/SourceKitLanguageClient";
-import { DocCDocumentationRequest, ReIndexProjectRequest } from "./sourcekit-lsp/extensions";
+import {
+    DocCDocumentationRequest,
+    DocCSymbolLinkDefinitionRequest,
+    ReIndexProjectRequest,
+} from "./sourcekit-lsp/extensions";
 import { Version } from "./utilities/version";
 
 /**
@@ -89,6 +93,11 @@ export interface ContextKeys {
     supportsDocumentationLivePreview: boolean;
 
     /**
+     * Whether the SourceKit-LSP server supports resolving DocC symbol links to their definition.
+     */
+    supportsSymbolLinkDefinition: boolean;
+
+    /**
      * Whether the installed version of Swiftly can be used to install toolchains from within VS Code.
      */
     supportsSwiftlyInstall: boolean;
@@ -139,6 +148,7 @@ export class ContextKeyManager implements ContextKeys {
     private _createNewProjectAvailable = false;
     private _supportsReindexing = false;
     private _supportsDocumentationLivePreview = false;
+    private _supportsSymbolLinkDefinition = false;
     private _supportsSwiftlyInstall = false;
     private _switchPlatformAvailable = false;
 
@@ -246,6 +256,18 @@ export class ContextKeyManager implements ContextKeys {
         );
     }
 
+    get supportsSymbolLinkDefinition(): boolean {
+        return this._supportsSymbolLinkDefinition;
+    }
+    set supportsSymbolLinkDefinition(value: boolean) {
+        this._supportsSymbolLinkDefinition = value;
+        void vscode.commands.executeCommand(
+            "setContext",
+            "swift.supportsSymbolLinkDefinition",
+            value
+        );
+    }
+
     get supportsSwiftlyInstall(): boolean {
         return this._supportsSwiftlyInstall;
     }
@@ -310,6 +332,10 @@ export class ContextKeyManager implements ContextKeys {
                 );
                 this.supportsDocumentationLivePreview = client.checkExperimentalCapability(
                     DocCDocumentationRequest.method,
+                    1
+                );
+                this.supportsSymbolLinkDefinition = client.checkExperimentalCapability(
+                    DocCSymbolLinkDefinitionRequest.method,
                     1
                 );
             });

--- a/src/ContextKeyManager.ts
+++ b/src/ContextKeyManager.ts
@@ -16,11 +16,7 @@ import * as vscode from "vscode";
 
 import { FolderContext } from "./FolderContext";
 import { SourceKitLanguageClient } from "./sourcekit-lsp/client/SourceKitLanguageClient";
-import {
-    DocCDocumentationRequest,
-    DocCSymbolLinkDefinitionRequest,
-    ReIndexProjectRequest,
-} from "./sourcekit-lsp/extensions";
+import { DocCDocumentationRequest, ReIndexProjectRequest } from "./sourcekit-lsp/extensions";
 import { Version } from "./utilities/version";
 
 /**
@@ -93,11 +89,6 @@ export interface ContextKeys {
     supportsDocumentationLivePreview: boolean;
 
     /**
-     * Whether the SourceKit-LSP server supports resolving DocC symbol links to their definition.
-     */
-    supportsSymbolLinkDefinition: boolean;
-
-    /**
      * Whether the installed version of Swiftly can be used to install toolchains from within VS Code.
      */
     supportsSwiftlyInstall: boolean;
@@ -148,7 +139,6 @@ export class ContextKeyManager implements ContextKeys {
     private _createNewProjectAvailable = false;
     private _supportsReindexing = false;
     private _supportsDocumentationLivePreview = false;
-    private _supportsSymbolLinkDefinition = false;
     private _supportsSwiftlyInstall = false;
     private _switchPlatformAvailable = false;
 
@@ -256,18 +246,6 @@ export class ContextKeyManager implements ContextKeys {
         );
     }
 
-    get supportsSymbolLinkDefinition(): boolean {
-        return this._supportsSymbolLinkDefinition;
-    }
-    set supportsSymbolLinkDefinition(value: boolean) {
-        this._supportsSymbolLinkDefinition = value;
-        void vscode.commands.executeCommand(
-            "setContext",
-            "swift.supportsSymbolLinkDefinition",
-            value
-        );
-    }
-
     get supportsSwiftlyInstall(): boolean {
         return this._supportsSwiftlyInstall;
     }
@@ -332,10 +310,6 @@ export class ContextKeyManager implements ContextKeys {
                 );
                 this.supportsDocumentationLivePreview = client.checkExperimentalCapability(
                     DocCDocumentationRequest.method,
-                    1
-                );
-                this.supportsSymbolLinkDefinition = client.checkExperimentalCapability(
-                    DocCSymbolLinkDefinitionRequest.method,
                     1
                 );
             });

--- a/src/documentation/DocumentationPreviewEditor.ts
+++ b/src/documentation/DocumentationPreviewEditor.ts
@@ -18,6 +18,7 @@ import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 
 import { WorkspaceContext } from "../WorkspaceContext";
 import { DocCDocumentationRequest } from "../sourcekit-lsp/extensions";
+import { DocCSymbolLinkDefinitionRequest } from "../sourcekit-lsp/extensions";
 import { Disposable } from "../utilities/Disposable";
 import { RenderNode, WebviewContent, WebviewMessage } from "./webview/WebviewMessage";
 
@@ -163,6 +164,68 @@ export class DocumentationPreviewEditor implements Disposable {
             case "rendered":
                 this.renderEmitter.fire();
                 break;
+            case "symbolLinkClicked":
+                void this.resolveSymbolLink(message.data);
+                break;
+        }
+    }
+
+    private async resolveSymbolLink(href: string): Promise<void> {
+        if (!this.activeTextEditor) {
+            this.context.logger.debug(`resolveSymbolLink: no active text editor for href=${href}`);
+            return;
+        }
+        const document = this.activeTextEditor.document;
+        const folderContext = this.context.folders.find(folderContext =>
+            document.uri.fsPath.startsWith(folderContext.folder.fsPath)
+        );
+        if (!folderContext) {
+            this.context.logger.debug(
+                `resolveSymbolLink: no folderContext for ${document.uri.fsPath}`
+            );
+            return;
+        }
+
+        const symbolLink = href.startsWith("/") ? href.slice(1) : href;
+        this.context.logger.debug(
+            `resolveSymbolLink: resolving "${symbolLink}" from ${document.uri.toString()}`
+        );
+
+        try {
+            const client = this.context.languageClientManager.getClient(folderContext);
+            this.context.logger.debug(`resolveSymbolLink: got client, sending request`);
+            const location = await client.useLanguageClient(async client => {
+                const result = await client.sendRequest(DocCSymbolLinkDefinitionRequest.type, {
+                    symbolLink,
+                    textDocument: { uri: document.uri.toString() },
+                });
+                this.context.logger.debug(
+                    `resolveSymbolLink: request returned ${JSON.stringify(result)}`
+                );
+                return result ? client.protocol2CodeConverter.asDefinitionResult(result) : null;
+            });
+            if (location) {
+                const first = Array.isArray(location) ? location[0] : location;
+                const targetUri = "uri" in first ? first.uri : first.targetUri;
+                const targetRange = "range" in first ? first.range : first.targetSelectionRange;
+
+                this.context.logger.debug(`resolveSymbolLink: navigating to ${targetUri}`);
+                const targetDoc = await vscode.workspace.openTextDocument(targetUri);
+                await vscode.window.showTextDocument(targetDoc, {
+                    selection: targetRange,
+                    viewColumn: vscode.ViewColumn.One,
+                });
+            } else {
+                this.context.logger.debug(
+                    `resolveSymbolLink: server returned null/no location for "${symbolLink}"`
+                );
+                void vscode.window.showErrorMessage(
+                    `Symbol link could not be resolved: ${symbolLink}`
+                );
+            }
+        } catch (error) {
+            this.context.logger.error(`Failed to resolve symbol link "${symbolLink}": ${error}`);
+            void vscode.window.showErrorMessage(`Symbol not found: ${symbolLink}`);
         }
     }
 

--- a/src/documentation/DocumentationPreviewEditor.ts
+++ b/src/documentation/DocumentationPreviewEditor.ts
@@ -165,14 +165,14 @@ export class DocumentationPreviewEditor implements Disposable {
                 this.renderEmitter.fire();
                 break;
             case "symbolLinkClicked":
-                void this.resolveSymbolLink(message.data);
+                void this.resolveSymbolLink(message.link);
                 break;
         }
     }
 
     private async resolveSymbolLink(href: string): Promise<void> {
         if (!this.activeTextEditor) {
-            this.context.logger.debug(`resolveSymbolLink: no active text editor for href=${href}`);
+            this.context.logger.debug(`No active text editor for href=${href}`);
             return;
         }
         const document = this.activeTextEditor.document;
@@ -180,51 +180,48 @@ export class DocumentationPreviewEditor implements Disposable {
             document.uri.fsPath.startsWith(folderContext.folder.fsPath)
         );
         if (!folderContext) {
-            this.context.logger.debug(
-                `resolveSymbolLink: no folderContext for ${document.uri.fsPath}`
-            );
+            this.context.logger.debug(`No folderContext for ${document.uri.fsPath}`);
             return;
         }
 
         const symbolLink = href.startsWith("/") ? href.slice(1) : href;
-        this.context.logger.debug(
-            `resolveSymbolLink: resolving "${symbolLink}" from ${document.uri.toString()}`
-        );
+        this.context.logger.debug(`Resolving "${symbolLink}" from ${document.uri.toString()}`);
 
         try {
             const client = this.context.languageClientManager.getClient(folderContext);
-            this.context.logger.debug(`resolveSymbolLink: got client, sending request`);
             const location = await client.useLanguageClient(async client => {
+                if (
+                    !client.checkExperimentalCapability(DocCSymbolLinkDefinitionRequest.method, 1)
+                ) {
+                    this.context.logger.debug(
+                        `SourceKit-LSP does not support ${DocCSymbolLinkDefinitionRequest.method}`
+                    );
+                    return null;
+                }
                 const result = await client.sendRequest(DocCSymbolLinkDefinitionRequest.type, {
                     symbolLink,
                     textDocument: { uri: document.uri.toString() },
                 });
-                this.context.logger.debug(
-                    `resolveSymbolLink: request returned ${JSON.stringify(result)}`
-                );
                 return result ? client.protocol2CodeConverter.asDefinitionResult(result) : null;
             });
             if (location) {
                 const first = Array.isArray(location) ? location[0] : location;
                 const targetUri = "uri" in first ? first.uri : first.targetUri;
                 const targetRange = "range" in first ? first.range : first.targetSelectionRange;
-
-                this.context.logger.debug(`resolveSymbolLink: navigating to ${targetUri}`);
                 const targetDoc = await vscode.workspace.openTextDocument(targetUri);
                 await vscode.window.showTextDocument(targetDoc, {
                     selection: targetRange,
                     viewColumn: vscode.ViewColumn.One,
                 });
             } else {
-                this.context.logger.debug(
-                    `resolveSymbolLink: server returned null/no location for "${symbolLink}"`
-                );
                 void vscode.window.showErrorMessage(
                     `Symbol link could not be resolved: ${symbolLink}`
                 );
             }
         } catch (error) {
-            this.context.logger.error(`Failed to resolve symbol link "${symbolLink}": ${error}`);
+            this.context.logger.error(
+                Error(`Failed to resolve symbol link "${symbolLink}"`, { cause: error })
+            );
             void vscode.window.showErrorMessage(`Symbol not found: ${symbolLink}`);
         }
     }

--- a/src/documentation/webview/WebviewMessage.ts
+++ b/src/documentation/webview/WebviewMessage.ts
@@ -15,7 +15,11 @@
 /**
  * Represents a message that can be sent between the webview and vscode-swift
  */
-export type WebviewMessage = LoadedMessage | RenderedMessage | UpdateContentMessage;
+export type WebviewMessage =
+    | LoadedMessage
+    | RenderedMessage
+    | UpdateContentMessage
+    | SymbolLinkClickedMessage;
 
 /**
  * Sent from the webview to the extension to indicate that the webview has loaded
@@ -31,6 +35,15 @@ export interface LoadedMessage {
  */
 export interface RenderedMessage {
     type: "rendered";
+}
+
+/**
+ * Sent from the webview to the extension when the user clicks a DocC symbol link,
+ * so the extension can resolve it via SourceKit-LSP and navigate to its definition.
+ */
+export interface SymbolLinkClickedMessage {
+    type: "symbolLinkClicked";
+    data: string;
 }
 
 /**

--- a/src/documentation/webview/WebviewMessage.ts
+++ b/src/documentation/webview/WebviewMessage.ts
@@ -43,7 +43,7 @@ export interface RenderedMessage {
  */
 export interface SymbolLinkClickedMessage {
     type: "symbolLinkClicked";
-    data: string;
+    link: string;
 }
 
 /**

--- a/src/documentation/webview/webview.ts
+++ b/src/documentation/webview/webview.ts
@@ -25,13 +25,6 @@ const themeObserver = new ThemeObserver();
 themeObserver.updateTheme();
 themeObserver.start();
 
-// Disable clicking on links as they do not work
-const disableLinks = document.createElement("style");
-disableLinks.textContent = `a {
-    pointer-events: none;
-}`;
-document.head.appendChild(disableLinks);
-
 // Set up the communication bridges to VS Code and swift-docc-render
 createCommunicationBridge().then(async bridge => {
     const vscode = acquireVsCodeApi();
@@ -54,6 +47,24 @@ createCommunicationBridge().then(async bridge => {
             }
         }
     });
+
+    document.addEventListener(
+        "click",
+        event => {
+            const anchor = (event.target as HTMLElement)?.closest(
+                "a[href]"
+            ) as HTMLAnchorElement | null;
+            if (!anchor) {
+                return;
+            }
+            event.preventDefault();
+            const href = anchor.getAttribute("href");
+            if (href) {
+                vscode.postMessage({ type: "symbolLinkClicked", data: href });
+            }
+        },
+        { capture: true }
+    );
 
     // Handle messages coming from vscode-swift
     // eslint-disable-next-line sonarjs/post-message

--- a/src/documentation/webview/webview.ts
+++ b/src/documentation/webview/webview.ts
@@ -60,7 +60,7 @@ createCommunicationBridge().then(async bridge => {
             event.preventDefault();
             const href = anchor.getAttribute("href");
             if (href) {
-                vscode.postMessage({ type: "symbolLinkClicked", data: href });
+                vscode.postMessage({ type: "symbolLinkClicked", link: href });
             }
         },
         { capture: true }

--- a/src/sourcekit-lsp/extensions/DocCSymbolLinkDefinitionRequest.ts
+++ b/src/sourcekit-lsp/extensions/DocCSymbolLinkDefinitionRequest.ts
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+// We use namespaces to store request information just like vscode-languageclient
+/* eslint-disable @typescript-eslint/no-namespace */
+import {
+    Definition,
+    DefinitionLink,
+    MessageDirection,
+    RequestType,
+    TextDocumentIdentifier,
+} from "vscode-languageclient";
+
+/** Parameters used to make a {@link DocCSymbolLinkDefinitionRequest}. */
+interface DocCSymbolLinkDefinitionParams {
+    /**
+     * The document the symbol link was clicked in, used to resolve the link relative to the correct workspace/index.
+     */
+    textDocument: TextDocumentIdentifier;
+
+    /**
+     * The DocC symbol link to resolve.
+     */
+    symbolLink: string;
+}
+
+/**
+ * The response from a {@link DocCSymbolLinkDefinitionRequest}. `null` if the symbol
+ * link could not be parsed or no matching definition was found in the index.
+ */
+
+export type LocationsOrLocationLinksResponse = Definition | DefinitionLink[] | null;
+
+// eslint-disable-next-line sonarjs/redundant-type-aliases
+export type DocCSymbolLinkDefinitionResponse = LocationsOrLocationLinksResponse;
+
+export namespace DocCSymbolLinkDefinitionRequest {
+    export const method = "sourcekit/textDocument/doccSymbolLinkDefinition" as const;
+    export const messageDirection: MessageDirection = MessageDirection.clientToServer;
+    export const type = new RequestType<
+        DocCSymbolLinkDefinitionParams,
+        DocCSymbolLinkDefinitionResponse,
+        never
+    >(method);
+}

--- a/src/sourcekit-lsp/extensions/index.ts
+++ b/src/sourcekit-lsp/extensions/index.ts
@@ -15,6 +15,7 @@
 // Definitions for non-standard requests used by sourcekit-lsp
 
 export * from "./DocCDocumentationRequest";
+export * from "./DocCSymbolLinkDefinitionRequest";
 export * from "./GetReferenceDocumentRequest";
 export * from "./GetTestsRequest";
 export * from "./LegacyInlayHintRequest";


### PR DESCRIPTION
## Description
- Makes symbol links in the Documentation Preview clickable.
- Extracts the symbol link from the `href` attribute of the clicked link.
- Resolves the symbol link's definition via `DocCSymbolLinkDefinitionRequest` and navigates to
  the definition location if it's found, otherwise shows an error message if the link can't be resolved.
  
### Dependency
This PR is dependent on https://github.com/swiftlang/sourcekit-lsp/pull/2748

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
