### PR TITLE
Fix duplicate `LanguageStatusItem` caused by `reloadWorkspaceContext`

### DIFF
--- a/src/InternalSwiftExtensionApi.ts
+++ b/src/InternalSwiftExtensionApi.ts
@@ -364,16 +364,21 @@ export class InternalSwiftExtensionApi implements SwiftExtensionApi {
         if (this.state.type === "uninitialized") {
             throw new Error("The Swift extension has not been activated yet.");
         }
-        if (this.state.type === "initializing") {
-            this.state.cancel();
-        }
+        const previousState = this.state;
+
         let disposePromise = Promise.resolve();
-        if (this.state.type === "active") {
-            this.state.subscriptions.forEach(s => s.dispose());
-            disposePromise = this.state.context.dispose();
+        if (previousState.type === "initializing") {
+            previousState.cancel();
+            disposePromise = previousState.promise.then(
+                () => {},
+                () => {}
+            );
+        } else if (previousState.type === "active") {
+            previousState.subscriptions.forEach(s => s.dispose());
+            disposePromise = previousState.context.dispose();
         }
         const cancellationSource = new vscode.CancellationTokenSource();
-        const activatedBy = this.state.activatedBy;
+        const activatedBy = previousState.activatedBy;
         this.state = {
             type: "initializing",
             activatedBy,


### PR DESCRIPTION
## Description
### Problem
If a configuration change (e.g. `swift.SDK`) fires while the extension is still activating, `reloadWorkspaceContext()` would cancel the in-flight `initializeWorkspace` call and immediately start a new one without waiting for the first to actually stop. Both ended up running in parallel and registering the same `LanguageStatusItem`, causing:

`LanguageStatusItem with id 'swiftlang version' already exists` error and a broken LSP.

### Fix 
Now when its `initializing`, instead of starting the new `InitializeWorkspace` immediately, we wait for the previous `initializeWorkspace` to fully finish (and clean up) before starting the next one.

### Testing 
Reproduced the issue with a custom LSP config that triggers a config-change reload during activation. After the fix, the duplicate `LanguageStatusItem` error no longer shows up and the LSP starts correctly.

## Tasks
- [ ] Required tests have been written
- [ ] Documentation has been updated
- [ ] Added an entry to CHANGELOG.md if applicable
