### PR TITLE
Parse remarks as well, just like notes, warnings and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Diagnostics with `remark` severity are now shown in the Problems pane ([#2338](https://github.com/swiftlang/vscode-swift/pull/2338))
 - Toolchain changes will now automatically reload the workspace ([#2196](https://github.com/swiftlang/vscode-swift/pull/2196))
 - Add a button that installs Swiftly and the latest Swift toolchain to the extension's welcome walkthrough ([#2078](https://github.com/swiftlang/vscode-swift/pull/2078))
 

--- a/src/DiagnosticsManager.ts
+++ b/src/DiagnosticsManager.ts
@@ -413,7 +413,7 @@ export class DiagnosticsManager implements Disposable {
         line: string
     ): ParsedDiagnostic | vscode.DiagnosticRelatedInformation | undefined {
         const diagnosticRegex =
-            /^(?:[`-\s]*)(.*?):(\d+)(?::(\d+))?:\s+(warning|error|note):\s+(.*)$/g;
+            /^(?:[`-\s]*)(.*?):(\d+)(?::(\d+))?:\s+(warning|error|note|remark):\s+(.*)$/g;
         const switfcExtraWarningsRegex = /\[(-W|#).*?\]/g;
         const match = diagnosticRegex.exec(line);
         if (!match) {
@@ -423,7 +423,7 @@ export class DiagnosticsManager implements Disposable {
         const message = this.capitalize(match[5]).replace(switfcExtraWarningsRegex, "").trim();
         const range = this.range(match[2], match[3]);
         const severity = this.severity(match[4]);
-        if (severity === vscode.DiagnosticSeverity.Information) {
+        if (match[4] === "note") {
             return new vscode.DiagnosticRelatedInformation(
                 new vscode.Location(vscode.Uri.file(uri), range),
                 message
@@ -449,6 +449,9 @@ export class DiagnosticsManager implements Disposable {
                 severity = vscode.DiagnosticSeverity.Warning;
                 break;
             case "note":
+                severity = vscode.DiagnosticSeverity.Information;
+                break;
+            case "remark":
                 severity = vscode.DiagnosticSeverity.Information;
                 break;
             default:

--- a/test/integration-tests/DiagnosticsManager.test.ts
+++ b/test/integration-tests/DiagnosticsManager.test.ts
@@ -366,6 +366,12 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 vscode.DiagnosticSeverity.Error
             );
             outputDiagnostic.source = "swiftc";
+            const outputRemark = new vscode.Diagnostic(
+                new vscode.Range(new vscode.Position(12, 4), new vscode.Position(12, 4)),
+                "Import of 'A' and 'B' triggered a cross-import of 'AB'",
+                vscode.DiagnosticSeverity.Information
+            );
+            outputRemark.source = "swiftc";
             let workspaceFolder: vscode.WorkspaceFolder;
 
             setup(async () => {
@@ -403,6 +409,20 @@ tag("medium").suite("DiagnosticsManager Test Suite", function () {
                 await waitForDiagnostics({ [mainUri.fsPath]: [outputDiagnostic] });
                 // Should only include one
                 expect(vscode.languages.getDiagnostics(mainUri)).to.have.length(1);
+            });
+
+            test("Parse remarks", async () => {
+                const fixture = testSwiftTask("swift", ["build"], workspaceFolder, toolchain);
+                const startPromise = waitForStartTaskProcess(fixture.task);
+                await vscode.tasks.executeTask(fixture.task);
+                await startPromise;
+                // Wait to spawn before writing
+                fixture.process.write(
+                    `${mainUri.fsPath}:13:5: remark: import of 'A' and 'B' triggered a cross-import of 'AB'`
+                );
+                fixture.process.close(0);
+                await waitForNoRunningTasks();
+                await waitForDiagnostics({ [mainUri.fsPath]: [outputRemark] });
             });
 
             test("New set of swiftc diagnostics clear old list", async () => {


### PR DESCRIPTION
## Description

`swiftc` can emit "warning"s, "error"s, "note"s. It also can emit "remark"s.
Let's make sure the extension doesn't exclude remarks.

## Showcase

The blue ones are the remarks.

<kbd> <img width="3200" height="1636" alt="Screenshot 2026-08-22 at 4 53 49 PM" src="https://github.com/user-attachments/assets/2fb79982-53e4-418d-a1f5-9d30c5a82d6a" /> </kbd>

## Build Log Sample

```bash
swiftly run swift build --build-tests -c release --no-color-diagnostics > build-log-w-remarks-sample.txt 2>&1
```
Result: [build-log-w-remarks-sample.txt](https://github.com/user-attachments/files/31333689/build-log-w-remarks-sample.txt)

## Tasks
- [x] Required tests have been written
- [x] Documentation has been updated
- [x] Added an entry to CHANGELOG.md if applicable
