### PR TITLE
Move SourceKit-LSP configuration settings under swift.sourcekit-lsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -917,13 +917,17 @@
           },
           "swift.lspConfigurationBranch": {
             "type": "string",
-            "markdownDescription": "Set the branch to use when setting the `$schema` property of the SourceKit-LSP configuration. For example: \"release/6.1\" or \"main\". When this setting is unset, the extension will determine the branch based on the version of the toolchain that is in use."
+            "markdownDescription": "Set the branch to use when setting the `$schema` property of the SourceKit-LSP configuration. For example: \"release/6.1\" or \"main\". When this setting is unset, the extension will determine the branch based on the version of the toolchain that is in use.",
+            "deprecationMessage": "Deprecated: Please use \"swift.sourcekit-lsp.configurationBranch\" instead.",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.configurationBranch#` instead."
           },
           "swift.checkLspConfigurationSchema": {
             "type": "boolean",
             "default": true,
-            "markdownDescription": "When opening a .sourckit-lsp/config.json configuration file, whether or not to check if the $schema matches the version of Swift you are using.",
-            "scope": "machine-overridable"
+            "markdownDescription": "When opening a .sourcekit-lsp/config.json configuration file, whether or not to check if the $schema matches the version of Swift you are using.",
+            "scope": "machine-overridable",
+            "deprecationMessage": "Deprecated: Please use \"swift.sourcekit-lsp.checkConfigurationSchema\" instead.",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#swift.sourcekit-lsp.checkConfigurationSchema#` instead."
           }
         }
       },
@@ -1015,6 +1019,18 @@
             ],
             "markdownDescription": "Controls whether the symbol declaration is included in the results of `Find All References`.",
             "order": 7,
+            "scope": "machine-overridable"
+          },
+          "swift.sourcekit-lsp.configurationBranch": {
+            "type": "string",
+            "markdownDescription": "Set the branch to use when setting the `$schema` property of the SourceKit-LSP configuration. For example: \"release/6.1\" or \"main\". When this setting is unset, the extension will determine the branch based on the version of the toolchain that is in use.",
+            "order": 8
+          },
+          "swift.sourcekit-lsp.checkConfigurationSchema": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "When opening a .sourcekit-lsp/config.json configuration file, whether or not to check if the $schema matches the version of Swift you are using.",
+            "order": 9,
             "scope": "machine-overridable"
           },
           "sourcekit-lsp.support-c-cpp": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -724,23 +724,43 @@ const configuration = {
             .get<Record<string, boolean>>("excludePathsFromActivation", {});
     },
     get lspConfigurationBranch(): string {
-        return validateStringSetting(
-            vscode.workspace.getConfiguration("swift").get<string>("lspConfigurationBranch", ""),
-            "swift.lspConfigurationBranch"
+        const branch = getExplicitSetting<string>(
+            vscode.workspace.getConfiguration("swift.sourcekit-lsp"),
+            "configurationBranch"
         );
+        if (branch !== undefined) {
+            return validateStringSetting(branch, "swift.sourcekit-lsp.configurationBranch");
+        }
+        const deprecatedBranch = getExplicitSetting<string>(
+            vscode.workspace.getConfiguration("swift"),
+            "lspConfigurationBranch"
+        );
+        if (deprecatedBranch !== undefined) {
+            return validateStringSetting(deprecatedBranch, "swift.lspConfigurationBranch");
+        }
+        return "";
     },
     get checkLspConfigurationSchema(): boolean {
-        return validateBooleanSetting(
-            vscode.workspace
-                .getConfiguration("swift")
-                .get<boolean>("checkLspConfigurationSchema", true),
-            "swift.checkLspConfigurationSchema"
+        const check = getExplicitSetting<boolean>(
+            vscode.workspace.getConfiguration("swift.sourcekit-lsp"),
+            "checkConfigurationSchema"
         );
+        if (check !== undefined) {
+            return validateBooleanSetting(check, "swift.sourcekit-lsp.checkConfigurationSchema");
+        }
+        const deprecatedCheck = getExplicitSetting<boolean>(
+            vscode.workspace.getConfiguration("swift"),
+            "checkLspConfigurationSchema"
+        );
+        if (deprecatedCheck !== undefined) {
+            return validateBooleanSetting(deprecatedCheck, "swift.checkLspConfigurationSchema");
+        }
+        return true;
     },
     set checkLspConfigurationSchema(value: boolean) {
         void vscode.workspace
-            .getConfiguration("swift")
-            .update("checkLspConfigurationSchema", value)
+            .getConfiguration("swift.sourcekit-lsp")
+            .update("checkConfigurationSchema", value)
             .then(() => {
                 /* Put in worker queue */
             });

--- a/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
+++ b/test/integration-tests/commands/generateSourcekitConfiguration.test.ts
@@ -93,6 +93,19 @@ suite("Generate SourceKit-LSP configuration Command", function () {
 
     test("Uses hardcoded path", async () => {
         resetSettings = await updateSettings({
+            "swift.sourcekit-lsp.configurationBranch": "release/6.1",
+        });
+        const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
+        expect(result).to.be.true;
+        const config = await getSchema();
+        expect(config).to.have.property(
+            "$schema",
+            `https://raw.githubusercontent.com/swiftlang/sourcekit-lsp/refs/heads/release/6.1/config.schema.json`
+        );
+    });
+
+    test("Uses hardcoded path from the deprecated setting", async () => {
+        resetSettings = await updateSettings({
             "swift.lspConfigurationBranch": "release/6.1",
         });
         const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
@@ -106,7 +119,7 @@ suite("Generate SourceKit-LSP configuration Command", function () {
 
     test('Fallsback to "main" when path does not exist', async () => {
         resetSettings = await updateSettings({
-            "swift.lspConfigurationBranch": "totally-invalid-branch",
+            "swift.sourcekit-lsp.configurationBranch": "totally-invalid-branch",
         });
         const result = await vscode.commands.executeCommand(Commands.GENERATE_SOURCEKIT_CONFIG);
         expect(result).to.be.true;


### PR DESCRIPTION
The docs for the Generate SourceKit-LSP Configuration command point people at a `swift.sourcekit-lsp.configurationBranch` setting, but that setting doesn't exist. It isn't in the configuration contributed by package.json and it doesn't show up anywhere in src. The setting that actually pins the schema branch is `swift.lspConfigurationBranch`, which is what generateSourcekitConfiguration.ts reads. I also fixed a small typo in the description for `swift.checkLspConfigurationSchema` where sourcekit was spelled sourckit. That string shows up in the Settings UI.