### PR TITLE
Only list parameterized arguments that are worth showing

### DIFF
--- a/src/TestExplorer/TestParsers/ParameterizedArgumentRows.ts
+++ b/src/TestExplorer/TestParsers/ParameterizedArgumentRows.ts
@@ -1,0 +1,278 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the VS Code Swift open source project
+//
+// Copyright (c) 2026 the VS Code Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of VS Code Swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import { TestClass } from "../TestDiscovery";
+import { ITestRunState } from "./TestRunState";
+
+/**
+ * How many argument rows a run will list up front, in a pending state, across all of its
+ * parameterized tests.
+ */
+export const MAX_PARAMETERIZED_PENDING_ROWS = 1000;
+
+/**
+ * How many failing argument rows a run will list for the parameterized tests it held back. Kept
+ * separate from the pending budget so a run that spends that one up front can still show why a
+ * later test failed.
+ */
+export const MAX_PARAMETERIZED_FAILURE_ROWS = 1000;
+
+const PASSED_SUMMARY_ID = "swift.passedTestCases";
+
+/**
+ * The part of the test run that argument rows are written to. `TestRunProxy` satisfies this type.
+ */
+export type ParameterizedTestCaseSink = {
+    clearParameterizedTestCases(parentIndex: number): void;
+    /** Adds one argument row, returning its test item index, or undefined if the parent is gone. */
+    addParameterizedTestCase(testClass: TestClass, parentIndex: number): number | undefined;
+};
+
+/** An argument of a parameterized test, as named in the test run's events. */
+type Argument = {
+    id: string;
+    label: string;
+};
+
+type ParameterizedFunction = {
+    parentIndex: number;
+    /** Whether the function's arguments were too numerous to list up front. */
+    heldBack: boolean;
+    /** Argument id to the index of the test item listed for it. */
+    rows: Map<string, number>;
+    /** When each argument started, so a held back row can be given a duration once listed. */
+    startInstants: Map<string, number>;
+    failed: Set<string>;
+    passed: number;
+};
+
+const argumentSortText = (index: number) => `${index}`.padStart(8, "0");
+
+/** Sorts after every `argumentSortText`, putting the summary below the arguments. */
+const SUMMARY_SORT_TEXT = "99999999";
+
+function argumentTestClass(id: string, label: string, sortText: string): TestClass {
+    return {
+        id,
+        label,
+        tags: [],
+        children: [],
+        style: "swift-testing",
+        location: undefined,
+        disabled: true,
+        sortText,
+    };
+}
+
+/**
+ * Decides which of a run's parameterized test arguments should be shown in the Test
+ * Explorer.
+ *
+ * Every listed row costs the UI a state update as it starts and another as it ends, so a
+ * cross-product test with tens of thousands of arguments stalls the Test Explorer. A run gets a
+ * budget of rows to list up front; a test that no longer fits is held back, and only its failures
+ * earn a row, with its passes collapsed into a single summary row when the test function ends.
+ */
+export class ParameterizedArgumentRows {
+    private functions = new Map<string, ParameterizedFunction>();
+    private pendingRows = 0;
+    private failureRows = 0;
+    private failureBudgetNoticeSent = false;
+
+    constructor(private sink: ParameterizedTestCaseSink) {}
+
+    /**
+     * Takes over a parameterized test function, discarding any rows a previous run left under it
+     * and listing its arguments up front if the run can still afford them.
+     *
+     * @param argumentCount How many arguments the function has, which is all the budget needs.
+     * @param listArguments The arguments, only called when they are going to be listed — a held
+     *   back function can have tens of thousands, and naming them all up front is wasted work.
+     */
+    public begin(
+        functionName: string,
+        parentIndex: number,
+        argumentCount: number,
+        listArguments: () => Argument[]
+    ) {
+        this.sink.clearParameterizedTestCases(parentIndex);
+
+        const fn: ParameterizedFunction = {
+            parentIndex,
+            heldBack: this.pendingRows + argumentCount > MAX_PARAMETERIZED_PENDING_ROWS,
+            rows: new Map(),
+            startInstants: new Map(),
+            failed: new Set(),
+            passed: 0,
+        };
+        this.functions.set(functionName, fn);
+        if (fn.heldBack) {
+            return;
+        }
+
+        listArguments().forEach((argument, index) =>
+            this.list(fn, argument, argumentSortText(index))
+        );
+        this.pendingRows += fn.rows.size;
+    }
+
+    /**
+     * Records that an argument started.
+     * @param resolveIndex Resolves the index of an argument this doesn't own a row for.
+     * @returns The index to start, or undefined when the run deliberately has no row for it.
+     */
+    public noteStarted(
+        functionName: string,
+        argumentId: string,
+        instant: number,
+        resolveIndex: () => number
+    ): number | undefined {
+        const fn = this.functions.get(functionName);
+        if (!fn) {
+            return resolveIndex();
+        }
+
+        if (fn.heldBack) {
+            fn.startInstants.set(argumentId, instant);
+            return undefined;
+        }
+        return fn.rows.get(argumentId) ?? resolveIndex();
+    }
+
+    /**
+     * Records that an argument produced an issue, listing a row for it if it was held back and the
+     * run can still afford one.
+     * @returns The row the issue belongs to, or undefined when it belongs on the test function.
+     */
+    public noteIssue(
+        functionName: string,
+        argument: Argument,
+        instant: number,
+        runState: ITestRunState
+    ): number | undefined {
+        const fn = this.functions.get(functionName);
+        if (!fn) {
+            return undefined;
+        }
+
+        // Warnings arrive here as issues too; an argument with either is worth a row of its own.
+        fn.failed.add(argument.id);
+
+        const listed = fn.rows.get(argument.id);
+        if (listed !== undefined || !fn.heldBack) {
+            return listed;
+        }
+
+        if (this.failureRows >= MAX_PARAMETERIZED_FAILURE_ROWS) {
+            this.reportFailureBudgetExhausted(runState);
+            return fn.parentIndex;
+        }
+
+        const row = this.list(fn, argument, argumentSortText(fn.rows.size));
+        if (row === undefined) {
+            return undefined;
+        }
+        this.failureRows += 1;
+
+        // A held back row is listed after its `testCaseStarted`, and completing with a timestamp
+        // is an error unless the row was started with one.
+        runState.started(row, fn.startInstants.get(argument.id) ?? instant);
+        return row;
+    }
+
+    /**
+     * Records that an argument finished.
+     * @param resolveIndex Resolves the index of an argument this doesn't own a row for.
+     * @returns The index to complete, or undefined when the run deliberately has no row for it.
+     */
+    public noteEnded(
+        functionName: string,
+        argumentId: string,
+        resolveIndex: () => number
+    ): number | undefined {
+        const fn = this.functions.get(functionName);
+        if (!fn) {
+            return resolveIndex();
+        }
+
+        fn.startInstants.delete(argumentId);
+        const failed = fn.failed.delete(argumentId);
+
+        const row = fn.rows.get(argumentId);
+        if (row !== undefined) {
+            return row;
+        }
+        if (!fn.heldBack) {
+            return resolveIndex();
+        }
+
+        // A held back pass only ever reaches the UI through the summary row this tallies towards;
+        // its failures already have a row.
+        if (!failed) {
+            fn.passed += 1;
+        }
+        return undefined;
+    }
+
+    /** Releases a test function, listing the single row standing in for its passing arguments. */
+    public finish(functionName: string, instant: number, runState: ITestRunState) {
+        const fn = this.functions.get(functionName);
+        this.functions.delete(functionName);
+        if (!fn?.passed) {
+            return;
+        }
+
+        const row = this.sink.addParameterizedTestCase(
+            argumentTestClass(
+                `${functionName}/${PASSED_SUMMARY_ID}`,
+                `${fn.passed.toLocaleString()} test case${fn.passed === 1 ? "" : "s"} passed`,
+                SUMMARY_SORT_TEXT
+            ),
+            fn.parentIndex
+        );
+        if (row === undefined) {
+            return;
+        }
+
+        runState.started(row, instant);
+        runState.completed(row, { timestamp: instant });
+    }
+
+    private list(
+        fn: ParameterizedFunction,
+        argument: Argument,
+        sortText: string
+    ): number | undefined {
+        const row = this.sink.addParameterizedTestCase(
+            argumentTestClass(argument.id, argument.label, sortText),
+            fn.parentIndex
+        );
+        if (row === undefined) {
+            return undefined;
+        }
+        fn.rows.set(argument.id, row);
+        return row;
+    }
+
+    private reportFailureBudgetExhausted(runState: ITestRunState) {
+        if (this.failureBudgetNoticeSent) {
+            return;
+        }
+        this.failureBudgetNoticeSent = true;
+
+        runState.recordOutput(
+            undefined,
+            `Listing the first ${MAX_PARAMETERIZED_FAILURE_ROWS} failing parameterized arguments for this run; the rest are reported on their test functions.\r\n`
+        );
+    }
+}

--- a/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
+++ b/src/TestExplorer/TestParsers/SwiftTestingOutputParser.ts
@@ -17,7 +17,7 @@ import { Readable } from "stream";
 import { SwiftLogger } from "../../logging/SwiftLogger";
 import { lineBreakRegex } from "../../utilities/tasks";
 import { colorize, sourceLocationToVSCodeLocation } from "../../utilities/utilities";
-import { TestClass } from "../TestDiscovery";
+import { ParameterizedArgumentRows, ParameterizedTestCaseSink } from "./ParameterizedArgumentRows";
 import {
     INamedPipeReader,
     UnixNamedPipeReader,
@@ -197,12 +197,15 @@ export class SwiftTestingOutputParser {
     private completionMap = new Map<number, boolean>();
     private testCaseMap = new Map<string, Map<string, TestCase>>();
     private reader?: INamedPipeReader;
+    private argumentRows: ParameterizedArgumentRows;
 
     constructor(
-        public addParameterizedTestCases: (testClasses: TestClass[], parentIndex: number) => void,
-        public onAttachment: (testIndex: number, path: string) => void,
+        testCaseSink: ParameterizedTestCaseSink,
+        private onAttachment: (testIndex: number, path: string) => void,
         private logger?: SwiftLogger
-    ) {}
+    ) {
+        this.argumentRows = new ParameterizedArgumentRows(testCaseSink);
+    }
 
     /**
      * Watches for test events on the named pipe at the supplied path.
@@ -340,16 +343,16 @@ export class SwiftTestingOutputParser {
         // map an event.payload.testID back to a test case.
         this.buildTestCaseMapForParameterizedTest(item);
 
-        const testIndex = this.testItemIndexFromTestID(item.payload.id, runState);
-        // If a test has test cases it is paramterized and we need to notify
-        // the caller that the TestClass should be added to the vscode.TestRun.
-        const parameterizedTestCases = item.payload._testCases
-            .map((testCase, index) =>
-                this.parameterizedFunctionTestCaseToTestClass(item.payload.id, testCase, index)
-            )
-            .flatMap(testClass => (testClass ? [testClass] : []));
-
-        this.addParameterizedTestCases(parameterizedTestCases, testIndex);
+        this.argumentRows.begin(
+            this.testName(item.payload.id),
+            this.testItemIndexFromTestID(item.payload.id, runState),
+            item.payload._testCases.length,
+            () =>
+                item.payload._testCases.map(testCase => ({
+                    id: this.idFromOptionalTestCase(item.payload.id, testCase),
+                    label: testCase.displayName,
+                }))
+        );
     }
 
     private handleTestStarted(payload: TestStarted, runState: ITestRunState) {
@@ -359,7 +362,16 @@ export class SwiftTestingOutputParser {
 
     private handleTestCaseStarted(payload: TestCaseStarted, runState: ITestRunState) {
         const testID = this.idFromOptionalTestCase(payload.testID, payload._testCase);
-        const testIndex = this.getTestCaseIndex(runState, testID);
+        const testIndex = this.argumentRows.noteStarted(
+            this.testName(payload.testID),
+            testID,
+            payload.instant.absolute,
+            () => this.getTestCaseIndex(runState, testID)
+        );
+        if (testIndex === undefined) {
+            return;
+        }
+
         runState.started(testIndex, payload.instant.absolute);
     }
 
@@ -370,7 +382,15 @@ export class SwiftTestingOutputParser {
 
     private handleIssueRecorded(payload: IssueRecorded, runState: ITestRunState) {
         const testID = this.idFromOptionalTestCase(payload.testID, payload._testCase);
-        const testIndex = this.getTestCaseIndex(runState, testID);
+        const argumentIndex = payload._testCase
+            ? this.argumentRows.noteIssue(
+                  this.testName(payload.testID),
+                  { id: testID, label: payload._testCase.displayName },
+                  payload.instant.absolute,
+                  runState
+              )
+            : undefined;
+        const testIndex = argumentIndex ?? this.getTestCaseIndex(runState, testID);
         const { isKnown, sourceLocation } = payload.issue;
         const filePath = sourceLocation._filePath ?? sourceLocation.filePath;
         const location = sourceLocationToVSCodeLocation(
@@ -414,15 +434,19 @@ export class SwiftTestingOutputParser {
         });
 
         if (payload._testCase && testID !== payload.testID) {
-            const testIndex = this.getTestCaseIndex(runState, payload.testID);
-            messages.forEach(message => {
-                runState.recordIssue(testIndex, message.text, isKnown, location);
-            });
+            // An argument with no row of its own already recorded against it above.
+            const functionIndex = this.getTestCaseIndex(runState, payload.testID);
+            if (functionIndex !== testIndex) {
+                messages.forEach(message => {
+                    runState.recordIssue(functionIndex, message.text, isKnown, location);
+                });
+            }
         }
     }
 
     private handleTestEnded(payload: TestEnded, runState: ITestRunState) {
         const testIndex = this.testItemIndexFromTestID(payload.testID, runState);
+        this.argumentRows.finish(this.testName(payload.testID), payload.instant.absolute, runState);
 
         // When running a single test the testEnded and testCaseEnded events
         // have the same ID, and so we'd end the same test twice.
@@ -434,7 +458,12 @@ export class SwiftTestingOutputParser {
 
     private handleTestCaseEnded(payload: TestCaseEnded, runState: ITestRunState) {
         const testID = this.idFromOptionalTestCase(payload.testID, payload._testCase);
-        const testIndex = this.getTestCaseIndex(runState, testID);
+        const testIndex = this.argumentRows.noteEnded(this.testName(payload.testID), testID, () =>
+            this.getTestCaseIndex(runState, testID)
+        );
+        if (testIndex === undefined) {
+            return;
+        }
 
         // When running a single test the testEnded and testCaseEnded events
         // have the same ID, and so we'd end the same test twice.
@@ -488,23 +517,6 @@ export class SwiftTestingOutputParser {
         return testCase
             ? this.testCaseId(testID, this.idFromTestCase(testCase))
             : this.testName(testID);
-    }
-
-    private parameterizedFunctionTestCaseToTestClass(
-        testId: string,
-        testCase: TestCase,
-        index: number
-    ): TestClass {
-        return {
-            id: this.testCaseId(testId, this.idFromTestCase(testCase)),
-            label: testCase.displayName,
-            tags: [],
-            children: [],
-            style: "swift-testing",
-            location: undefined,
-            disabled: true,
-            sortText: `${index}`.padStart(8, "0"),
-        };
     }
 
     private buildTestCaseMapForParameterizedTest(record: TestRecord) {

--- a/src/TestExplorer/TestParsers/TestRunState.ts
+++ b/src/TestExplorer/TestParsers/TestRunState.ts
@@ -81,3 +81,24 @@ export interface TestIssueDiff {
     expected: string;
     actual: string;
 }
+
+/**
+ * Converts a completion's timing into a duration in milliseconds.
+ *
+ * A timestamp is only half of a duration, so the test must have been started with one too.
+ * Completing without that is a bug in the parser and can't be caused by a user.
+ */
+export function durationFrom(
+    timing: { duration: number } | { timestamp: number },
+    startTime: number | undefined
+): number {
+    if (!("timestamp" in timing)) {
+        return timing.duration * 1000;
+    }
+    if (startTime === undefined) {
+        throw Error(
+            "Timestamp was provided on test completion, but there was no startTime set when the test was started."
+        );
+    }
+    return (timing.timestamp - startTime) * 1000;
+}

--- a/src/TestExplorer/TestRunProxy.ts
+++ b/src/TestExplorer/TestRunProxy.ts
@@ -106,14 +106,13 @@ export class TestRunProxy implements vscode.CancellationToken {
     private testItemFinder: TestItemFinder;
     private testRunCompleteEmitter = new vscode.EventEmitter<void>();
     private coverage: TestCoverage;
-    private _testItems: vscode.TestItem[];
     private warningDiagnosticUris = new Set<string>();
 
     /**
      * The list of test items for this test run
      **/
     public get testItems(): vscode.TestItem[] {
-        return this._testItems;
+        return this.testItemFinder.testItems;
     }
 
     /**
@@ -153,19 +152,21 @@ export class TestRunProxy implements vscode.CancellationToken {
     constructor(
         private testRunRequest: vscode.TestRunRequest,
         private controller: vscode.TestController,
-        private args: TestRunArguments,
+        args: TestRunArguments,
         private folderContext: FolderContext,
         private recordDuration: boolean,
         testProfileCancellationToken: vscode.CancellationToken
     ) {
-        this._testItems = args.testItems;
         this.coverage = new TestCoverage(folderContext);
         this.token = new CompositeCancellationToken(testProfileCancellationToken);
         this.onCancellationRequested = this.token.onCancellationRequested.bind(this.token);
+        // Copied because the run appends the argument rows it discovers. These belong to the
+        // run rather than to the request that started it.
+        const testItems = [...args.testItems];
         this.testItemFinder =
             process.platform === "darwin"
-                ? new DarwinTestItemFinder(args.testItems)
-                : new NonDarwinTestItemFinder(args.testItems, this.folderContext);
+                ? new DarwinTestItemFinder(testItems)
+                : new NonDarwinTestItemFinder(testItems, this.folderContext);
         this.onTestRunComplete = this.testRunCompleteEmitter.event;
     }
 
@@ -196,60 +197,60 @@ export class TestRunProxy implements vscode.CancellationToken {
     }
 
     /**
-     * Adds a parameterized test case (a swift-testing only concept). Parameterized test cases are
-     * discovered at run time, and are linked to a parent test class.
-     * @param testClasses A list of parameterized tests to add
+     * Discards any argument rows a previous run left under a parameterized test function.
      * @param parentIndex The index of the parent `vscode.TestItem`
      */
-    public addParameterizedTestCases(testClasses: TestClass[], parentIndex: number) {
-        const addedTestItems = testClasses
-            .map(testClass => {
-                const parent = this.args.testItems[parentIndex];
-                // clear out the children before we add the new ones.
-                parent.children.replace([]);
-                return {
-                    testClass,
-                    parent,
-                };
-            })
-            .map(({ testClass, parent }) => {
+    public clearParameterizedTestCases(parentIndex: number) {
+        this.testItems[parentIndex]?.children.replace([]);
+    }
+
+    /**
+     * Adds a single parameterized test case beneath its test function. Parameterized test
+     * cases are discovered at run time, one row per call as each argument's result arrives.
+     *
+     * @param parentIndex The index of the parent `vscode.TestItem`
+     * @returns The index of the added test item, or undefined if the parent is unknown.
+     */
+    public addParameterizedTestCase(testClass: TestClass, parentIndex: number): number | undefined {
+        const parent = this.testItems[parentIndex];
+        if (!parent) {
+            return undefined;
+        }
+
+        const added = upsertTestItem(
+            this.controller,
+            {
+                ...testClass,
                 // strip the location off parameterized tests so only the parent TestItem
                 // has one. The parent collects all the issues so they're colated on the top
                 // level test item and users can cycle through them with the up/down arrows in the UI.
-                testClass.location = undefined;
+                location: undefined,
 
                 // Results should inherit any tags from the parent.
                 // Until we can rerun a swift-testing test with an individual argument, mark
                 // the argument test items as not runnable. This should be revisited when
                 // https://github.com/swiftlang/swift-testing/issues/671 is resolved.
-                testClass.tags = compactMap(parent.tags, t =>
+                tags: compactMap(parent.tags, t =>
                     t.id === runnableTag.id ? null : new vscode.TestTag(t.id)
-                ).concat(new vscode.TestTag(TestRunProxy.Tags.PARAMETERIZED_TEST_RESULT));
+                ).concat(new vscode.TestTag(TestRunProxy.Tags.PARAMETERIZED_TEST_RESULT)),
+            },
+            parent
+        );
 
-                const added = upsertTestItem(this.controller, testClass, parent);
-
-                // If we just update leaf nodes the root test controller never realizes that
-                // items have updated. This may be a bug in VS Code. We can work around it by
-                // re-adding the existing items back up the chain to refresh all the nodes along the way.
-                let p = parent;
-                while (p?.parent) {
-                    p.parent.children.add(p);
-                    p = p.parent;
-                }
-
-                return added;
-            });
-        this._testItems = [...this.testItems, ...addedTestItems];
-
-        for (const test of addedTestItems) {
-            this.enqueued(test);
+        // If we just update leaf nodes the root test controller never realizes that
+        // items have updated. This may be a bug in VS Code. We can work around it by
+        // re-adding the existing items back up the chain to refresh all the nodes along the way.
+        let p = parent;
+        while (p?.parent) {
+            p.parent.children.add(p);
+            p = p.parent;
         }
 
-        // Recreate a test item finder with the added test items
-        this.testItemFinder =
-            process.platform === "darwin"
-                ? new DarwinTestItemFinder(this.testItems)
-                : new NonDarwinTestItemFinder(this.testItems, this.folderContext);
+        // Appended in place; rebuilding the finder per row would be quadratic.
+        const index = this.testItemFinder.add(added);
+        this.enqueued(added);
+
+        return index;
     }
 
     /**
@@ -579,6 +580,12 @@ export class TestRunProxy implements vscode.CancellationToken {
 /** Interface defining how to find test items given a test id from XCTest output */
 interface TestItemFinder {
     getIndex(id: string, filename?: string): number;
+    /**
+     * Appends a test item discovered during the run, returning its index. Indices are stable, but
+     * `clearParameterizedTestCases` can detach an item from the tree while leaving it here, so an
+     * index resolves to an item that is not necessarily still shown.
+     */
+    add(item: vscode.TestItem): number;
     testItems: vscode.TestItem[];
 }
 
@@ -593,6 +600,12 @@ class DarwinTestItemFinder implements TestItemFinder {
     getIndex(id: string): number {
         return this.testItemMap.get(id) ?? -1;
     }
+
+    add(item: vscode.TestItem): number {
+        const index = this.testItems.push(item) - 1;
+        this.testItemMap.set(item.id, index);
+        return index;
+    }
 }
 
 /** Defines how to find test items given a test id from XCTest output on non-Darwin platforms */
@@ -601,6 +614,10 @@ class NonDarwinTestItemFinder implements TestItemFinder {
         public testItems: vscode.TestItem[],
         public folderContext: FolderContext
     ) {}
+
+    add(item: vscode.TestItem): number {
+        return this.testItems.push(item) - 1;
+    }
 
     /**
      * Get test item index from id for non Darwin platforms. It is a little harder to

--- a/src/TestExplorer/TestRunner.ts
+++ b/src/TestExplorer/TestRunner.ts
@@ -43,7 +43,7 @@ import { IS_RUNNING_UNDER_TEST, execFile, getErrorDescription } from "../utiliti
 import { runnableTag } from "./TestDiscovery";
 import { TestKind, isDebugging, isRelease } from "./TestKind";
 import { SwiftTestingOutputParser } from "./TestParsers/SwiftTestingOutputParser";
-import { ITestRunState, TestIssueDiff } from "./TestParsers/TestRunState";
+import { ITestRunState, TestIssueDiff, durationFrom } from "./TestParsers/TestRunState";
 import {
     IXCTestOutputParser,
     ParallelXCTestOutputParser,
@@ -114,11 +114,7 @@ export class TestRunner {
                       this.folderContext.toolchain.hasMultiLineParallelTestOutput
                   )
                 : new XCTestOutputParser();
-        this.swiftTestOutputParser = new SwiftTestingOutputParser(
-            this.testRun.addParameterizedTestCases.bind(this.testRun),
-            this.testRun.addAttachment.bind(this.testRun),
-            this.folderContext.workspaceContext.logger
-        );
+        this.swiftTestOutputParser = this.createSwiftTestOutputParser();
         this.onDebugSessionTerminated = this.debugSessionTerminatedEmitter.event;
     }
 
@@ -129,12 +125,16 @@ export class TestRunner {
      */
     public setIteration(iteration: number) {
         // The SwiftTestingOutputParser holds state and needs to be reset between iterations.
-        this.swiftTestOutputParser = new SwiftTestingOutputParser(
-            this.testRun.addParameterizedTestCases,
-            this.testRun.addAttachment,
+        this.swiftTestOutputParser = this.createSwiftTestOutputParser();
+        this.testRun.setIteration(iteration);
+    }
+
+    private createSwiftTestOutputParser(): SwiftTestingOutputParser {
+        return new SwiftTestingOutputParser(
+            this.testRun,
+            (testIndex, path) => this.testRun.addAttachment(testIndex, path),
             this.folderContext.workspaceContext.logger
         );
-        this.testRun.setIteration(iteration);
     }
 
     /**
@@ -1124,21 +1124,7 @@ export class TestRunnerTestRunState implements ITestRunState {
             return;
         }
         const test = this.testRun.testItems[index];
-        const startTime = this.startTimes.get(index);
-
-        let duration: number;
-        if ("timestamp" in timing) {
-            // Completion was specified in timestamp format but the test has no saved `started` timestamp.
-            // This is a bug in the code and can't be caused by a user.
-            if (startTime === undefined) {
-                throw Error(
-                    "Timestamp was provided on test completion, but there was no startTime set when the test was started."
-                );
-            }
-            duration = (timing.timestamp - startTime) * 1000;
-        } else {
-            duration = timing.duration * 1000;
-        }
+        const duration = durationFrom(timing, this.startTimes.get(index));
 
         const isSuite = test.children.size > 0;
         const issues = isSuite ? this.childrensIssues(test) : (this.issues.get(index) ?? []);

--- a/test/integration-tests/testexplorer/MockTestRunState.ts
+++ b/test/integration-tests/testexplorer/MockTestRunState.ts
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 import * as vscode from "vscode";
 
-import { ITestRunState, TestIssueDiff } from "@src/TestExplorer/TestParsers/TestRunState";
+import {
+    ITestRunState,
+    TestIssueDiff,
+    durationFrom,
+} from "@src/TestExplorer/TestParsers/TestRunState";
 
 /** TestStatus */
 export enum TestStatus {
@@ -85,6 +89,12 @@ export class TestRunState implements ITestRunState {
 
     public testItemFinder: ITestItemFinder;
 
+    /**
+     * The start time each test index was started with. `TestRunnerTestRunState` throws if a test
+     * completes with a timestamp but was started without one.
+     */
+    public startTimes = new Map<number, number | undefined>();
+
     get tests(): TestRunTestItem[] {
         return this.testItemFinder.tests;
     }
@@ -102,11 +112,16 @@ export class TestRunState implements ITestRunState {
         return this.testItemFinder.getIndex(id);
     }
 
-    started(index: number): void {
+    started(index: number, startTime?: number): void {
         this.testItemFinder.tests[index].status = TestStatus.started;
+        this.startTimes.set(index, startTime);
     }
 
     completed(index: number, timing: { duration: number } | { timestamp: number }): void {
+        // Validated the same way as production, so a mock run can't pass where a real one throws.
+        // The duration itself is not recorded; tests assert on the raw timing.
+        durationFrom(timing, this.startTimes.get(index));
+
         this.testItemFinder.tests[index].status =
             this.testItemFinder.tests[index].issues !== undefined
                 ? TestStatus.failed

--- a/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/integration-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -16,6 +16,12 @@ import { beforeEach } from "mocha";
 import { Readable } from "stream";
 import * as vscode from "vscode";
 
+import { TestClass } from "@src/TestExplorer/TestDiscovery";
+import {
+    MAX_PARAMETERIZED_FAILURE_ROWS,
+    MAX_PARAMETERIZED_PENDING_ROWS,
+    ParameterizedTestCaseSink,
+} from "@src/TestExplorer/TestParsers/ParameterizedArgumentRows";
 import {
     EventMessage,
     EventRecord,
@@ -28,6 +34,8 @@ import {
 } from "@src/TestExplorer/TestParsers/SwiftTestingOutputParser";
 
 import { TestRunState, TestStatus } from "./MockTestRunState";
+
+type Outcome = "pass" | "fail" | "warn";
 
 class TestEventStream {
     constructor(private items: SwiftTestEvent[]) {}
@@ -48,11 +56,43 @@ suite("SwiftTestingOutputParser Suite", () => {
 
     beforeEach(() => {
         outputParser = new SwiftTestingOutputParser(
-            () => {},
+            {
+                clearParameterizedTestCases: () => {},
+                addParameterizedTestCase: () => undefined,
+            },
             () => {}
         );
         testRunState = new TestRunState(true);
     });
+
+    /** A sink that records every row it is handed and registers it with the run state. */
+    function recordingSink(listed: TestClass[]): ParameterizedTestCaseSink {
+        return {
+            clearParameterizedTestCases: () => {},
+            addParameterizedTestCase: testClass => {
+                listed.push(testClass);
+                return testRunState.getTestItemIndex(testClass.id);
+            },
+        };
+    }
+
+    function parameterizedRecord(testId: string, count: number): SwiftTestEvent {
+        return {
+            kind: "test",
+            version: 0,
+            payload: {
+                kind: "function",
+                id: testId,
+                name: testId,
+                isParameterized: true,
+                _testCases: Array.from({ length: count }, (_, i) => ({
+                    id: `arg-${i}`,
+                    displayName: `arg-${i}`,
+                })),
+                sourceLocation: { _filePath: "file:///f.swift", line: 1, column: 1 },
+            },
+        } as unknown as SwiftTestEvent;
+    }
 
     type ExtractPayload<T> = T extends { payload: infer E } ? E : never;
     type IssueOverrides = { isFailure?: boolean; severity?: string };
@@ -82,6 +122,217 @@ suite("SwiftTestingOutputParser Suite", () => {
             } as EventRecordPayload,
         };
     }
+
+    suite("parameterized argument budgets", () => {
+        const TEST_ID = "MyTests.MyTests/testParameterized()";
+
+        function caseEvents(testId: string, index: number, outcome: Outcome): SwiftTestEvent[] {
+            const arg = `arg-${index}`;
+            const events: SwiftTestEvent[] = [
+                testEvent("testCaseStarted", testId, undefined, undefined, arg),
+            ];
+            if (outcome !== "pass") {
+                events.push(
+                    testEvent(
+                        "issueRecorded",
+                        testId,
+                        [{ text: `issue ${index}`, symbol: TestSymbol.fail }],
+                        { _filePath: "file:///f.swift", line: 1, column: 1 },
+                        arg,
+                        outcome === "warn" ? { severity: "warning" } : undefined
+                    )
+                );
+            }
+            events.push(testEvent("testCaseEnded", testId, undefined, undefined, arg));
+            return events;
+        }
+
+        async function runFunctions(
+            functions: { id: string; outcomes: Outcome[] }[]
+        ): Promise<TestClass[]> {
+            return runEvents(
+                functions.flatMap(fn => [
+                    parameterizedRecord(fn.id, fn.outcomes.length),
+                    testEvent("testStarted", fn.id),
+                    ...fn.outcomes.flatMap((outcome, i) => caseEvents(fn.id, i, outcome)),
+                    testEvent("testEnded", fn.id),
+                ])
+            );
+        }
+
+        async function runEvents(events: SwiftTestEvent[]): Promise<TestClass[]> {
+            const listed: TestClass[] = [];
+            await new SwiftTestingOutputParser(recordingSink(listed), () => {}).watch(
+                "file:///mock/named/pipe",
+                testRunState,
+                new TestEventStream([testEvent("runStarted"), ...events, testEvent("runEnded")])
+            );
+            return listed;
+        }
+
+        const ids = (rows: TestClass[]) => rows.map(row => row.id);
+
+        function outcomes(
+            count: number,
+            fill: Outcome = "pass",
+            overrides: Record<number, Outcome> = {}
+        ): Outcome[] {
+            return Array.from({ length: count }, (_, i) => overrides[i] ?? fill);
+        }
+
+        test("Arguments are listed before any results arrive when they fit in the budget", async () => {
+            const listed = await runEvents([parameterizedRecord(TEST_ID, 3)]);
+
+            assert.deepStrictEqual(ids(listed), [
+                `${TEST_ID}/arg-0`,
+                `${TEST_ID}/arg-1`,
+                `${TEST_ID}/arg-2`,
+            ]);
+        });
+
+        test("A test with more arguments than the budget lists nothing up front", async () => {
+            const listed = await runEvents([
+                parameterizedRecord(TEST_ID, MAX_PARAMETERIZED_PENDING_ROWS + 1),
+            ]);
+
+            assert.strictEqual(listed.length, 0);
+        });
+
+        test("A test that does not fit alongside an earlier test lists nothing up front", async () => {
+            const listed = await runEvents([
+                parameterizedRecord("MyTests.MyTests/first()", MAX_PARAMETERIZED_PENDING_ROWS),
+                parameterizedRecord("MyTests.MyTests/second()", 5),
+            ]);
+
+            assert.strictEqual(listed.length, MAX_PARAMETERIZED_PENDING_ROWS);
+            assert.ok(!ids(listed).some(id => id.startsWith("MyTests.MyTests/second()")));
+        });
+
+        test("A held back test lists its failures and summarises its passes in one row", async () => {
+            const total = MAX_PARAMETERIZED_PENDING_ROWS + 3;
+
+            const listed = await runFunctions([
+                { id: TEST_ID, outcomes: outcomes(total, "pass", { 0: "fail", 1: "fail" }) },
+            ]);
+
+            assert.deepStrictEqual(ids(listed), [
+                `${TEST_ID}/arg-0`,
+                `${TEST_ID}/arg-1`,
+                `${TEST_ID}/swift.passedTestCases`,
+            ]);
+            assert.strictEqual(
+                listed[2].label,
+                `${(total - 2).toLocaleString()} test cases passed`
+            );
+        });
+
+        test("A held back test with a single passing argument summarises it in the singular", async () => {
+            const total = MAX_PARAMETERIZED_PENDING_ROWS + 1;
+
+            const listed = await runFunctions([
+                { id: TEST_ID, outcomes: outcomes(total, "fail", { [total - 1]: "pass" }) },
+            ]);
+
+            assert.strictEqual(listed[listed.length - 1].label, "1 test case passed");
+        });
+
+        test("A held back test with no passing arguments has no summary row", async () => {
+            const listed = await runFunctions([
+                { id: TEST_ID, outcomes: outcomes(MAX_PARAMETERIZED_PENDING_ROWS + 1, "fail") },
+            ]);
+
+            assert.ok(!ids(listed).some(id => id.endsWith("swift.passedTestCases")));
+        });
+
+        test("A test that fits in the budget has no summary row", async () => {
+            const listed = await runFunctions([{ id: TEST_ID, outcomes: outcomes(3) }]);
+
+            assert.ok(!ids(listed).some(id => id.endsWith("swift.passedTestCases")));
+        });
+
+        test("Failing arguments are capped by their own budget", async () => {
+            const listed = await runFunctions([
+                { id: TEST_ID, outcomes: outcomes(MAX_PARAMETERIZED_FAILURE_ROWS + 10, "fail") },
+            ]);
+
+            assert.strictEqual(listed.length, MAX_PARAMETERIZED_FAILURE_ROWS);
+        });
+
+        test("Warnings are listed like failures rather than folded into the summary", async () => {
+            const total = MAX_PARAMETERIZED_PENDING_ROWS + 1;
+
+            const listed = await runFunctions([
+                { id: TEST_ID, outcomes: outcomes(total, "pass", { 4: "warn" }) },
+            ]);
+
+            assert.deepStrictEqual(ids(listed), [
+                `${TEST_ID}/arg-4`,
+                `${TEST_ID}/swift.passedTestCases`,
+            ]);
+        });
+
+        test("The pending budget is shared across every parameterized test in the run", async () => {
+            const half = Math.floor(MAX_PARAMETERIZED_PENDING_ROWS / 2) + 50;
+
+            const listed = await runFunctions([
+                { id: "MyTests.MyTests/first()", outcomes: outcomes(half) },
+                { id: "MyTests.MyTests/second()", outcomes: outcomes(half) },
+            ]);
+
+            assert.strictEqual(listed.length, half + 1);
+            assert.strictEqual(
+                listed[listed.length - 1].id,
+                "MyTests.MyTests/second()/swift.passedTestCases"
+            );
+        });
+
+        test("A failure in a later test survives an earlier one spending the pending budget", async () => {
+            const listed = await runFunctions([
+                {
+                    id: "MyTests.MyTests/first()",
+                    outcomes: outcomes(MAX_PARAMETERIZED_PENDING_ROWS),
+                },
+                { id: "MyTests.MyTests/second()", outcomes: ["fail", "fail"] },
+            ]);
+
+            assert.ok(ids(listed).includes("MyTests.MyTests/second()/arg-0"));
+            assert.ok(ids(listed).includes("MyTests.MyTests/second()/arg-1"));
+        });
+
+        test("A failure that outruns the budget is recorded once on its test function", async () => {
+            const overBudget = 10;
+
+            await runFunctions([
+                {
+                    id: TEST_ID,
+                    outcomes: outcomes(MAX_PARAMETERIZED_FAILURE_ROWS + overBudget, "fail"),
+                },
+            ]);
+
+            const testFunction = testRunState.tests.find(test => test.name === TEST_ID);
+            assert.strictEqual(
+                testFunction?.issues?.length,
+                MAX_PARAMETERIZED_FAILURE_ROWS + overBudget
+            );
+        });
+
+        test("A failure listed without a start event is still given a start time", async () => {
+            await runEvents([
+                parameterizedRecord(TEST_ID, MAX_PARAMETERIZED_PENDING_ROWS + 1),
+                testEvent(
+                    "issueRecorded",
+                    TEST_ID,
+                    [{ text: "issue", symbol: TestSymbol.fail }],
+                    { _filePath: "file:///f.swift", line: 1, column: 1 },
+                    "arg-0"
+                ),
+                testEvent("testCaseEnded", TEST_ID, undefined, undefined, "arg-0"),
+            ]);
+
+            const row = testRunState.tests.findIndex(test => test.name === `${TEST_ID}/arg-0`);
+            assert.notStrictEqual(testRunState.startTimes.get(row), undefined);
+        });
+    });
 
     test("Passed test", async () => {
         const events = new TestEventStream([
@@ -206,6 +457,7 @@ suite("SwiftTestingOutputParser Suite", () => {
                 version: 0,
             },
             testEvent("runStarted"),
+            testEvent("testStarted", "MyTests.MyTests/testParameterized()"),
             testEvent(
                 "testCaseStarted",
                 "MyTests.MyTests/testParameterized()",
@@ -238,18 +490,7 @@ suite("SwiftTestingOutputParser Suite", () => {
             testEvent("runEnded"),
         ]);
 
-        const outputParser = new SwiftTestingOutputParser(
-            testClasses => {
-                testClasses.forEach(testClass =>
-                    testRunState.testItemFinder.tests.push({
-                        name: testClass.id,
-                        status: TestStatus.enqueued,
-                        output: [],
-                    })
-                );
-            },
-            () => {}
-        );
+        const outputParser = new SwiftTestingOutputParser(recordingSink([]), () => {});
         await outputParser.watch("file:///mock/named/pipe", testRunState, events);
 
         assert.deepEqual(testRunState.tests, [

--- a/test/unit-tests/testexplorer/SwiftTestingOutputParser.test.ts
+++ b/test/unit-tests/testexplorer/SwiftTestingOutputParser.test.ts
@@ -29,7 +29,10 @@ suite("SwiftTestingOutputParser Unit Test Suite", () => {
                 recordOutput: mockFn(),
             });
             parser = new SwiftTestingOutputParser(
-                () => {},
+                {
+                    clearParameterizedTestCases: () => {},
+                    addParameterizedTestCase: () => undefined,
+                },
                 () => {}
             );
         });

--- a/test/unit-tests/testexplorer/TestRunProxy.test.ts
+++ b/test/unit-tests/testexplorer/TestRunProxy.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach } from "mocha";
 import * as vscode from "vscode";
 
 import { FolderContext } from "@src/FolderContext";
+import { TestClass, runnableTag } from "@src/TestExplorer/TestDiscovery";
 import { TestRunArguments } from "@src/TestExplorer/TestRunArguments";
 import { TestRunProxy } from "@src/TestExplorer/TestRunProxy";
 
@@ -109,6 +110,110 @@ suite("TestRunProxy Unit Test Suite", () => {
 
             expect(proxy.runState.enqueued).to.contain(suiteItem);
             expect(proxy.runState.enqueued).to.contain(second);
+        });
+    });
+
+    suite("addParameterizedTestCase()", () => {
+        function testClass(id: string, index: number): TestClass {
+            return {
+                id,
+                label: id,
+                tags: [],
+                children: [],
+                style: "swift-testing",
+                location: undefined,
+                disabled: true,
+                sortText: `${index}`.padStart(8, "0"),
+            };
+        }
+
+        function setup() {
+            const target = createTestItem("Target");
+            const suiteItem = createTestItem("Suite", target);
+            const parent = createTestItem("parameterized", suiteItem);
+            parent.tags = [runnableTag, new vscode.TestTag("swift-testing")];
+            const requestedItems = [target, suiteItem, parent];
+            const proxy = createProxy(requestedItems);
+            proxy.testRunStarted();
+            return { target, suiteItem, parent, requestedItems, proxy };
+        }
+
+        test("Adds the argument as a child of the parent", () => {
+            const { parent, proxy } = setup();
+
+            proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            expect(parent.children.size).to.equal(1);
+        });
+
+        test("Appends rather than replacing previously added arguments", () => {
+            const { parent, proxy } = setup();
+
+            proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+            proxy.addParameterizedTestCase(testClass("arg-1", 1), 2);
+
+            expect(parent.children.size).to.equal(2);
+        });
+
+        test("Returns an index that resolves back to the added item", () => {
+            const { proxy } = setup();
+
+            const index = proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            expect(index).to.not.be.undefined;
+            expect(proxy.testItems[index!].id).to.equal("arg-0");
+        });
+
+        test("The added item is findable by id straight away", () => {
+            const { proxy } = setup();
+
+            const index = proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            expect(proxy.getTestIndex("arg-0")).to.equal(index);
+        });
+
+        test("Arguments inherit the parent's tags but are not runnable", () => {
+            const { parent, proxy } = setup();
+
+            proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            const tagIds = (parent.children.get("arg-0")?.tags ?? []).map(t => t.id);
+            expect(tagIds).to.contain("swift-testing");
+            expect(tagIds).to.contain(TestRunProxy.Tags.PARAMETERIZED_TEST_RESULT);
+            expect(tagIds).to.not.contain(runnableTag.id);
+        });
+
+        test("Added arguments are appended to the run's test items and enqueued", () => {
+            const { parent, proxy } = setup();
+            const before = proxy.testItems.length;
+
+            proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            expect(proxy.testItems).to.have.lengthOf(before + 1);
+            expect(proxy.runState.enqueued.has(parent.children.get("arg-0")!)).to.be.true;
+        });
+
+        test("An unknown parent is reported rather than throwing", () => {
+            const { proxy } = setup();
+
+            expect(proxy.addParameterizedTestCase(testClass("arg-0", 0), -1)).to.be.undefined;
+        });
+
+        test("The test items the run was asked for are left alone", () => {
+            const { requestedItems, proxy } = setup();
+
+            proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            expect(requestedItems).to.have.lengthOf(3);
+        });
+
+        test("clearParameterizedTestCases discards rows from a previous run", () => {
+            const { parent, proxy } = setup();
+            proxy.addParameterizedTestCase(testClass("arg-0", 0), 2);
+
+            proxy.clearParameterizedTestCases(2);
+
+            expect(parent.children.size).to.equal(0);
         });
     });
 });


### PR DESCRIPTION
When a parameterized test has hundreds or thousands of test cases, whenever one test case finished VS Code made a UI update. With thousands of quick finishing test cases running in parallel the UI would slow to a crawl, and take several orders of magnitude longer to finish a test run than on the command line.

A run now gets a budget of 1,000 argument rows. A parameterized test whose arguments fit in what is left of that budget is listed up front as before, so its rows still show up pending while the test runs.

A test that doesn't fit is held back. Only the arguments that record an issue get a row, capped by a separate budget of 1,000 so a wall of failures can't swamp the UI either, and everything that passed is collapsed into a single row like "1,200 test cases passed" when the test function ends.
